### PR TITLE
PPX for antiquotations of Rust code in OCaml

### DIFF
--- a/engine/lib/ast.ml
+++ b/engine/lib/ast.ml
@@ -43,13 +43,14 @@ and primitive_ident = Deref | Cast | LogicalOp of logical_op
 module Global_ident = struct
   module T = struct
     type t =
-      [ `Concrete of concrete_ident
-      | `Primitive of primitive_ident
-      | `TupleType of int
-      | `TupleCons of int
-      | `TupleField of int * int
-      | `Projector of [ `Concrete of concrete_ident | `TupleField of int * int ]
-      ]
+      [ `Concrete of concrete_ident [@name "`Concrete"]
+      | `Primitive of primitive_ident [@name "`Primitive"]
+      | `TupleType of int [@name "`TupleType"]
+      | `TupleCons of int [@name "`TupleCons"]
+      | `TupleField of int * int [@name "`TupleField"]
+      | `Projector of
+        [ `Concrete of concrete_ident [@name "`Concrete"]
+        | `TupleField of int * int [@name "`TupleField"] ] ]
     [@@deriving show, yojson, compare, hash, sexp, eq]
   end
 

--- a/engine/lib/concrete_ident/concrete_ident.ml
+++ b/engine/lib/concrete_ident/concrete_ident.ml
@@ -347,6 +347,10 @@ module T = struct
 
   let of_name k = Concrete_ident_generated.def_id_of >> of_def_id k
 
+  let eq_def_id def_id ident =
+    let def_id = Imported.of_def_id def_id in
+    [%equal: Imported.def_id] def_id ident.def_id
+
   let eq_name name id =
     let of_name =
       Concrete_ident_generated.def_id_of name |> Imported.of_def_id

--- a/engine/lib/concrete_ident/concrete_ident.mli
+++ b/engine/lib/concrete_ident/concrete_ident.mli
@@ -20,6 +20,7 @@ module Kind : sig
 end
 
 val of_def_id : Kind.t -> Types.def_id -> t
+val eq_def_id : Types.def_id -> t -> bool
 val of_name : Kind.t -> name -> t
 val eq_name : name -> t -> bool
 val to_debug_string : t -> string

--- a/engine/lib/prelude.ml
+++ b/engine/lib/prelude.ml
@@ -1,3 +1,3 @@
 include Base
 include Utils
-include Ppx_yojson_conv_lib.Yojson_conv.Primitives
+include Yojson_conv_primitives

--- a/engine/lib/yojson_conv_primitives.ml
+++ b/engine/lib/yojson_conv_primitives.ml
@@ -1,0 +1,27 @@
+open Base
+include Ppx_yojson_conv_lib.Yojson_conv.Primitives
+
+type t = Yojson.Safe.t
+
+let mk_native n (args : t list) = `List (`String ("Native:" ^ n) :: args)
+let yojson_of_unit () : t = `Null
+let yojson_of_bool b : t = mk_native "Bool" [ yojson_of_bool b ]
+let yojson_of_string str : t = mk_native "String" [ yojson_of_string str ]
+let yojson_of_char c : t = mk_native "Char" [ yojson_of_char c ]
+let yojson_of_int n : t = mk_native "Int" [ yojson_of_int n ]
+let yojson_of_int32 n : t = mk_native "Int" [ yojson_of_int32 n ]
+let yojson_of_int64 n : t = mk_native "Int" [ yojson_of_int64 n ]
+let yojson_of_nativeint n : t = mk_native "Int" [ yojson_of_nativeint n ]
+
+let yojson_of_option yojson_of__a = function
+  | Some x -> `List [ `String "Some"; yojson_of__a x ]
+  | None -> `List [ `String "None" ]
+
+let yojson_of_pair yojson_of__a yojson_of__b (a, b) =
+  mk_native "Tuple" [ yojson_of__a a; yojson_of__b b ]
+
+let yojson_of_triple yojson_of__a yojson_of__b yojson_of__c (a, b, c) =
+  mk_native "Tuple" [ yojson_of__a a; yojson_of__b b; yojson_of__c c ]
+
+let yojson_of_list yojson_of__a lst =
+  mk_native "List" (List.rev (List.rev_map ~f:yojson_of__a lst))

--- a/engine/lib/yojson_conv_primitives.mli
+++ b/engine/lib/yojson_conv_primitives.mli
@@ -1,0 +1,1 @@
+include module type of Ppx_yojson_conv_lib.Yojson_conv.Primitives

--- a/engine/utils/ppx_generate_features/ppx_generate_features.ml
+++ b/engine/utils/ppx_generate_features/ppx_generate_features.ml
@@ -217,6 +217,10 @@ let expand ~(ctxt : Expansion_context.Extension.t) (features : string list) :
       [%m
       List.concat_map
         ~f:(fun txt ->
+          let variant_json_name =
+            Ast_builder.Default.pexp_constant ~loc
+              (Parsetree.Pconst_string ("FeatureWitness_" ^ txt, loc, None))
+          in
           (rename
              [ ("placeholder", txt); ("Placeholder", uppercase_first_char txt) ])
             #structure
@@ -226,7 +230,7 @@ let expand ~(ctxt : Expansion_context.Extension.t) (features : string list) :
 
                 val placeholder : placeholder
               end = struct
-                type placeholder = Placeholder
+                type placeholder = Placeholder [@name [%e variant_json_name]]
                 [@@deriving show, yojson, hash, eq]
 
                 let placeholder = Placeholder

--- a/extract.js
+++ b/extract.js
@@ -1,0 +1,232 @@
+const STOP = 'STOP';
+let walk = (o, f) =>
+    f(o) ||
+        (typeof o === 'object'
+         && Object.keys(o || {}).map(k => walk(o[k], f)).filter(x => x)[0]);
+
+let expects = {
+    array: [e => e instanceof Array && e],
+    expr: [({e, span, typ}) => span && typ && e, 'array'],
+    app: ['expr', ([tag, data]) => tag == 'App' && data.f && data.args && data],
+    global_var: ['array', ([tag, data]) => tag == 'GlobalVar' && data],
+    concrete_var: ['global_var', ([tag, data]) => tag == '`Concrete' && data?.def_id],
+    concrete_var_last: ['concrete_var', ({krate, path}) => path?.slice(-1)?.[0]?.data[1][1]],
+    mark: ['concrete_var_last', last => last == 'mark'],
+    expr_mark: ['app', ({f, args}) => expects.mark(f?.e) && args?.[1]],
+    skip_typ: ['concrete_var_last', last => last == 'skip'],
+    expr_skip_typ: ['app', ({f, args}) => {
+        if (expects.skip_typ(f?.e)) {
+            let [_native_list_tag, field, inner] = args;
+            field = field.e[1].e.e[1].args[1].e[1][1][1];
+            return {field, inner};
+        }
+        return false;
+    }],
+};
+
+
+for (let k in expects) {
+    expects[k] = expects[k].map(f => typeof f == 'string' ? (o => expects[f](o)) : f);
+}
+let DEBUG = false;
+let inspect = s => require('util').inspect(s, false, null, true);
+for (let k in expects) {
+    let filters = expects[k];
+    expects[k] = o => {
+        // let DEBUG = k == 'mark';
+        DEBUG && console.log('DEBUG['+k+'](', o, ')');
+        let current = o;
+        for (let i in filters) {
+            let f = filters[i];
+            if(!current) {
+                return current;
+            }
+            let prev = current;
+            current = f(current);
+            DEBUG && console.log('DEBUG['+k+']['+i+'](',inspect(prev),')\n -> ', inspect(current));
+        }
+        return current;
+    };
+}
+
+let isVariantName = s => typeof s == 'string' && s.match(/^[`]?(Native:)?([A-Z]+[a-z]*)+$/) !== null;
+const DENYKEYS = ['span', 'region', 'witness'];
+const WILDCARD = Symbol();
+
+const KINDS = {
+    RECORD: 'record',
+    CONSTRUCTOR: 'cons',
+    LIST: 'list',
+    TUPLE: 'tuple',
+    RAW_OCAML: 'raw_ocaml',
+    WILDCARD: 'wildcard',
+    PAT_VAR: 'pat_var',
+};
+
+function parse(o) {
+    function aux(o, tab = '') {
+        try {
+            return aux_(o, tab);
+        } catch(e) {
+            if (typeof e == 'object' && 'N' in e && 'name' in e) {
+                if (e?.N > 0)
+                    throw {...e, N: e.N - 1};
+                return [KINDS.PAT_VAR, e.name];
+            } else
+                throw e;
+        }
+    }
+    function aux_(o, tab = '') {
+        let skip = expects.expr_skip_typ(o);
+        if (skip) {
+            o = skip.inner;
+            o[skip.field] = WILDCARD;
+        }
+        if(o == WILDCARD){
+            return [KINDS.WILDCARD];
+        }
+        let h = o => aux(o, '   ' + tab);
+        let as_json = o => {
+            if(o == WILDCARD){
+                return [KINDS.WILDCARD];
+            }
+            let is_pat = (o||'').toString().match(/^_pat_(?<N>\d+)_(?<name>[a-z_\d]+)$/);
+            if(is_pat?.groups) {
+                let groups = is_pat.groups;
+                throw {...groups, N: +groups.N};
+            }
+            return [KINDS.RAW_OCAML, JSON.stringify(o)];
+        };
+        if (o instanceof Array && isVariantName(o?.[0])) {
+            let [tag, ...args] = o;
+            let [native_kwd, native_kind] = tag.split(':');
+            if (native_kwd == 'Native' && native_kind){
+                return (({
+                    String: as_json,
+                    Char: as_json,
+                    Int: as_json,
+                    Bool: as_json,
+                    Tuple: (...args) => [KINDS.TUPLE, ...args.map(h)],
+                    List: (...args) => [KINDS.LIST, ...args.map(h)],
+                })[native_kind] || (_ => {throw native_kind;}))(...args);
+            } else {
+                if (args.length == 1 && args?.[0] instanceof Array && typeof args?.[0]?.[0] != 'string'){
+                    args = args[0];
+                }
+                return [KINDS.CONSTRUCTOR, tag, ...args.map(h)];
+            }
+        } else if (typeof o == 'object') {
+            return [
+                KINDS.RECORD,
+                ...Object.entries(o).map(([k, v]) =>
+                    [k, DENYKEYS.includes(k) ? [KINDS.WILDCARD] : h(v)]
+                )
+            ];
+        }
+        return as_json(o);
+    };
+    return aux(o);
+}
+
+function merge(a, b) {
+    // console.log(a);
+    let [a_kind, ...a_args] = a;
+    let [b_kind, ...b_args] = b;
+    let wild = [KINDS.WILDCARD];
+    if (a_kind == KINDS.PAT_VAR) {
+        return a;
+    }
+    if (a_kind !== b_kind || a_args.length != b_args.length) {
+        return wild;
+    }
+    let default_merger = (a_args, b_args) =>
+        a_args.map((a_arg, i) => merge(a_arg, b_args[i]));
+    let merger = ({
+        [KINDS.RECORD]: (a_fields, b_fields) => a_fields.map(([af, av], i) => {
+              let [bf, bv] = b_fields[i];
+              if (bf !== af) return WILDCARD;
+              return [af, merge(av, bv)];
+           }),
+        [KINDS.CONSTRUCTOR]: ([a_tag, ...a_args], [b_tag, ...b_args]) => {
+            if (a_tag !== b_tag) return WILDCARD;
+            return [a_tag, ...default_merger(a_args, b_args)];
+        },
+        [KINDS.LIST]: default_merger,
+        [KINDS.TUPLE]: default_merger,
+        [KINDS.RAW_OCAML]: ([a], [b]) => a === b ? [a] : WILDCARD,
+        [KINDS.WILDCARD]: (_a, _b) => [],
+        [KINDS.PAT_VAR]: ([name], _) => [name],
+    })[a_kind] || (_ => {throw {unknown_kind: kind};});
+    let args = merger(a_args, b_args);
+    return args === WILDCARD ? wild : [a_kind, ...args];
+}
+function merge_n(l) {
+    return l.reduce(merge);
+}
+
+function rewrite_concrete_nodes(o) {
+    let id = 0;
+    let guards = [];
+    walk(o, x => {
+        if (x?.[0] == KINDS.CONSTRUCTOR && x?.[1] == '`Concrete') {
+            let pat_var = `def_id_${id++}`;
+            let concrete_ident = x[2];
+            let [_, def_id] = concrete_ident.slice(1).find(([k, v]) => k == 'def_id');
+            guards.push(`Concrete_ident.eq_def_id ${print(def_id)} ${pat_var}`);
+            x[2] = [KINDS.PAT_VAR, pat_var];
+        }
+    });
+    return guards;
+}
+
+function print(a) {
+    let [kind, ...args] = a;
+    let printer = ({
+        [KINDS.RECORD]: (...fields) => `{${fields.map(([k, v]) => `${k} = ${print(v)}`).join(';')}}`,
+        [KINDS.CONSTRUCTOR]: (tag, ...args) => {
+            if (args.length == 0)
+                return tag;
+            let first = args[0];
+            if (args.length == 1 && first[0] == KINDS.RECORD)
+                return `${tag} ${print(first)}`;
+            return `${tag}(${args.map(print).join(',')})`;
+        },
+        [KINDS.LIST]: (...args) => `[${args.map(print).join(';')}]`,
+        [KINDS.TUPLE]: (...args) => `(${args.map(print).join(',')})`,
+        [KINDS.RAW_OCAML]: (str) => str,
+        [KINDS.WILDCARD]: () => "_",
+        [KINDS.PAT_VAR]: (name) => name,
+    })[kind] || (_ => {throw {unknown_kind: kind};});
+    return printer(...args);
+}
+
+function run(stdin) {
+    let o = JSON.parse(stdin);
+    let items = o[0].items;
+    let results = [];
+    let r = walk(items, x => {
+        let r = expects.expr_mark(x);
+        r && results.push(r);
+    });
+    console.log(inspect({items}));
+    let merged = merge_n(results.map(parse));
+    let when_clause = rewrite_concrete_nodes(merged).join(' && ');
+    // console.log(inspect(merged));
+    console.log(print(merged) + (when_clause ? ' when ' + when_clause : ''));
+}
+
+async function read(stream) {
+    const chunks = [];
+    for await (const chunk of stream) chunks.push(chunk); 
+    return Buffer.concat(chunks).toString('utf8');
+}
+
+async function main(){
+    try {
+        run(await read(process.stdin));
+    } catch (e) {
+        console.error(e);
+        throw e;
+    }
+}
+main();

