### PR TITLE
Generic printer

### DIFF
--- a/engine/lib/diagnostics.ml
+++ b/engine/lib/diagnostics.ml
@@ -54,6 +54,7 @@ module Context = struct
     | Backend of Backend.t
     | ThirImport
     | DebugPrintRust
+    | GenericPrinter of string
     | Other of string
   [@@deriving show, eq, yojson, compare]
 
@@ -62,6 +63,7 @@ module Context = struct
     | Backend backend -> [%show: Backend.t] backend ^ " backend"
     | ThirImport -> "AST import"
     | DebugPrintRust -> "Rust debug printer"
+    | GenericPrinter kind -> kind ^ " generic printer"
     | Other s -> "Other (" ^ s ^ ")"
 end
 

--- a/engine/lib/generic_printer/generic_printer.ml
+++ b/engine/lib/generic_printer/generic_printer.ml
@@ -5,7 +5,7 @@ module Make (F : Features.T) (View : Concrete_ident.VIEW_API) = struct
   open Generic_printer_base
   open Generic_printer_base.Make (F)
 
-  include Api (struct
+  module Class = struct
     module U = Ast_utils.Make (F)
     open! AST
     open PPrint
@@ -420,5 +420,11 @@ module Make (F : Features.T) (View : Concrete_ident.VIEW_API) = struct
             let body = print#expr_at Arm_body body in
             pat ^^ string " => " ^^ body ^^ comma
       end
+  end
+
+  include Class
+
+  include Api (struct
+    let new_print () = (new Class.print :> print_object)
   end)
 end

--- a/engine/lib/generic_printer/generic_printer.ml
+++ b/engine/lib/generic_printer/generic_printer.ml
@@ -1,0 +1,424 @@
+open! Prelude
+open! Ast
+
+module Make (F : Features.T) (View : Concrete_ident.VIEW_API) = struct
+  open Generic_printer_base
+  open Generic_printer_base.Make (F)
+
+  include Api (struct
+    module U = Ast_utils.Make (F)
+    open! AST
+    open PPrint
+
+    let iblock f = group >> jump 2 0 >> terminate (break 0) >> f >> group
+
+    class print =
+      object (print)
+        inherit print_base as super
+        method printer_name = "Generic"
+
+        method par_state : ast_position -> par_state =
+          function
+          | Lhs_LhsArrayAccessor | Ty_Tuple | Ty_TSlice | Ty_TArray_length
+          | Expr_If_cond | Expr_If_then | Expr_If_else | Expr_Array
+          | Expr_Assign | Expr_Closure_param | Expr_Closure_body
+          | Expr_Ascription_e | Expr_Let_lhs | Expr_Let_rhs | Expr_Let_body
+          | Expr_App_arg | Expr_ConstructTuple | Pat_ConstructTuple | Pat_PArray
+          | Pat_Ascription_pat | Param_pat | Item_Fn_body | GenericParam_GPConst
+            ->
+              AlreadyPar
+          | _ -> NeedsPar
+
+        method namespace_of_concrete_ident
+            : concrete_ident -> string * string list =
+          fun i -> View.to_namespace i
+
+        method concrete_ident' ~(under_current_ns : bool) : concrete_ident fn =
+          fun id ->
+            let id = View.to_view id in
+            let chunks =
+              if under_current_ns then [ id.definition ]
+              else id.crate :: (id.path @ [ id.definition ])
+            in
+            separate_map (colon ^^ colon) utf8string chunks
+
+        method name_of_concrete_ident : concrete_ident fn =
+          View.to_definition_name >> utf8string
+
+        method mutability : 'a. 'a mutability fn = fun _ -> empty
+
+        method primitive_ident : primitive_ident fn =
+          function
+          | Deref -> string "deref"
+          | Cast -> string "cast"
+          | LogicalOp And -> string "and"
+          | LogicalOp Or -> string "or"
+
+        method local_ident : local_ident fn =
+          fun { name; _ } -> View.local_name name |> utf8string
+
+        method literal : literal_ctx -> literal fn =
+          (* TODO : escape *)
+          fun _ctx -> function
+            | String s -> utf8string s |> dquotes
+            | Char c -> char c |> bquotes
+            | Int { value; _ } -> string value
+            | Float { value; kind } ->
+                string value
+                |> terminate
+                     (string (match kind with F32 -> "f32" | F64 -> "f64"))
+            | Bool b -> OCaml.bool b
+
+        method generic_value : generic_value fn =
+          function
+          | GLifetime _ -> string "Lifetime"
+          | GType ty -> print#ty_at GenericValue_GType ty
+          | GConst expr -> print#expr_at GenericValue_GConst expr
+
+        method lhs : lhs fn =
+          function
+          | LhsLocalVar { var; _ } -> print#local_ident var
+          | LhsArbitraryExpr { e; _ } -> print#expr_at Lhs_LhsArbitraryExpr e
+          | LhsFieldAccessor { e; field; _ } ->
+              print#lhs e |> parens
+              |> terminate (dot ^^ print#global_ident_projector field)
+          | LhsArrayAccessor { e; index; _ } ->
+              print#lhs e |> parens
+              |> terminate (print#expr_at Lhs_LhsArrayAccessor index |> brackets)
+
+        method ty_bool : document = string "bool"
+        method ty_char : document = string "char"
+        method ty_str : document = string "str"
+
+        method ty_int : int_kind fn =
+          fun { size; signedness } ->
+            let signedness = match signedness with Signed -> "i" | _ -> "u" in
+            let size =
+              match int_of_size size with
+              | Some n -> OCaml.int n
+              | None -> string "size"
+            in
+            string signedness ^^ size
+
+        method ty_float : float_kind fn =
+          (function F32 -> "f32" | F64 -> "f64") >> string
+
+        method generic_values : generic_value list fn =
+          function
+          | [] -> empty
+          | values -> separate_map comma print#generic_value values |> angles
+
+        method ty_app : concrete_ident -> generic_value list fn =
+          fun f args -> print#concrete_ident f ^^ print#generic_values args
+
+        method ty_tuple : int -> ty list fn =
+          fun _n ->
+            separate_map (comma ^^ break 1) (print#ty_at Ty_Tuple)
+            >> iblock parens
+
+        method ty : par_state -> ty fn =
+          fun ctx ty ->
+            match ty with
+            | TBool -> string "bool"
+            | TChar -> string "char"
+            | TInt kind -> print#ty_int kind
+            | TFloat kind -> print#ty_float kind
+            | TStr -> string "String"
+            | TArrow (inputs, output) ->
+                separate_map (string "->") (print#ty_at Ty_TArrow)
+                  (inputs @ [ output ])
+                |> parens
+                |> precede (string "arrow!")
+            | TRef { typ; mut; _ } ->
+                ampersand ^^ print#mutability mut ^^ print#ty_at Ty_TRef typ
+            | TParam i -> print#local_ident i
+            | TSlice { ty; _ } -> print#ty_at Ty_TSlice ty |> brackets
+            | TRawPointer _ -> string "raw_pointer!()"
+            | TArray { typ; length } ->
+                print#ty_at Ty_TArray_length typ
+                ^/^ semi
+                ^/^ print#expr_at Ty_TArray_length length
+                |> brackets
+            | TProjectedAssociatedType _ -> string "proj_asso_type!()"
+            | TApp _ -> super#ty ctx ty
+
+        method expr' : par_state -> expr' fn =
+          fun ctx e ->
+            let wrap_parens =
+              group
+              >>
+              match ctx with AlreadyPar -> Fn.id | NeedsPar -> iblock braces
+            in
+            match e with
+            | If { cond; then_; else_ } ->
+                let if_then =
+                  (string "if" ^//^ nest 2 (print#expr_at Expr_If_cond cond))
+                  ^/^ string "then"
+                  ^//^ (print#expr_at Expr_If_then then_ |> braces |> nest 1)
+                in
+                (match else_ with
+                | None -> if_then
+                | Some else_ ->
+                    if_then ^^ break 1 ^^ string "else" ^^ space
+                    ^^ (print#expr_at Expr_If_else else_ |> iblock braces))
+                |> wrap_parens
+            | Match { scrutinee; arms } ->
+                let header =
+                  string "match" ^^ space
+                  ^^ (print#expr_at Expr_Match_scrutinee scrutinee
+                     |> terminate space |> iblock Fn.id)
+                  |> group
+                in
+                let arms =
+                  separate_map hardline
+                    (print#arm >> group >> nest 2
+                    >> precede (bar ^^ space)
+                    >> group)
+                    arms
+                in
+                header ^^ iblock braces arms
+            | Let { monadic; lhs; rhs; body } ->
+                (Option.map
+                   ~f:(fun monad -> print#expr_monadic_let ~monad)
+                   monadic
+                |> Option.value ~default:print#expr_let)
+                  ~lhs ~rhs body
+                |> wrap_parens
+            | Literal l -> print#literal Expr l
+            | Block (e, _) -> print#expr ctx e
+            | Array l ->
+                separate_map comma (print#expr_at Expr_Array) l
+                |> group |> brackets
+            | LocalVar i -> print#local_ident i
+            | GlobalVar (`Concrete i) -> print#concrete_ident i
+            | GlobalVar (`Primitive p) -> print#primitive_ident p
+            | GlobalVar (`TupleCons 0) -> print#expr_construct_tuple []
+            | GlobalVar
+                (`TupleType _ | `TupleField _ | `Projector _ | `TupleCons _) ->
+                print#assertion_failure "GlobalVar"
+            | Assign { lhs; e; _ } ->
+                group (print#lhs lhs)
+                ^^ space ^^ equals
+                ^/^ group (print#expr_at Expr_Assign e)
+                ^^ semi
+            | Loop _ -> string "todo loop;"
+            | Break _ -> string "todo break;"
+            | Return _ -> string "todo return;"
+            | Continue _ -> string "todo continue;"
+            | QuestionMark { e; _ } ->
+                print#expr_at Expr_QuestionMark e |> terminate qmark
+            | Borrow { kind; e; _ } ->
+                string (match kind with Mut _ -> "&mut " | _ -> "&")
+                ^^ print#expr_at Expr_Borrow e
+            | AddressOf _ -> string "todo address of;"
+            | Closure { params; body; _ } ->
+                separate_map comma (print#pat_at Expr_Closure_param) params
+                |> group |> enclose bar bar
+                |> terminate (print#expr_at Expr_Closure_body body |> group)
+                |> wrap_parens
+            | Ascription { e; typ } ->
+                print#expr_at Expr_Ascription_e e
+                ^^ string "as"
+                ^/^ print#ty_at Expr_Ascription_typ typ
+                |> wrap_parens
+            | MacroInvokation _ -> print#assertion_failure "MacroInvokation"
+            | EffectAction _ -> print#assertion_failure "EffectAction"
+            | App _ | Construct _ -> super#expr' ctx e
+
+        method expr_monadic_let
+            : monad:supported_monads * F.monadic_binding ->
+              lhs:pat ->
+              rhs:expr ->
+              expr fn =
+          fun ~monad:_ ~lhs ~rhs body -> print#expr_let ~lhs ~rhs body
+
+        method expr_let : lhs:pat -> rhs:expr -> expr fn =
+          fun ~lhs ~rhs body ->
+            string "let"
+            ^/^ iblock Fn.id (print#pat_at Expr_Let_lhs lhs)
+            ^/^ equals
+            ^/^ iblock Fn.id (print#expr_at Expr_Let_rhs rhs)
+            ^^ semi
+            ^/^ (print#expr_at Expr_Let_body body |> group)
+
+        method tuple_projection : size:int -> nth:int -> expr fn =
+          fun ~size:_ ~nth e ->
+            print#expr_at Expr_TupleProjection e
+            |> terminate (dot ^^ OCaml.int nth)
+
+        method field_projection : concrete_ident -> expr fn =
+          fun i e ->
+            print#expr_at Expr_FieldProjection e
+            |> terminate (dot ^^ print#name_of_concrete_ident i)
+
+        method expr_app : expr -> expr list fn =
+          fun f args ->
+            let args =
+              separate_map
+                (comma ^^ break 1)
+                (print#expr_at Expr_App_arg >> group)
+                args
+            in
+            let f = print#expr_at Expr_App_f f |> group in
+            f ^^ iblock parens args
+
+        method doc_construct_tuple : document list fn =
+          separate comma >> iblock parens
+
+        method expr_construct_tuple : expr list fn =
+          List.map ~f:(print#expr_at Expr_ConstructTuple)
+          >> print#doc_construct_tuple
+
+        method pat_construct_tuple : pat list fn =
+          List.map ~f:(print#pat_at Pat_ConstructTuple)
+          >> print#doc_construct_tuple
+
+        method global_ident_projector : global_ident fn =
+          function
+          | `Projector (`Concrete i) -> print#concrete_ident i
+          | _ ->
+              print#assertion_failure "global_ident_projector: not a projector"
+
+        method doc_construct_inductive
+            : is_record:bool ->
+              is_struct:bool ->
+              constructor:concrete_ident ->
+              base:document option ->
+              (global_ident * document) list fn =
+          fun ~is_record ~is_struct:_ ~constructor ~base:_ args ->
+            if is_record then
+              print#concrete_ident constructor
+              ^^ space
+              ^^ iblock parens
+                   (separate_map (break 0)
+                      (fun (field, body) ->
+                        (print#global_ident_projector field
+                        |> terminate comma |> group)
+                        ^^ colon ^^ space ^^ iblock Fn.id body)
+                      args)
+            else
+              print#concrete_ident constructor
+              ^^ space
+              ^^ iblock parens (separate_map (break 0) snd args)
+
+        method expr_construct_inductive
+            : is_record:bool ->
+              is_struct:bool ->
+              constructor:concrete_ident ->
+              base:(expr * F.construct_base) option ->
+              (global_ident * expr) list fn =
+          fun ~is_record ~is_struct ~constructor ~base ->
+            let base =
+              Option.map
+                ~f:(fst >> print#expr_at Expr_ConcreteInductive_base)
+                base
+            in
+            List.map ~f:(print#expr_at Expr_ConcreteInductive_field |> map_snd)
+            >> print#doc_construct_inductive ~is_record ~is_struct ~constructor
+                 ~base
+
+        method attr : attr fn = fun _ -> empty
+
+        method pat' : par_state -> pat' fn =
+          fun ctx ->
+            let wrap_parens =
+              group
+              >>
+              match ctx with AlreadyPar -> Fn.id | NeedsPar -> iblock braces
+            in
+            function
+            | PWild -> underscore
+            | PAscription { typ; typ_span; pat } ->
+                print#pat_ascription ~typ ~typ_span pat |> wrap_parens
+            | PBinding { mut; mode; var; typ = _; subpat } -> (
+                let p =
+                  (match mode with ByRef _ -> string "&" | _ -> empty)
+                  ^^ (match mut with Mutable _ -> string "mut " | _ -> empty)
+                  ^^ print#local_ident var
+                in
+                match subpat with
+                | Some (subpat, _) ->
+                    p ^^ space ^^ at ^^ space
+                    ^^ print#pat_at Pat_PBinding_subpat subpat
+                    |> wrap_parens
+                | None -> p)
+            | PArray { args } ->
+                separate_map (break 0)
+                  (print#pat_at Pat_PArray >> terminate comma >> group)
+                  args
+                |> iblock brackets
+            | PDeref { subpat; _ } ->
+                ampersand ^^ print#pat_at Pat_PDeref subpat
+            | (PConstruct _ | PConstant _) as pat -> super#pat' ctx pat
+
+        method pat_ascription : typ:ty -> typ_span:span -> pat fn =
+          fun ~typ ~typ_span pat ->
+            print#pat_at Pat_Ascription_pat pat
+            ^^ colon
+            ^^ print#with_span ~span:typ_span (fun () ->
+                   print#ty_at Pat_Ascription_typ typ)
+
+        method expr_unwrapped : par_state -> expr fn =
+          fun ctx { e; _ } -> print#expr' ctx e
+
+        method param : param fn =
+          fun { pat; typ; typ_span; attrs } ->
+            let typ =
+              match typ_span with
+              | Some span ->
+                  print#with_span ~span (fun _ -> print#ty_at Param_typ typ)
+              | None -> print#ty_at Param_typ typ
+            in
+            print#attrs attrs ^^ print#pat_at Param_pat pat ^^ space ^^ colon
+            ^^ space ^^ typ
+
+        method item' : item' fn =
+          function
+          | Fn { name; generics; body; params } ->
+              let params =
+                iblock parens
+                  (separate_map (comma ^^ break 1) print#param params)
+              in
+              let generics = print#generic_params generics.params in
+              string "fn" ^^ space ^^ print#concrete_ident name ^^ generics
+              ^^ params
+              ^^ iblock braces (print#expr_at Item_Fn_body body)
+          | _ -> string "item not implemented"
+
+        method generic_param' : generic_param fn =
+          fun { ident; attrs; kind; _ } ->
+            let suffix =
+              match kind with
+              | GPLifetime _ -> space ^^ colon ^^ space ^^ string "'unk"
+              | GPType { default = None } -> empty
+              | GPType { default = Some default } ->
+                  space ^^ equals ^^ space
+                  ^^ print#ty_at GenericParam_GPType default
+              | GPConst { typ } ->
+                  space ^^ colon ^^ space
+                  ^^ print#ty_at GenericParam_GPConst typ
+            in
+            let prefix =
+              match kind with
+              | GPConst _ -> string "const" ^^ space
+              | _ -> empty
+            in
+            let ident =
+              let name =
+                if String.(ident.name = "_") then "Anonymous" else ident.name
+              in
+              { ident with name }
+            in
+            prefix ^^ print#attrs attrs ^^ print#local_ident ident ^^ suffix
+
+        method generic_params : generic_param list fn =
+          separate_map comma print#generic_param >> group >> angles
+
+        method arm' : arm' fn =
+          fun { arm_pat; body } ->
+            let pat = print#pat_at Arm_pat arm_pat |> group in
+            let body = print#expr_at Arm_body body in
+            pat ^^ string " => " ^^ body ^^ comma
+      end
+  end)
+end

--- a/engine/lib/generic_printer/generic_printer.mli
+++ b/engine/lib/generic_printer/generic_printer.mli
@@ -1,0 +1,4 @@
+module Make (F : Features.T) (View : Concrete_ident.VIEW_API) : sig
+  open Generic_printer_base.Make(F)
+  include API
+end

--- a/engine/lib/generic_printer/generic_printer.mli
+++ b/engine/lib/generic_printer/generic_printer.mli
@@ -1,4 +1,5 @@
 module Make (F : Features.T) (View : Concrete_ident.VIEW_API) : sig
   open Generic_printer_base.Make(F)
   include API
+  class print: print_class
 end

--- a/engine/lib/generic_printer/generic_printer_base.ml
+++ b/engine/lib/generic_printer/generic_printer_base.ml
@@ -47,6 +47,7 @@ type ast_position =
   | Pat_ConcreteInductive
   | Pat_Ascription_pat
   | Pat_Ascription_typ
+  | Pat_Or
   | Param_pat
   | Param_typ
   | GenericParam_GPType

--- a/engine/lib/generic_printer/generic_printer_base.ml
+++ b/engine/lib/generic_printer/generic_printer_base.ml
@@ -57,11 +57,11 @@ type ast_position =
 [@@warning "-37"]
 
 module Annotation = struct
-  type loc = { line : int; col : int }
-  type t = loc * span
+  type loc = { line : int; col : int } [@@deriving show, yojson, eq]
+  type t = loc * span [@@deriving show, yojson, eq]
 end
 
-type annot_str = string * Annotation.t list
+type annot_str = string * Annotation.t list [@@deriving show, yojson, eq]
 
 (** When printing a chunk of AST, should we wrap parenthesis
 ({!NeedsPar}) or not ({!AlreadyPar})? *)
@@ -74,276 +74,272 @@ module Make (F : Features.T) = struct
   module U = Ast_utils.Make (F)
   open Ast.Make (F)
 
-  (** Raw generic printers classes. Those are useful for building a
+  type 't fn = 't -> document
+
+  (** Raw generic printers base class. Those are useful for building a
   printer, not for consuming printers. Consumers should use
   the {!module:Api} functor. *)
-  module P = struct
-    type 't fn = 't -> document
+  class virtual print_base =
+    object (print)
+      val mutable current_span = Span.default
+      val mutable span_data : Annotation.t list = []
+      val mutable current_namespace : (string * string list) option = None
+      method get_span_data () = span_data
 
-    class virtual print_base =
-      object (print)
-        val mutable current_span = Span.default
-        val mutable span_data : Annotation.t list = []
-        val mutable current_namespace : (string * string list) option = None
-        method get_span_data () = span_data
+      method with_span ~span f =
+        let prev_span = current_span in
+        current_span <- span;
+        let doc = f () |> print#spanned_doc |> custom in
+        current_span <- prev_span;
+        doc
 
-        method with_span ~span f =
-          let prev_span = current_span in
-          current_span <- span;
-          let doc = f () |> print#spanned_doc |> custom in
-          current_span <- prev_span;
-          doc
+      method spanned_doc (doc : document) : custom =
+        let span = current_span in
+        object
+          method requirement : requirement = requirement doc
 
-        method spanned_doc (doc : document) : custom =
-          let span = current_span in
-          object
-            method requirement : requirement = requirement doc
+          method pretty : output -> state -> int -> bool -> unit =
+            fun o s i b ->
+              span_data <-
+                ({ line = s.line; col = s.column }, span) :: span_data;
+              pretty o s i b doc
 
-            method pretty : output -> state -> int -> bool -> unit =
-              fun o s i b ->
-                span_data <-
-                  ({ line = s.line; col = s.column }, span) :: span_data;
-                pretty o s i b doc
+          method compact : output -> unit = fun o -> compact o doc
+        end
 
-            method compact : output -> unit = fun o -> compact o doc
-          end
+      method concrete_ident : concrete_ident fn =
+        fun id ->
+          let current_ns = print#get_current_namespace () in
+          let id_ns = print#namespace_of_concrete_ident id in
+          print#concrete_ident'
+            ~under_current_ns:
+              ([%equal: (string * string list) option] current_ns (Some id_ns))
+            id
 
-        method concrete_ident : concrete_ident fn =
-          fun id ->
-            let current_ns = print#get_current_namespace () in
-            let id_ns = print#namespace_of_concrete_ident id in
-            print#concrete_ident'
-              ~under_current_ns:
-                ([%equal: (string * string list) option] current_ns (Some id_ns))
-              id
+      method assertion_failure : 'any. string -> 'any =
+        fun details ->
+          let span = Span.to_thir current_span in
+          let kind = Types.AssertionFailure { details } in
+          let ctx = Diagnostics.Context.GenericPrinter print#printer_name in
+          Diagnostics.SpanFreeError.raise ~span ctx kind
 
-        method assertion_failure : 'any. string -> 'any =
-          fun details ->
-            let span = Span.to_thir current_span in
-            let kind = Types.AssertionFailure { details } in
-            let ctx = Diagnostics.Context.GenericPrinter print#printer_name in
-            Diagnostics.SpanFreeError.raise ~span ctx kind
+      method set_current_namespace ns = current_namespace <- ns
+      method get_current_namespace () = current_namespace
 
-        method set_current_namespace ns = current_namespace <- ns
-        method get_current_namespace () = current_namespace
+      (* `*_at` variants *)
+      method expr_at : ast_position -> expr fn = print#par_state >> print#expr
+      method ty_at : ast_position -> ty fn = print#par_state >> print#ty
+      method pat_at : ast_position -> pat fn = print#par_state >> print#pat
 
-        (* `*_at` variants *)
-        method expr_at : ast_position -> expr fn = print#par_state >> print#expr
-        method ty_at : ast_position -> ty fn = print#par_state >> print#ty
-        method pat_at : ast_position -> pat fn = print#par_state >> print#pat
+      method pat : par_state -> pat fn =
+        fun ctx { p; span; _ } ->
+          print#with_span ~span (fun _ -> print#pat' ctx p)
 
-        method pat : par_state -> pat fn =
-          fun ctx { p; span; _ } ->
-            print#with_span ~span (fun _ -> print#pat' ctx p)
+      method item_unwrapped : item fn = fun { v; _ } -> print#item' v
 
-        method item_unwrapped : item fn = fun { v; _ } -> print#item' v
+      method generic_param : generic_param fn =
+        fun ({ span; _ } as p) ->
+          print#with_span ~span (fun _ -> print#generic_param' p)
 
-        method generic_param : generic_param fn =
-          fun ({ span; _ } as p) ->
-            print#with_span ~span (fun _ -> print#generic_param' p)
+      method arm : arm fn =
+        fun { arm; span } -> print#with_span ~span (fun _ -> print#arm' arm)
 
-        method arm : arm fn =
-          fun { arm; span } -> print#with_span ~span (fun _ -> print#arm' arm)
-
-        method ty : par_state -> ty fn =
-          fun _ctx ty ->
-            match ty with
-            | TApp { ident = `Concrete ident; args } ->
-                print#ty_app ident args |> group
-            | TApp
-                {
-                  ident =
-                    `Primitive _ | `TupleCons _ | `TupleField _ | `Projector _;
-                  _;
-                } ->
-                print#assertion_failure "TApp not concrete"
-            | TApp { ident = `TupleType n; args } ->
-                let args =
-                  List.filter_map
-                    ~f:(function GType t -> Some t | _ -> None)
-                    args
-                in
-                if [%equal: int] (List.length args) n |> not then
-                  print#assertion_failure "malformed ty app tuple";
-                print#ty_tuple n args
-            | TApp _ -> .
-            | _ ->
-                print#assertion_failure
-                  "default ty is only implemented for TApp"
-
-        method expr' : par_state -> expr' fn =
-          fun _ctx e ->
-            match e with
-            | App { f = { e = GlobalVar i; _ } as f; args } -> (
-                let expect_one_arg where =
-                  match args with
-                  | [ arg ] -> arg
-                  | _ ->
-                      print#assertion_failure @@ "Expected one arg at " ^ where
-                in
-                match i with
-                | `Concrete _ | `Primitive _ -> print#expr_app f args
-                | `TupleType _ | `TupleCons _ | `TupleField _ ->
-                    print#assertion_failure "App: unexpected tuple"
-                | `Projector (`TupleField (nth, size)) ->
-                    let arg = expect_one_arg "projector tuple field" in
-                    print#tuple_projection ~size ~nth arg
-                | `Projector (`Concrete i) ->
-                    let arg = expect_one_arg "projector concrete" in
-                    print#field_projection i arg)
-            | App { f; args } -> print#expr_app f args
-            | Construct { constructor; fields; base; is_record; is_struct } -> (
-                match constructor with
-                | `Concrete constructor ->
-                    print#expr_construct_inductive ~is_record ~is_struct
-                      ~constructor ~base fields
-                | `TupleCons _ ->
-                    List.map ~f:snd fields |> print#expr_construct_tuple
-                | `Primitive _ | `TupleType _ | `TupleField _ | `Projector _ ->
-                    print#assertion_failure "Construct unexpected constructors")
-            | App _ | Construct _ -> .
-            | _ ->
-                print#assertion_failure
-                  "default expr' is only implemented for App and Construct"
-
-        method pat' : par_state -> pat' fn =
-          fun _ -> function
-            | PConstant { lit } -> print#literal Pat lit
-            | PConstruct { name; args; is_record; is_struct } -> (
-                match name with
-                | `Concrete constructor ->
-                    print#doc_construct_inductive ~is_record ~is_struct
-                      ~constructor ~base:None
-                      (List.map
-                         ~f:(fun fp ->
-                           (fp.field, print#pat_at Pat_ConcreteInductive fp.pat))
-                         args)
-                | `TupleCons _ ->
-                    List.map ~f:(fun fp -> fp.pat) args
-                    |> print#pat_construct_tuple
-                | `Primitive _ | `TupleType _ | `TupleField _ | `Projector _ ->
-                    print#assertion_failure "todo err")
-            | _ ->
-                print#assertion_failure
-                  "default pat' is only implemented for PConstant and \
-                   PConstruct"
-
-        method expr : par_state -> expr fn =
-          fun ctx e ->
-            let span = e.span in
-            print#with_span ~span (fun _ ->
-                try print#expr_unwrapped ctx e
-                with Diagnostics.SpanFreeError.Exn (Data (context, kind)) ->
-                  U.hax_failure_expr span e.typ (context, kind)
-                    (U.LiftToFullAst.expr e)
-                  (* TODO: if the printer is extremely broken, this results in a stack overflow *)
-                  |> print#expr ctx)
-
-        method item : item fn =
-          fun i ->
-            print#set_current_namespace
-              (print#namespace_of_concrete_ident i.ident |> Option.some);
-            try print#item_unwrapped i
-            with Diagnostics.SpanFreeError.Exn (Data (context, kind)) ->
-              let error = Diagnostics.pretty_print_context_kind context kind in
-              let cast_item : item -> Ast.Full.item = Stdlib.Obj.magic in
-              let ast = cast_item i |> Print_rust.pitem_str in
-              let msg =
-                error ^ "\nLast available AST for this item:\n\n" ^ ast
+      method ty : par_state -> ty fn =
+        fun _ctx ty ->
+          match ty with
+          | TApp { ident = `Concrete ident; args } ->
+              print#ty_app ident args |> group
+          | TApp
+              {
+                ident =
+                  `Primitive _ | `TupleCons _ | `TupleField _ | `Projector _;
+                _;
+              } ->
+              print#assertion_failure "TApp not concrete"
+          | TApp { ident = `TupleType n; args } ->
+              let args =
+                List.filter_map
+                  ~f:(function GType t -> Some t | _ -> None)
+                  args
               in
-              (* TODO: if the printer is extremely broken, this results in a stack overflow *)
-              make_hax_error_item i.span i.ident msg |> print#item
+              if [%equal: int] (List.length args) n |> not then
+                print#assertion_failure "malformed ty app tuple";
+              print#ty_tuple n args
+          | TApp _ -> .
+          | _ ->
+              print#assertion_failure "default ty is only implemented for TApp"
 
-        method items : item list fn = separate_map (twice hardline) print#item
-        method attrs : attrs fn = separate_map hardline print#attr
-      end
+      method expr' : par_state -> expr' fn =
+        fun _ctx e ->
+          match e with
+          | App { f = { e = GlobalVar i; _ } as f; args } -> (
+              let expect_one_arg where =
+                match args with
+                | [ arg ] -> arg
+                | _ -> print#assertion_failure @@ "Expected one arg at " ^ where
+              in
+              match i with
+              | `Concrete _ | `Primitive _ -> print#expr_app f args
+              | `TupleType _ | `TupleCons _ | `TupleField _ ->
+                  print#assertion_failure "App: unexpected tuple"
+              | `Projector (`TupleField (nth, size)) ->
+                  let arg = expect_one_arg "projector tuple field" in
+                  print#tuple_projection ~size ~nth arg
+              | `Projector (`Concrete i) ->
+                  let arg = expect_one_arg "projector concrete" in
+                  print#field_projection i arg)
+          | App { f; args } -> print#expr_app f args
+          | Construct { constructor; fields; base; is_record; is_struct } -> (
+              match constructor with
+              | `Concrete constructor ->
+                  print#expr_construct_inductive ~is_record ~is_struct
+                    ~constructor ~base fields
+              | `TupleCons _ ->
+                  List.map ~f:snd fields |> print#expr_construct_tuple
+              | `Primitive _ | `TupleType _ | `TupleField _ | `Projector _ ->
+                  print#assertion_failure "Construct unexpected constructors")
+          | App _ | Construct _ -> .
+          | _ ->
+              print#assertion_failure
+                "default expr' is only implemented for App and Construct"
 
-    class type print =
-      object
-        method printer_name : string
+      method pat' : par_state -> pat' fn =
+        fun _ -> function
+          | PConstant { lit } -> print#literal Pat lit
+          | PConstruct { name; args; is_record; is_struct } -> (
+              match name with
+              | `Concrete constructor ->
+                  print#doc_construct_inductive ~is_record ~is_struct
+                    ~constructor ~base:None
+                    (List.map
+                       ~f:(fun fp ->
+                         (fp.field, print#pat_at Pat_ConcreteInductive fp.pat))
+                       args)
+              | `TupleCons _ ->
+                  List.map ~f:(fun fp -> fp.pat) args
+                  |> print#pat_construct_tuple
+              | `Primitive _ | `TupleType _ | `TupleField _ | `Projector _ ->
+                  print#assertion_failure "todo err")
+          | _ ->
+              print#assertion_failure
+                "default pat' is only implemented for PConstant and PConstruct"
 
-        method namespace_of_concrete_ident :
-          concrete_ident -> string * string list
+      method expr : par_state -> expr fn =
+        fun ctx e ->
+          let span = e.span in
+          print#with_span ~span (fun _ ->
+              try print#expr_unwrapped ctx e
+              with Diagnostics.SpanFreeError.Exn (Data (context, kind)) ->
+                U.hax_failure_expr span e.typ (context, kind)
+                  (U.LiftToFullAst.expr e)
+                (* TODO: if the printer is extremely broken, this results in a stack overflow *)
+                |> print#expr ctx)
 
-        method par_state : ast_position -> par_state
-        method concrete_ident' : under_current_ns:bool -> concrete_ident fn
-        method concrete_ident : concrete_ident fn
-        method name_of_concrete_ident : concrete_ident fn
-        method mutability : 'a. 'a mutability fn
-        method primitive_ident : primitive_ident fn
-        method local_ident : local_ident fn
-        method literal : literal_ctx -> literal fn
-        method generic_value : generic_value fn
-        method lhs : lhs fn
-        method ty_bool : document
-        method ty_char : document
-        method ty_str : document
-        method ty_int : int_kind fn
-        method ty_float : float_kind fn
-        method generic_values : generic_value list fn
-        method ty_app : concrete_ident -> generic_value list fn
-        method ty_tuple : int -> ty list fn
-        method ty : par_state -> ty fn
-        method expr' : par_state -> expr' fn
+      method item : item fn =
+        fun i ->
+          print#set_current_namespace
+            (print#namespace_of_concrete_ident i.ident |> Option.some);
+          try print#item_unwrapped i
+          with Diagnostics.SpanFreeError.Exn (Data (context, kind)) ->
+            let error = Diagnostics.pretty_print_context_kind context kind in
+            let cast_item : item -> Ast.Full.item = Stdlib.Obj.magic in
+            let ast = cast_item i |> Print_rust.pitem_str in
+            let msg = error ^ "\nLast available AST for this item:\n\n" ^ ast in
+            (* TODO: if the printer is extremely broken, this results in a stack overflow *)
+            make_hax_error_item i.span i.ident msg |> print#item
 
-        method expr_monadic_let :
-          monad:supported_monads * F.monadic_binding ->
-          lhs:pat ->
-          rhs:expr ->
-          expr fn
+      method items : item list fn = separate_map (twice hardline) print#item
+      method attrs : attrs fn = separate_map hardline print#attr
+    end
 
-        method expr_let : lhs:pat -> rhs:expr -> expr fn
-        method tuple_projection : size:int -> nth:int -> expr fn
-        method field_projection : concrete_ident -> expr fn
-        method expr_app : expr -> expr list fn
-        method doc_construct_tuple : document list fn
-        method expr_construct_tuple : expr list fn
-        method pat_construct_tuple : pat list fn
-        method global_ident_projector : global_ident fn
+  type print_object =
+    < printer_name : string
+    ; get_span_data : unit -> Annotation.t list
+    ; ty : par_state -> ty fn
+    ; pat : par_state -> pat fn
+    ; arm : arm fn
+    ; expr : par_state -> expr fn
+    ; item : item fn
+    ; items : item list fn >
+  (** In the end, an printer *object* should be of the type {!print_object}. *)
 
-        method doc_construct_inductive :
-          is_record:bool ->
-          is_struct:bool ->
-          constructor:concrete_ident ->
-          base:document option ->
-          (global_ident * document) list fn
+  class type print_class =
+    object
+      inherit print_base
+      method printer_name : string
+      method get_span_data : unit -> Annotation.t list
 
-        method expr_construct_inductive :
-          is_record:bool ->
-          is_struct:bool ->
-          constructor:concrete_ident ->
-          base:(expr * F.construct_base) option ->
-          (global_ident * expr) list fn
+      method namespace_of_concrete_ident :
+        concrete_ident -> string * string list
 
-        method attr : attr fn
-        method attrs : attrs fn
-        method pat' : par_state -> pat' fn
-        method pat_ascription : typ:ty -> typ_span:span -> pat fn
-        method pat : par_state -> pat fn
-        method expr_unwrapped : par_state -> expr fn
-        method param : param fn
-        method item' : item' fn
-        method item_unwrapped : item fn
-        method generic_param' : generic_param fn
-        method generic_param : generic_param fn
-        method generic_params : generic_param list fn
-        method arm' : arm' fn
-        method arm : arm fn
-        method expr : par_state -> expr fn
-        method item : item fn
-        method items : item list fn
-      end
-  end
+      method par_state : ast_position -> par_state
+      method concrete_ident' : under_current_ns:bool -> concrete_ident fn
+      method concrete_ident : concrete_ident fn
+      method name_of_concrete_ident : concrete_ident fn
+      method mutability : 'a. 'a mutability fn
+      method primitive_ident : primitive_ident fn
+      method local_ident : local_ident fn
+      method literal : literal_ctx -> literal fn
+      method generic_value : generic_value fn
+      method lhs : lhs fn
+      method ty_bool : document
+      method ty_char : document
+      method ty_str : document
+      method ty_int : int_kind fn
+      method ty_float : float_kind fn
+      method generic_values : generic_value list fn
+      method ty_app : concrete_ident -> generic_value list fn
+      method ty_tuple : int -> ty list fn
+      method ty : par_state -> ty fn
+      method expr' : par_state -> expr' fn
 
-  include P
+      method expr_monadic_let :
+        monad:supported_monads * F.monadic_binding ->
+        lhs:pat ->
+        rhs:expr ->
+        expr fn
 
-  module type PRINT_CLASS = sig
-    class print :
-      object
-        inherit P.print
-        inherit P.print_base
-      end
-  end
+      method expr_let : lhs:pat -> rhs:expr -> expr fn
+      method tuple_projection : size:int -> nth:int -> expr fn
+      method field_projection : concrete_ident -> expr fn
+      method expr_app : expr -> expr list fn
+      method doc_construct_tuple : document list fn
+      method expr_construct_tuple : expr list fn
+      method pat_construct_tuple : pat list fn
+      method global_ident_projector : global_ident fn
+
+      method doc_construct_inductive :
+        is_record:bool ->
+        is_struct:bool ->
+        constructor:concrete_ident ->
+        base:document option ->
+        (global_ident * document) list fn
+
+      method expr_construct_inductive :
+        is_record:bool ->
+        is_struct:bool ->
+        constructor:concrete_ident ->
+        base:(expr * F.construct_base) option ->
+        (global_ident * expr) list fn
+
+      method attr : attr fn
+      method attrs : attrs fn
+      method pat' : par_state -> pat' fn
+      method pat_ascription : typ:ty -> typ_span:span -> pat fn
+      method pat : par_state -> pat fn
+      method expr_unwrapped : par_state -> expr fn
+      method param : param fn
+      method item' : item' fn
+      method item_unwrapped : item fn
+      method generic_param' : generic_param fn
+      method generic_param : generic_param fn
+      method generic_params : generic_param list fn
+      method arm' : arm' fn
+      method arm : arm fn
+      method expr : par_state -> expr fn
+      method item : item fn
+      method items : item list fn
+    end
 
   module type API = sig
     val items : item list -> annot_str
@@ -351,16 +347,16 @@ module Make (F : Features.T) = struct
     val expr : expr -> annot_str
     val pat : pat -> annot_str
     val ty : ty -> annot_str
-
-    module Class : PRINT_CLASS
   end
 
-  module Api (Class : PRINT_CLASS) = struct
-    module Class = Class
-    open Class
+  module Api (NewPrint : sig
+    val new_print : unit -> print_object
+  end) =
+  struct
+    open NewPrint
 
-    let mk (f : print -> 'a -> PPrint.document) (x : 'a) : annot_str =
-      let printer = new print in
+    let mk (f : print_object -> 'a -> PPrint.document) (x : 'a) : annot_str =
+      let printer = new_print () in
       let doc = f printer x in
       let buf = Buffer.create 0 in
       PPrint.ToBuffer.pretty 1.0 80 buf doc;

--- a/engine/lib/generic_printer/generic_printer_base.ml
+++ b/engine/lib/generic_printer/generic_printer_base.ml
@@ -1,0 +1,375 @@
+open! Prelude
+open! Ast
+open PPrint
+
+(** Generic printer for the {!module:Ast} ASTs. It uses the [PPrint]
+library, and additionaly computes {!Annotation.t}.  *)
+
+(** Identifies a position in the AST. This is useful for figuring out
+wether we should wrap a chunk of AST in parenthesis. or not *)
+type ast_position =
+  | GenericValue_GType
+  | GenericValue_GConst
+  | Lhs_LhsArbitraryExpr
+  | Lhs_LhsArrayAccessor
+  | Ty_TArrow
+  | Ty_TRef
+  | Ty_Tuple
+  | Ty_TSlice
+  | Ty_TArray_typ
+  | Ty_TArray_length
+  | Expr_If_cond
+  | Expr_If_then
+  | Expr_If_else
+  | Expr_Array
+  | Expr_Assign
+  | Expr_Closure_param
+  | Expr_Closure_body
+  | Expr_Ascription_e
+  | Expr_Ascription_typ
+  | Expr_Let_lhs
+  | Expr_Let_rhs
+  | Expr_Let_body
+  | Expr_Match_scrutinee
+  | Expr_QuestionMark
+  | Expr_Borrow
+  | Expr_TupleProjection
+  | Expr_ConstructTuple
+  | Expr_FieldProjection
+  | Expr_App_f
+  | Expr_App_arg
+  | Expr_ConcreteInductive_base
+  | Expr_ConcreteInductive_field
+  | Pat_PBinding_subpat
+  | Pat_PDeref
+  | Pat_PArray
+  | Pat_ConstructTuple
+  | Pat_ConcreteInductive
+  | Pat_Ascription_pat
+  | Pat_Ascription_typ
+  | Param_pat
+  | Param_typ
+  | GenericParam_GPType
+  | GenericParam_GPConst
+  | Arm_pat
+  | Arm_body
+  | Item_Fn_body
+[@@warning "-37"]
+
+module Annotation = struct
+  type loc = { line : int; col : int }
+  type t = loc * span
+end
+
+type annot_str = string * Annotation.t list
+
+(** When printing a chunk of AST, should we wrap parenthesis
+({!NeedsPar}) or not ({!AlreadyPar})? *)
+type par_state = NeedsPar | AlreadyPar
+
+type literal_ctx = Pat | Expr
+
+module Make (F : Features.T) = struct
+  module AST = Ast.Make (F)
+  module U = Ast_utils.Make (F)
+  open Ast.Make (F)
+
+  (** Raw generic printers classes. Those are useful for building a
+  printer, not for consuming printers. Consumers should use
+  the {!module:Api} functor. *)
+  module P = struct
+    type 't fn = 't -> document
+
+    class virtual print_base =
+      object (print)
+        val mutable current_span = Span.default
+        val mutable span_data : Annotation.t list = []
+        val mutable current_namespace : (string * string list) option = None
+        method get_span_data () = span_data
+
+        method with_span ~span f =
+          let prev_span = current_span in
+          current_span <- span;
+          let doc = f () |> print#spanned_doc |> custom in
+          current_span <- prev_span;
+          doc
+
+        method spanned_doc (doc : document) : custom =
+          let span = current_span in
+          object
+            method requirement : requirement = requirement doc
+
+            method pretty : output -> state -> int -> bool -> unit =
+              fun o s i b ->
+                span_data <-
+                  ({ line = s.line; col = s.column }, span) :: span_data;
+                pretty o s i b doc
+
+            method compact : output -> unit = fun o -> compact o doc
+          end
+
+        method concrete_ident : concrete_ident fn =
+          fun id ->
+            let current_ns = print#get_current_namespace () in
+            let id_ns = print#namespace_of_concrete_ident id in
+            print#concrete_ident'
+              ~under_current_ns:
+                ([%equal: (string * string list) option] current_ns (Some id_ns))
+              id
+
+        method assertion_failure : 'any. string -> 'any =
+          fun details ->
+            let span = Span.to_thir current_span in
+            let kind = Types.AssertionFailure { details } in
+            let ctx = Diagnostics.Context.GenericPrinter print#printer_name in
+            Diagnostics.SpanFreeError.raise ~span ctx kind
+
+        method set_current_namespace ns = current_namespace <- ns
+        method get_current_namespace () = current_namespace
+
+        (* `*_at` variants *)
+        method expr_at : ast_position -> expr fn = print#par_state >> print#expr
+        method ty_at : ast_position -> ty fn = print#par_state >> print#ty
+        method pat_at : ast_position -> pat fn = print#par_state >> print#pat
+
+        method pat : par_state -> pat fn =
+          fun ctx { p; span; _ } ->
+            print#with_span ~span (fun _ -> print#pat' ctx p)
+
+        method item_unwrapped : item fn = fun { v; _ } -> print#item' v
+
+        method generic_param : generic_param fn =
+          fun ({ span; _ } as p) ->
+            print#with_span ~span (fun _ -> print#generic_param' p)
+
+        method arm : arm fn =
+          fun { arm; span } -> print#with_span ~span (fun _ -> print#arm' arm)
+
+        method ty : par_state -> ty fn =
+          fun _ctx ty ->
+            match ty with
+            | TApp { ident = `Concrete ident; args } ->
+                print#ty_app ident args |> group
+            | TApp
+                {
+                  ident =
+                    `Primitive _ | `TupleCons _ | `TupleField _ | `Projector _;
+                  _;
+                } ->
+                print#assertion_failure "TApp not concrete"
+            | TApp { ident = `TupleType n; args } ->
+                let args =
+                  List.filter_map
+                    ~f:(function GType t -> Some t | _ -> None)
+                    args
+                in
+                if [%equal: int] (List.length args) n |> not then
+                  print#assertion_failure "malformed ty app tuple";
+                print#ty_tuple n args
+            | TApp _ -> .
+            | _ ->
+                print#assertion_failure
+                  "default ty is only implemented for TApp"
+
+        method expr' : par_state -> expr' fn =
+          fun _ctx e ->
+            match e with
+            | App { f = { e = GlobalVar i; _ } as f; args } -> (
+                let expect_one_arg where =
+                  match args with
+                  | [ arg ] -> arg
+                  | _ ->
+                      print#assertion_failure @@ "Expected one arg at " ^ where
+                in
+                match i with
+                | `Concrete _ | `Primitive _ -> print#expr_app f args
+                | `TupleType _ | `TupleCons _ | `TupleField _ ->
+                    print#assertion_failure "App: unexpected tuple"
+                | `Projector (`TupleField (nth, size)) ->
+                    let arg = expect_one_arg "projector tuple field" in
+                    print#tuple_projection ~size ~nth arg
+                | `Projector (`Concrete i) ->
+                    let arg = expect_one_arg "projector concrete" in
+                    print#field_projection i arg)
+            | App { f; args } -> print#expr_app f args
+            | Construct { constructor; fields; base; is_record; is_struct } -> (
+                match constructor with
+                | `Concrete constructor ->
+                    print#expr_construct_inductive ~is_record ~is_struct
+                      ~constructor ~base fields
+                | `TupleCons _ ->
+                    List.map ~f:snd fields |> print#expr_construct_tuple
+                | `Primitive _ | `TupleType _ | `TupleField _ | `Projector _ ->
+                    print#assertion_failure "Construct unexpected constructors")
+            | App _ | Construct _ -> .
+            | _ ->
+                print#assertion_failure
+                  "default expr' is only implemented for App and Construct"
+
+        method pat' : par_state -> pat' fn =
+          fun _ -> function
+            | PConstant { lit } -> print#literal Pat lit
+            | PConstruct { name; args; is_record; is_struct } -> (
+                match name with
+                | `Concrete constructor ->
+                    print#doc_construct_inductive ~is_record ~is_struct
+                      ~constructor ~base:None
+                      (List.map
+                         ~f:(fun fp ->
+                           (fp.field, print#pat_at Pat_ConcreteInductive fp.pat))
+                         args)
+                | `TupleCons _ ->
+                    List.map ~f:(fun fp -> fp.pat) args
+                    |> print#pat_construct_tuple
+                | `Primitive _ | `TupleType _ | `TupleField _ | `Projector _ ->
+                    print#assertion_failure "todo err")
+            | _ ->
+                print#assertion_failure
+                  "default pat' is only implemented for PConstant and \
+                   PConstruct"
+
+        method expr : par_state -> expr fn =
+          fun ctx e ->
+            let span = e.span in
+            print#with_span ~span (fun _ ->
+                try print#expr_unwrapped ctx e
+                with Diagnostics.SpanFreeError.Exn (Data (context, kind)) ->
+                  U.hax_failure_expr span e.typ (context, kind)
+                    (U.LiftToFullAst.expr e)
+                  (* TODO: if the printer is extremely broken, this results in a stack overflow *)
+                  |> print#expr ctx)
+
+        method item : item fn =
+          fun i ->
+            print#set_current_namespace
+              (print#namespace_of_concrete_ident i.ident |> Option.some);
+            try print#item_unwrapped i
+            with Diagnostics.SpanFreeError.Exn (Data (context, kind)) ->
+              let error = Diagnostics.pretty_print_context_kind context kind in
+              let cast_item : item -> Ast.Full.item = Stdlib.Obj.magic in
+              let ast = cast_item i |> Print_rust.pitem_str in
+              let msg =
+                error ^ "\nLast available AST for this item:\n\n" ^ ast
+              in
+              (* TODO: if the printer is extremely broken, this results in a stack overflow *)
+              make_hax_error_item i.span i.ident msg |> print#item
+
+        method items : item list fn = separate_map (twice hardline) print#item
+        method attrs : attrs fn = separate_map hardline print#attr
+      end
+
+    class type print =
+      object
+        method printer_name : string
+
+        method namespace_of_concrete_ident :
+          concrete_ident -> string * string list
+
+        method par_state : ast_position -> par_state
+        method concrete_ident' : under_current_ns:bool -> concrete_ident fn
+        method concrete_ident : concrete_ident fn
+        method name_of_concrete_ident : concrete_ident fn
+        method mutability : 'a. 'a mutability fn
+        method primitive_ident : primitive_ident fn
+        method local_ident : local_ident fn
+        method literal : literal_ctx -> literal fn
+        method generic_value : generic_value fn
+        method lhs : lhs fn
+        method ty_bool : document
+        method ty_char : document
+        method ty_str : document
+        method ty_int : int_kind fn
+        method ty_float : float_kind fn
+        method generic_values : generic_value list fn
+        method ty_app : concrete_ident -> generic_value list fn
+        method ty_tuple : int -> ty list fn
+        method ty : par_state -> ty fn
+        method expr' : par_state -> expr' fn
+
+        method expr_monadic_let :
+          monad:supported_monads * F.monadic_binding ->
+          lhs:pat ->
+          rhs:expr ->
+          expr fn
+
+        method expr_let : lhs:pat -> rhs:expr -> expr fn
+        method tuple_projection : size:int -> nth:int -> expr fn
+        method field_projection : concrete_ident -> expr fn
+        method expr_app : expr -> expr list fn
+        method doc_construct_tuple : document list fn
+        method expr_construct_tuple : expr list fn
+        method pat_construct_tuple : pat list fn
+        method global_ident_projector : global_ident fn
+
+        method doc_construct_inductive :
+          is_record:bool ->
+          is_struct:bool ->
+          constructor:concrete_ident ->
+          base:document option ->
+          (global_ident * document) list fn
+
+        method expr_construct_inductive :
+          is_record:bool ->
+          is_struct:bool ->
+          constructor:concrete_ident ->
+          base:(expr * F.construct_base) option ->
+          (global_ident * expr) list fn
+
+        method attr : attr fn
+        method attrs : attrs fn
+        method pat' : par_state -> pat' fn
+        method pat_ascription : typ:ty -> typ_span:span -> pat fn
+        method pat : par_state -> pat fn
+        method expr_unwrapped : par_state -> expr fn
+        method param : param fn
+        method item' : item' fn
+        method item_unwrapped : item fn
+        method generic_param' : generic_param fn
+        method generic_param : generic_param fn
+        method generic_params : generic_param list fn
+        method arm' : arm' fn
+        method arm : arm fn
+        method expr : par_state -> expr fn
+        method item : item fn
+        method items : item list fn
+      end
+  end
+
+  include P
+
+  module type PRINT_CLASS = sig
+    class print :
+      object
+        inherit P.print
+        inherit P.print_base
+      end
+  end
+
+  module type API = sig
+    val items : item list -> annot_str
+    val item : item -> annot_str
+    val expr : expr -> annot_str
+    val pat : pat -> annot_str
+    val ty : ty -> annot_str
+
+    module Class : PRINT_CLASS
+  end
+
+  module Api (Class : PRINT_CLASS) = struct
+    module Class = Class
+    open Class
+
+    let mk (f : print -> 'a -> PPrint.document) (x : 'a) : annot_str =
+      let printer = new print in
+      let doc = f printer x in
+      let buf = Buffer.create 0 in
+      PPrint.ToBuffer.pretty 1.0 80 buf doc;
+      (Buffer.contents buf, printer#get_span_data ())
+
+    let items : item list -> annot_str = mk (fun p -> p#items)
+    let item : item -> annot_str = mk (fun p -> p#item)
+    let expr : expr -> annot_str = mk (fun p -> p#expr AlreadyPar)
+    let pat : pat -> annot_str = mk (fun p -> p#pat AlreadyPar)
+    let ty : ty -> annot_str = mk (fun p -> p#ty AlreadyPar)
+  end
+end


### PR DESCRIPTION
Start an exploration of a generic printer, aiming at factorizing backends a little.
In this PR the default printer is a Rust-like printer for the whole AST; the idea is to have a printer per family of languages.
For instance, Lean, Coq and F* share a lot in terms of structure.

This implementation uses OCaml classes (surprisingly!). This is somehow a bit nice here because we want to be able to refine an printer in another printer: we could have a `FunctionalFlavorPrinter` as a basis for `CoqPrinter`, `FStarPrinter` an d `LeanPrinter` that would override some parts of `FunctionalFlavorPrinter`, but inherit other parts.
In OCaml, I think OOP is the only way to achieve that. In type-class capable languages, we could use a double-dispatch thing with typeclasses and default implementation of methods. But in OCaml, I think OOP is the only sane way.

WDYT @cmester0?
 
(cc @R1kM also, since you're looking into having a Lean backend)