### PR TITLE
fix(engine): add all `js_of_ocaml` dependencies

### DIFF
--- a/engine/dune-project
+++ b/engine/dune-project
@@ -43,6 +43,8 @@
         ocamlgraph
 
         js_of_ocaml-compiler
+        js_of_ocaml
+        js_of_ocaml-ppx
         zarith_stubs_js
         
         ; F*-specific dependencies

--- a/engine/hax-engine.opam
+++ b/engine/hax-engine.opam
@@ -32,6 +32,8 @@ depends: [
   "logs"
   "ocamlgraph"
   "js_of_ocaml-compiler"
+  "js_of_ocaml"
+  "js_of_ocaml-ppx"
   "zarith_stubs_js"
   "batteries"
   "zarith"


### PR DESCRIPTION
Does that fix the bug of missing `js_of_ocaml` while building the engine @franziskuskiefer?