--- a/tests/attributes/src/lib.rs
+++ b/tests/attributes/src/lib.rs
@@ -1,35 +1,46 @@
-use hax_lib_macros::*;
-use serde::Deserialize;
-
-#[derive(Deserialize, Debug)]
-pub struct SerdeTest {
-    foo: u32,
+fn mark<T>(x: T) -> T {
+    panic!()
 }
 
-#[skip]
-pub fn f<'a, T>(c: bool, x: &'a mut T, y: &'a mut T) -> &'a mut T {
-    if c {
-        x
-    } else {
-        y
-    }
+fn hello(_pat_1_hello: bool) {
+    let x = mark({ 3 });
+    // let x = mark(assert!(_pat_1_hello));
+    // let x = mark(assert!(true));
+    // let x = mark(2u32 + 2);
 }
 
-#[hax_attributes]
-pub struct Foo {
-    pub x: u32,
-    #[refine(y > 3)]
-    pub y: u32,
-    #[refine(y + x + z > 3)]
-    pub z: u32,
-}
+// use hax_lib_macros::*;
+// use serde::Deserialize;
 
-#[skip]
-impl Foo {
-    fn g(&self) {}
-}
+// #[derive(Deserialize, Debug)]
+// pub struct SerdeTest {
+//     foo: u32,
+// }
 
-impl Foo {
-    #[skip]
-    fn h(&self) {}
-}
+// #[skip]
+// pub fn f<'a, T>(c: bool, x: &'a mut T, y: &'a mut T) -> &'a mut T {
+//     if c {
+//         x
+//     } else {
+//         y
+//     }
+// }
+
+// #[hax_attributes]
+// pub struct Foo {
+//     pub x: u32,
+//     #[refine(y > 3)]
+//     pub y: u32,
+//     #[refine(y + x + z > 3)]
+//     pub z: u32,
+// }
+
+// #[skip]
+// impl Foo {
+//     fn g(&self) {}
+// }
+
+// impl Foo {
+//     #[skip]
+//     fn h(&self) {}
+// }


### PR DESCRIPTION
This PR aims at allowing the following:
```ocaml
match (e: SomeAST.expr) with
| [%rust_pat? "assert!(PAT_1_someName)"] -> something where `someName` is bound
...
```

`[%rust_pat? "CODE"]`: CODE is an arbitrary Rust expression. Anything named `PAT_N_<NAME>` will be turned into a pattern variable in OCaml.
Basically, this thing will call Hax itself, output hax's internal AST in JSON, parse that, and generate an OCaml pattern that match any internal hax expressions that looks like CODE.

The logic is mostly working already! Will finish that when I'm back, but that should help a lot. Currently we have horrible hand-written patterns like https://github.com/hacspec/hax/blob/cabd4b5efb7144f2ab2c3b1b242ba65ff382d725/engine/lib/phases/phase_reconstruct_for_loops.ml#L52
We could replace that whole thing with `[%rust_pat? "for _PAT_1_i in _PAT_1_range { PAT_1_body }"]` morally.
This will be much easier to read, to write and much more stable (if the translation changes, such horrible pattern had to be revisited)