### PR TITLE
Fix unsizes on mutations

### DIFF
--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -653,7 +653,6 @@ struct
 
   let pmaybe_refined_ty span (free_variables : string list) (attrs : attrs)
       (binder_name : string) (ty : ty) : F.AST.term =
-    prerr_endline @@ "pmaybe_refined_ty[attrs]=" ^ [%show: attrs] attrs;
     match Attrs.associated_refinement_in_type free_variables attrs with
     | Some refinement ->
         F.mk_refined binder_name (pty span ty) (fun ~x -> pexpr refinement)

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -927,7 +927,9 @@ struct
             | _ -> unsupported_macro ())
         | _ -> unsupported_macro ())
     | Trait { name; generics; items } ->
-        let bds = List.map ~f:(pgeneric_param_bd e.span) generics.params in
+        let bds =
+          List.map ~f:(pgeneric_param_bd ~aqual:None e.span) generics.params
+        in
         let name_str = U.Concrete_ident_view.to_definition_name name in
         let name = F.id @@ name_str in
         let fields =

--- a/engine/lib/ast.ml
+++ b/engine/lib/ast.ml
@@ -395,6 +395,7 @@ functor
       | LhsFieldAccessor of {
           e : lhs;
           typ : ty;
+          (* TODO: change type (see #316) *)
           field : global_ident;
           witness : F.nontrivial_lhs;
         }

--- a/engine/lib/ast_utils.ml
+++ b/engine/lib/ast_utils.ml
@@ -667,7 +667,7 @@ module Make (F : Features.T) = struct
     | LhsFieldAccessor { e; typ; field; _ } ->
         let e = expr_of_lhs span e in
         let f = { e = GlobalVar field; typ = TArrow ([ e.typ ], typ); span } in
-        { e = App { f; args = [ e ] }; typ = e.typ; span }
+        { e = App { f; args = [ e ] }; typ; span }
     | LhsArrayAccessor { e; typ; index; _ } ->
         let args = [ expr_of_lhs span e; index ] in
         call Core__ops__index__Index__index args span typ

--- a/engine/lib/ast_utils.ml
+++ b/engine/lib/ast_utils.ml
@@ -457,6 +457,13 @@ module Make (F : Features.T) = struct
     | TApp { ident = `TupleType 1; args = [ GType t ] } -> remove_tuple1 t
     | _ -> t
 
+  let remove_unsize (e : expr) : expr =
+    match e.e with
+    | App { f = { e = GlobalVar f; _ }; args = [ e ] }
+      when Global_ident.eq_name Rust_primitives__unsize f ->
+        e
+    | _ -> e
+
   (* let rec remove_empty_tap *)
 
   let is_unit_typ : ty -> bool =

--- a/engine/lib/ast_utils.ml
+++ b/engine/lib/ast_utils.ml
@@ -817,7 +817,7 @@ module Make (F : Features.T) = struct
           call' projector [ e ] p.span p.typ
       | IndexProjection { place; index } ->
           let e = to_expr place in
-          call Core__ops__index__IndexMut__index_mut [ e; index ] p.span p.typ
+          call Core__ops__index__Index__index [ e; index ] p.span p.typ
 
     let expect_deref_mut (p : t) : t option =
       match p.place with

--- a/engine/lib/phases/phase_and_mut_defsite.ml
+++ b/engine/lib/phases/phase_and_mut_defsite.ml
@@ -155,16 +155,13 @@ struct
           | LocalVar var -> LhsLocalVar { var; typ }
           | FieldProjection { place; projector } ->
               let e = place_to_lhs place in
-              let field =
-                match projector with
-                | `Projector field -> (field :> global_ident)
-                | _ ->
-                    Error.unimplemented
-                      ~details:"try to borrow a projected tuple component?"
-                      p.span
-              in
               LhsFieldAccessor
-                { witness = Features.On.nontrivial_lhs; field; typ; e }
+                {
+                  witness = Features.On.nontrivial_lhs;
+                  field = projector;
+                  typ;
+                  e;
+                }
           | IndexProjection { place; index } ->
               let e = place_to_lhs place in
               LhsArrayAccessor

--- a/engine/lib/phases/phase_and_mut_defsite.ml
+++ b/engine/lib/phases/phase_and_mut_defsite.ml
@@ -148,6 +148,7 @@ struct
         visitor#visit_expr ()
 
       let convert_lhs =
+        (* TODO: refactor (see #316) *)
         let rec place_to_lhs (p : Place.t) : lhs =
           let typ = p.typ in
           match p.place with

--- a/engine/lib/phases/phase_direct_and_mut.ml
+++ b/engine/lib/phases/phase_direct_and_mut.ml
@@ -46,6 +46,7 @@ struct
     let expect_mut_borrow_of_place_or_pure_expr (e : A.expr) :
         (Place.t, A.expr) Either.t option =
       let e = UA.Mappers.normalize_borrow_mut#visit_expr () e in
+      let e = UA.remove_unsize e in
       let* e = UA.Expect.mut_borrow e in
       Option.some
       @@

--- a/engine/lib/phases/phase_direct_and_mut.ml
+++ b/engine/lib/phases/phase_direct_and_mut.ml
@@ -86,15 +86,8 @@ struct
       | LocalVar var -> LhsLocalVar { var; typ }
       | FieldProjection { place; projector } ->
           let e = place_to_lhs place in
-          let field =
-            match projector with
-            | `Projector field -> (field :> global_ident)
-            | _ ->
-                Error.unimplemented
-                  ~details:"try to borrow a projected tuple component?" p.span
-          in
           LhsFieldAccessor
-            { witness = Features.On.nontrivial_lhs; field; typ; e }
+            { witness = Features.On.nontrivial_lhs; field = projector; typ; e }
       | IndexProjection { place; index } ->
           let e = place_to_lhs place in
           let index = dexpr index in

--- a/engine/lib/phases/phase_direct_and_mut.ml
+++ b/engine/lib/phases/phase_direct_and_mut.ml
@@ -79,6 +79,7 @@ struct
       | [%inline_arms "dborrow_kind.*" - Mut] -> auto
       | Mut _ -> Shared
 
+    (* TODO: refactor (see #316) *)
     and place_to_lhs (p : Place.t) : B.lhs =
       let typ = dty p.span p.typ in
       match p.place with

--- a/engine/lib/phases/phase_trivialize_assign_lhs.ml
+++ b/engine/lib/phases/phase_trivialize_assign_lhs.ml
@@ -34,7 +34,7 @@ module%inlined_contents Make (F : Features.T) = struct
         (Local_ident.t * B.ty) * B.expr =
       match lhs with
       | LhsLocalVar { var; typ } -> ((var, dty span typ), rhs)
-      | LhsFieldAccessor { e; field; _ } -> (
+      | LhsFieldAccessor { e; field; typ; _ } -> (
           let lhs = UA.expr_of_lhs span e |> dexpr in
           match lhs.typ with
           | TApp { ident; _ } ->
@@ -48,7 +48,7 @@ module%inlined_contents Make (F : Features.T) = struct
                     base = Some (lhs, Features.On.construct_base);
                   }
               in
-              let rhs = { B.e = rhs'; typ = lhs.typ; span } in
+              let rhs = { B.e = rhs'; typ = dty span typ; span } in
               updater_of_lhs e rhs span
           | _ -> Error.raise { kind = ArbitraryLHS; span })
       | LhsArrayAccessor { e; typ = _; index; _ } ->

--- a/engine/lib/phases/phase_trivialize_assign_lhs.ml
+++ b/engine/lib/phases/phase_trivialize_assign_lhs.ml
@@ -34,7 +34,7 @@ module%inlined_contents Make (F : Features.T) = struct
         (Local_ident.t * B.ty) * B.expr =
       match lhs with
       | LhsLocalVar { var; typ } -> ((var, dty span typ), rhs)
-      | LhsFieldAccessor { e; field; typ; _ } -> (
+      | LhsFieldAccessor { e; field; _ } -> (
           let lhs = UA.expr_of_lhs span e |> dexpr in
           match lhs.typ with
           | TApp { ident; _ } ->
@@ -48,7 +48,7 @@ module%inlined_contents Make (F : Features.T) = struct
                     base = Some (lhs, Features.On.construct_base);
                   }
               in
-              let rhs = { B.e = rhs'; typ = dty span typ; span } in
+              let rhs = { B.e = rhs'; typ = lhs.typ; span } in
               updater_of_lhs e rhs span
           | _ -> Error.raise { kind = ArbitraryLHS; span })
       | LhsArrayAccessor { e; typ = _; index; _ } ->
@@ -70,7 +70,7 @@ module%inlined_contents Make (F : Features.T) = struct
           {
             e = Assign { lhs; e; witness };
             span = expr.span;
-            typ = dty expr.span expr.typ;
+            typ = UB.unit_typ;
           }
       | [%inline_arms "dexpr'.*" - Assign] ->
           map (fun e -> B.{ e; typ = dty expr.span expr.typ; span = expr.span })

--- a/engine/lib/print_rust.ml
+++ b/engine/lib/print_rust.ml
@@ -111,9 +111,10 @@ module Raw = struct
 
   let pborrow_kind span = pure span << function Mut _ -> "mut " | _ -> ""
 
-  let last_of_global_ident (g : global_ident) span =
+  let rec last_of_global_ident (g : global_ident) span =
     match g with
     | `Concrete c -> Concrete_ident_view.to_definition_name c
+    | `Projector c -> last_of_global_ident (c :> global_ident) span
     | _ ->
         Diagnostics.report
           {

--- a/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
@@ -50,12 +50,30 @@ let index_mutation (x: Core.Ops.Range.t_Range usize) (a: t_Slice u8) : Prims.uni
   let v:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
     Rust_primitives.Hax.update_at v
       x
-      (Core.Slice.impl__copy_from_slice (Core.Ops.Index.IndexMut.index_mut v x <: t_Slice u8) a
-        <:
-        t_Slice u8)
+      (Core.Slice.impl__copy_from_slice (v.[ x ] <: t_Slice u8) a <: t_Slice u8)
   in
   let v:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global = Rust_primitives.Hax.update_at v (sz 1) 3uy in
   ()
+
+let index_mutation_unsize (x: t_Array u8 (sz 12)) : u8 =
+  let x:t_Array u8 (sz 12) =
+    Rust_primitives.Hax.update_at x
+      ({ Core.Ops.Range.f_start = sz 4; Core.Ops.Range.f_end = sz 5 })
+      (Core.Slice.impl__copy_from_slice (x.[ {
+                Core.Ops.Range.f_start = sz 4;
+                Core.Ops.Range.f_end = sz 5
+              } ]
+            <:
+            t_Slice u8)
+          (Rust_primitives.unsize (let list = [1uy; 2uy] in
+                FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
+                Rust_primitives.Hax.array_of_list list)
+            <:
+            t_Slice u8)
+        <:
+        t_Slice u8)
+  in
+  42uy
 
 let build_vec: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
   Alloc.Slice.impl__into_vec (Rust_primitives.unsize (Rust_primitives.Hax.box_new (let list =

--- a/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
@@ -37,6 +37,29 @@ open Core
 
 type t_S = { f_b:t_Array u8 (sz 5) }
 
+let foo (lhs rhs: t_S) : t_S =
+  let lhs:t_S =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+              Core.Ops.Range.f_start = sz 0;
+              Core.Ops.Range.f_end = sz 1
+            })
+        <:
+        Core.Ops.Range.t_Range usize)
+      lhs
+      (fun lhs i ->
+          {
+            lhs with
+            f_b
+            =
+            Rust_primitives.Hax.update_at lhs.f_b
+              i
+              ((lhs.f_b.[ i ] <: u8) +! (rhs.f_b.[ i ] <: u8) <: u8)
+            <:
+            t_Array u8 (sz 5)
+          })
+  in
+  lhs
+
 let impl__S__update (self: t_S) (x: u8) : t_S =
   let self:t_S = { self with f_b = Rust_primitives.Hax.update_at self.f_b (sz 0) x } in
   self
@@ -155,14 +178,14 @@ let g (x: t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global))
   in
   x.f_a
 
+let h (x: u8) : u8 =
+  let x:u8 = x +! 10uy in
+  x
+
 type t_Bar = {
   f_a:u8;
   f_b:u8
 }
-
-let h (x: u8) : u8 =
-  let x:u8 = x +! 10uy in
-  x
 
 let i (bar: t_Bar) : (t_Bar & u8) =
   let bar:t_Bar = { bar with f_b = bar.f_b +! bar.f_a } in

--- a/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
@@ -35,6 +35,12 @@ module Mut_ref_functionalization
 #set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
 open Core
 
+type t_S = { f_b:t_Array u8 (sz 5) }
+
+let impl__S__update (self: t_S) (x: u8) : t_S =
+  let self:t_S = { self with f_b = Rust_primitives.Hax.update_at self.f_b (sz 0) x } in
+  self
+
 let index_mutation (x: Core.Ops.Range.t_Range usize) (a: t_Slice u8) : Prims.unit =
   let v:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
     Alloc.Slice.impl__into_vec (Rust_primitives.unsize (Rust_primitives.Hax.box_new (let list =
@@ -145,7 +151,7 @@ let g (x: t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global))
     { x with f_a = Core.Slice.impl__swap x.f_a (sz 0) (sz 1) }
   in
   let x:t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) =
-    { x with f_b = { f_b x with f_field = Core.Slice.impl__swap x.f_b.f_field (sz 0) (sz 1) } }
+    { x with f_b = { x.f_b with f_field = Core.Slice.impl__swap x.f_b.f_field (sz 0) (sz 1) } }
   in
   x.f_a
 

--- a/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
@@ -199,7 +199,7 @@ let j (x: t_Bar) : (t_Bar & u8) =
   let output:u8 = out in
   x, output
 
-class t_FooTrait (#v_Self: Type) = { f_z:v_Self -> v_Self }
+class t_FooTrait (v_Self: Type) = { f_z:v_Self -> v_Self }
 
 let impl_FooTrait_for_Foo: t_FooTrait t_Foo = { f_z = fun (self: t_Foo) -> self }
 

--- a/test-harness/src/snapshots/toolchain__naming into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__naming into-fstar.snap
@@ -76,17 +76,17 @@ let reserved_names (v_val v_noeq v_of: u8) : u8 = (v_val +! v_noeq <: u8) +! v_o
 
 type t_Arity1 (v_T: Type) {| _: Core.Marker.t_Sized v_T |} = | Arity1 : v_T -> t_Arity1 v_T
 
-class t_T1 (#v_Self: Type) = { __marker_trait_t_T1:Prims.unit }
+class t_T1 (v_Self: Type) = { __marker_trait_t_T1:Prims.unit }
 
 let impl_T1_for_Foo: t_T1 t_Foo = { __marker_trait = () }
 
 let impl_T1_for_tuple_Foo_u8: t_T1 (t_Foo & u8) = { __marker_trait = () }
 
-class t_T2_for_a (#v_Self: Type) = { __marker_trait_t_T2_for_a:Prims.unit }
+class t_T2_for_a (v_Self: Type) = { __marker_trait_t_T2_for_a:Prims.unit }
 
 let impl_T2_e_for_a_for_Arity1_of_tuple_Foo_u8: t_T2_for_a (t_Arity1 (t_Foo & u8)) =
   { __marker_trait = () }
 
-class t_T3_e_for_a (#v_Self: Type) = { __marker_trait_t_T3_e_for_a:Prims.unit }
+class t_T3_e_for_a (v_Self: Type) = { __marker_trait_t_T3_e_for_a:Prims.unit }
 
 let impl_T3_e_e_for_a_for_Foo: t_T3_e_for_a t_Foo = { __marker_trait = () }'''

--- a/tests/mut-ref-functionalization/src/lib.rs
+++ b/tests/mut-ref-functionalization/src/lib.rs
@@ -4,6 +4,14 @@ struct S {
     b: [u8; 5],
 }
 
+pub fn foo(mut lhs: S, rhs: &S) -> S {
+    for i in 0..1 {
+        lhs.b[i] += rhs.b[i];
+    }
+
+    lhs
+}
+
 impl S {
     fn update(&mut self, x: u8) {
         self.b[0] = x;

--- a/tests/mut-ref-functionalization/src/lib.rs
+++ b/tests/mut-ref-functionalization/src/lib.rs
@@ -6,6 +6,11 @@ fn index_mutation(x: core::ops::Range<usize>, a: &'static [u8]) {
     v[1] = 3;
 }
 
+fn index_mutation_unsize(mut x: [u8; 12]) -> u8 {
+    x[4..5].copy_from_slice(&[1, 2]);
+    42
+}
+
 fn build_vec() -> Vec<u8> {
     vec![1, 2, 3]
 }

--- a/tests/mut-ref-functionalization/src/lib.rs
+++ b/tests/mut-ref-functionalization/src/lib.rs
@@ -72,13 +72,13 @@ fn g(x: Pair<Vec<u8>>) -> Vec<u8> {
     x.a
 }
 
+fn h(x: &mut u8) {
+    *x += 10;
+}
+
 struct Bar {
     a: u8,
     b: u8,
-}
-
-fn h(x: &mut u8) {
-    *x += 10;
 }
 
 fn i(bar: &mut Bar) -> u8 {

--- a/tests/mut-ref-functionalization/src/lib.rs
+++ b/tests/mut-ref-functionalization/src/lib.rs
@@ -1,5 +1,15 @@
 #![allow(dead_code)]
 
+struct S {
+    b: [u8; 5],
+}
+
+impl S {
+    fn update(&mut self, x: u8) {
+        self.b[0] = x;
+    }
+}
+
 fn index_mutation(x: core::ops::Range<usize>, a: &'static [u8]) {
     let mut v = vec![1];
     v[x].copy_from_slice(a);


### PR DESCRIPTION
Fixes #256: `copy_from_slice` (and any other functions with &mut inputs actually) on sized things (e.g. fixed size arrays `[T; N]`) 

This is related to thin / fat pointers.

cc @karthikbhargavan @xvzcf @geonnave