### PR TITLE
feat(fstar/engine): add types on closure binders

### DIFF
--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -489,7 +489,10 @@ struct
           (F.term @@ F.AST.Name (pglobal_ident e.span constructor))
           [ r ]
     | Closure { params; body } ->
-        F.mk_e_abs (List.map ~f:ppat params) (pexpr body)
+        let ppat_ascribed pat =
+          F.pat @@ F.AST.PatAscribed (ppat pat, (pty pat.span pat.typ, None))
+        in
+        F.mk_e_abs (List.map ~f:ppat_ascribed params) (pexpr body)
     | Return { e } ->
         F.term @@ F.AST.App (F.term_of_lid [ "RETURN_STMT" ], pexpr e, Nothing)
     | MacroInvokation { macro; args; witness } ->

--- a/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
@@ -154,7 +154,7 @@ let g (x: t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global))
         <:
         Core.Ops.Range.t_Range u8)
       x
-      (fun x i ->
+      (fun (x: t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)) (i: u8) ->
           { x with f_a = Alloc.Vec.impl_1__push x.f_a i <: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global }
       )
   in
@@ -175,7 +175,7 @@ let foo (lhs rhs: t_S) : t_S =
         <:
         Core.Ops.Range.t_Range usize)
       lhs
-      (fun lhs i ->
+      (fun (lhs: t_S) (i: usize) ->
           {
             lhs with
             f_b


### PR DESCRIPTION
Before, closures used to be translated to untyped lambdas in F*, now they are translated to typed lambdas.
Example: `|x: u64| x + x` was `fun x -> x + x`, now it is `fun (x: u64) -> x + x`.