### PR TITLE
Fixes for &mut index assignations

### DIFF
--- a/engine/lib/ast_utils.ml
+++ b/engine/lib/ast_utils.ml
@@ -789,6 +789,11 @@ module Make (F : Features.T) = struct
           let* place = of_expr place in
           wrap @@ FieldProjection { place; projector }
       | App { f = { e = GlobalVar f; _ }; args = [ place; index ] }
+        when Global_ident.eq_name Core__ops__index__Index__index f ->
+          let* place = of_expr place in
+          let place = IndexProjection { place; index } in
+          Some { place; span = e.span; typ = e.typ }
+      | App { f = { e = GlobalVar f; _ }; args = [ place; index ] }
         when Global_ident.eq_name Core__ops__index__IndexMut__index_mut f ->
           (* Note that here, we allow any type to be `index_mut`ed:
              Hax translates that to `Rust_primitives.Hax.update_at`.

--- a/engine/lib/phases/phase_and_mut_defsite.ml
+++ b/engine/lib/phases/phase_and_mut_defsite.ml
@@ -193,7 +193,7 @@ struct
                 |> Option.value_or_thunk ~default:(fun () ->
                        Error.assertion_failure span
                        @@ "Place.of_expr: got `None` for: "
-                       ^ Print_rust.pexpr_str (UB.LiftToFullAst.expr e))
+                       ^ Print_rust.pexpr_str (UB.LiftToFullAst.expr lhs))
                 |> place_to_lhs
               in
               Assign { lhs; e; witness }

--- a/tests/mut-ref-functionalization/src/lib.rs
+++ b/tests/mut-ref-functionalization/src/lib.rs
@@ -74,3 +74,7 @@ trait FooTrait {
 impl FooTrait for Foo {
     fn z(&mut self) {}
 }
+
+fn array(x: &mut [u8; 10]) {
+    x[1] = x[2];
+}


### PR DESCRIPTION
In the expression `x[i] = e`, `x[i]` was handled correctly only if the underlying indexing operation was [IndexMut](https://doc.rust-lang.org/core/ops/trait.IndexMut.html#tymethod.index_mut).
However, if `x` is of type `&mut T`, the trait being used is not [IndexMut](https://doc.rust-lang.org/core/ops/trait.IndexMut.html#tymethod.index_mut) anylonger but [Index](https://doc.rust-lang.org/core/ops/trait.Index.html#tymethod.index)!

This PR basically adds support for Index `x[i]` in LHS of assigns. It also adds a test.