### PR TITLE
feat(engine): propagate generics in fun calls

### DIFF
--- a/engine/lib/ast.ml
+++ b/engine/lib/ast.ml
@@ -299,7 +299,11 @@ functor
     and expr' =
       (* pure fragment *)
       | If of { cond : expr; then_ : expr; else_ : expr option }
-      | App of { f : expr; args : expr list (* ; f_span: span *) }
+      | App of {
+          f : expr;
+          args : expr list (* ; f_span: span *);
+          generic_args : generic_value list;
+        }
       | Literal of literal
       | Array of expr list
       | Construct of {

--- a/engine/lib/ast_utils.ml
+++ b/engine/lib/ast_utils.ml
@@ -693,6 +693,17 @@ module Make (F : Features.T) = struct
   let rec unbox_underef_expr e =
     (unbox_expr' unbox_underef_expr >> underef_expr' unbox_underef_expr) e
 
+  (* extracts a `param` out of a `generic_param` if it's a const
+     generic, otherwise returns `None`` *)
+  let param_of_generic_const_param (g : generic_param) : param option =
+    let* typ = match g.kind with GPConst { typ } -> Some typ | _ -> None in
+    let ({ span; ident = var; _ } : generic_param) = g in
+    let pat =
+      let mode, mut, subpat = (ByValue, Immutable, None) in
+      { p = PBinding { mut; mode; var; typ; subpat }; span; typ }
+    in
+    Some { pat; typ; typ_span = Some span; attrs = [] }
+
   let rec expr_of_lhs (span : span) (lhs : lhs) : expr =
     match lhs with
     | LhsLocalVar { var; typ } -> { e = LocalVar var; typ; span }

--- a/engine/lib/dependencies.mli
+++ b/engine/lib/dependencies.mli
@@ -2,7 +2,7 @@ module Make (F : Features.T) : sig
   module AST : module type of Ast.Make (F)
 
   val name_me : AST.item list -> AST.item list
-  val sort: AST.item list -> AST.item list
+  val sort : AST.item list -> AST.item list
 
   val filter_by_inclusion_clauses :
     Types.inclusion_clause list -> AST.item list -> AST.item list

--- a/engine/lib/generic_printer/generic_printer.ml
+++ b/engine/lib/generic_printer/generic_printer.ml
@@ -253,8 +253,8 @@ module Make (F : Features.T) (View : Concrete_ident.VIEW_API) = struct
             print#expr_at Expr_FieldProjection e
             |> terminate (dot ^^ print#name_of_concrete_ident i)
 
-        method expr_app : expr -> expr list fn =
-          fun f args ->
+        method expr_app : expr -> expr list -> generic_value list fn =
+          fun f args _generic_args ->
             let args =
               separate_map
                 (comma ^^ break 1)

--- a/engine/lib/generic_printer/generic_printer_base.ml
+++ b/engine/lib/generic_printer/generic_printer_base.ml
@@ -173,14 +173,14 @@ module Make (F : Features.T) = struct
       method expr' : par_state -> expr' fn =
         fun _ctx e ->
           match e with
-          | App { f = { e = GlobalVar i; _ } as f; args } -> (
+          | App { f = { e = GlobalVar i; _ } as f; args; generic_args } -> (
               let expect_one_arg where =
                 match args with
                 | [ arg ] -> arg
                 | _ -> print#assertion_failure @@ "Expected one arg at " ^ where
               in
               match i with
-              | `Concrete _ | `Primitive _ -> print#expr_app f args
+              | `Concrete _ | `Primitive _ -> print#expr_app f args generic_args
               | `TupleType _ | `TupleCons _ | `TupleField _ ->
                   print#assertion_failure "App: unexpected tuple"
               | `Projector (`TupleField (nth, size)) ->
@@ -189,7 +189,7 @@ module Make (F : Features.T) = struct
               | `Projector (`Concrete i) ->
                   let arg = expect_one_arg "projector concrete" in
                   print#field_projection i arg)
-          | App { f; args } -> print#expr_app f args
+          | App { f; args; generic_args } -> print#expr_app f args generic_args
           | Construct { constructor; fields; base; is_record; is_struct } -> (
               match constructor with
               | `Concrete constructor ->
@@ -303,7 +303,7 @@ module Make (F : Features.T) = struct
       method expr_let : lhs:pat -> rhs:expr -> expr fn
       method tuple_projection : size:int -> nth:int -> expr fn
       method field_projection : concrete_ident -> expr fn
-      method expr_app : expr -> expr list fn
+      method expr_app : expr -> expr list -> generic_value list fn
       method doc_construct_tuple : document list fn
       method expr_construct_tuple : expr list fn
       method pat_construct_tuple : pat list fn

--- a/engine/lib/phases/phase_direct_and_mut.ml
+++ b/engine/lib/phases/phase_direct_and_mut.ml
@@ -98,7 +98,8 @@ struct
           LhsArbitraryExpr { witness = Features.On.arbitrary_lhs; e }
 
     and translate_app (span : span) (otype : A.ty) (f : A.expr)
-        (raw_args : A.expr list) : B.expr =
+        (raw_args : A.expr list) (generic_args : B.generic_value list) : B.expr
+        =
       (* `otype` and `_otype` (below) are supposed to be the same
          type, but sometimes `_otype` is less precise (i.e. an associated
          type while a concrete type is available) *)
@@ -135,7 +136,7 @@ struct
           (* there is no mutation, we can reconstruct the expression right away *)
           let f, typ = (dexpr f, dty span otype) in
           let args = List.map ~f:dexpr raw_args in
-          B.{ e = B.App { f; args }; typ; span }
+          B.{ e = B.App { f; args; generic_args }; typ; span }
       | _ -> (
           (* TODO: when LHS are better (issue #222), compress `p1 = tmp1; ...; pN = tmpN` in `(p1...pN) = ...` *)
           (* we are generating:
@@ -210,7 +211,7 @@ struct
             in
             B.
               {
-                e = App { f; args = unmut_args };
+                e = App { f; args = unmut_args; generic_args };
                 typ = pat.typ;
                 span = pat.span;
               }
@@ -260,7 +261,9 @@ struct
     and dexpr_unwrapped (expr : A.expr) : B.expr =
       let span = expr.span in
       match expr.e with
-      | App { f; args } -> translate_app span expr.typ f args
+      | App { f; args; generic_args } ->
+          let generic_args = List.map ~f:(dgeneric_value span) generic_args in
+          translate_app span expr.typ f args generic_args
       | _ ->
           let e = dexpr' span expr.e in
           B.{ e; typ = dty expr.span expr.typ; span = expr.span }

--- a/engine/lib/phases/phase_drop_references.ml
+++ b/engine/lib/phases/phase_drop_references.ml
@@ -69,7 +69,7 @@ struct
 
     and dexpr' (span : span) (e : A.expr') : B.expr' =
       match (UA.unbox_underef_expr { e; span; typ = UA.never_typ }).e with
-      | [%inline_arms If + Literal + Array + App + Block] -> auto
+      | [%inline_arms If + Literal + Array + Block] -> auto
       | Construct { constructor; is_record; is_struct; fields; base } ->
           Construct
             {
@@ -110,6 +110,13 @@ struct
               body = dexpr body;
               captures = List.map ~f:dexpr captures;
             }
+      | App { f; args; generic_args } ->
+          let f = dexpr f in
+          let args = List.map ~f:dexpr args in
+          let generic_args =
+            List.filter_map ~f:(dgeneric_value span) generic_args
+          in
+          App { f; args; generic_args }
       | _ -> .
       [@@inline_ands bindings_of dexpr - dbinding_mode]
 

--- a/engine/lib/phases/phase_reconstruct_for_loops.ml
+++ b/engine/lib/phases/phase_reconstruct_for_loops.ml
@@ -118,6 +118,8 @@ struct
                                                                           };
                                                                     };
                                                                   ];
+                                                                _;
+                                                                (* TODO: see issue #328 *)
                                                               };
                                                         };
                                                       arms =
@@ -165,6 +167,8 @@ struct
                                                                                 };
                                                                               };
                                                                             ];
+                                                                          _;
+                                                                          (* TODO: see issue #328 *)
                                                                         };
                                                                   };
                                                               };

--- a/engine/lib/phases/phase_recontruct_for_index_loops.ml
+++ b/engine/lib/phases/phase_recontruct_for_index_loops.ml
@@ -57,6 +57,8 @@ module%inlined_contents Make (FA : Features.T) = struct
                             _;
                           };
                         ];
+                      _;
+                      (* TODO: see issue #328 *)
                     };
                 typ;
                 _;

--- a/engine/lib/print_rust.ml
+++ b/engine/lib/print_rust.ml
@@ -211,12 +211,14 @@ module Raw = struct
           match else_ with Some e -> !" else {" & pexpr e & !"}" | None -> !""
         in
         !"(" & !"if " & pexpr cond & !"{" & pexpr then_ & !"}" & else_ & !")"
-    | App { f = { e = GlobalVar _; _ } as f; args } ->
+    | App { f; args; generic_args } ->
         let args = concat ~sep:!"," @@ List.map ~f:pexpr args in
-        pexpr f & !"(" & args & !")"
-    | App { f; args } ->
-        let args = concat ~sep:!"," @@ List.map ~f:pexpr args in
-        pexpr f & !"(" & args & !")"
+        let generic_args =
+          let f = pgeneric_value e.span in
+          if List.is_empty generic_args then !""
+          else !"<" & (concat ~sep:!"," @@ List.map ~f generic_args) & !">"
+        in
+        pexpr f & generic_args & !"(" & args & !")"
     | Literal l -> pliteral e.span l
     | Block (e, _) -> !"{" & pexpr e & !"}"
     | Array l -> !"[" & concat ~sep:!"," (List.map ~f:pexpr l) & !"]"

--- a/engine/lib/side_effect_utils.ml
+++ b/engine/lib/side_effect_utils.ml
@@ -342,7 +342,7 @@ struct
                     m#plus (m#plus (no_lbs ethen) (no_lbs eelse)) effects
                   in
                   ({ e with e = If { cond; then_; else_ } }, effects))
-          | App { f; args } ->
+          | App { f; args; generic_args } ->
               HoistSeq.many env
                 (List.map ~f:(super#visit_expr env) (f :: args))
                 (fun l effects ->
@@ -351,7 +351,7 @@ struct
                     | f :: args -> (f, args)
                     | _ -> HoistSeq.err_hoist_invariant e.span Stdlib.__LOC__
                   in
-                  ({ e with e = App { f; args } }, effects))
+                  ({ e with e = App { f; args; generic_args } }, effects))
           | Literal _ -> (e, m#zero)
           | Block (inner, witness) ->
               HoistSeq.one env (super#visit_expr env inner)

--- a/engine/lib/subtype.ml
+++ b/engine/lib/subtype.ml
@@ -151,7 +151,13 @@ struct
             then_ = dexpr then_;
             else_ = Option.map ~f:dexpr else_;
           }
-    | App { f; args } -> App { f = dexpr f; args = List.map ~f:dexpr args }
+    | App { f; args; generic_args } ->
+        App
+          {
+            f = dexpr f;
+            args = List.map ~f:dexpr args;
+            generic_args = List.map ~f:(dgeneric_value span) generic_args;
+          }
     | Literal lit -> Literal lit
     | Array l -> Array (List.map ~f:dexpr l)
     | Construct { constructor; is_record; is_struct; fields; base } ->

--- a/frontend/exporter/src/types/copied.rs
+++ b/frontend/exporter/src/types/copied.rs
@@ -1899,7 +1899,7 @@ pub enum ExprKind {
     },
     #[map({
         let e = gstate.thir().exprs[*fun].unroll_scope(gstate);
-        let (fun, r#impl) = match &e.kind {
+        let (fun, r#impl, generic_args) = match &e.kind {
             /* TODO: see whether [user_ty] below is relevant or not */
             rustc_middle::thir::ExprKind::ZstLiteral {user_ty: _ } => {
                 match ty.kind() {
@@ -1920,7 +1920,7 @@ pub enum ExprKind {
                             ty: e.ty.sinto(gstate),
                             hir_id,
                             attributes,
-                        }, r#impl)
+                        }, r#impl, substs.sinto(gstate))
                     },
                     ty_kind => supposely_unreachable_fatal!(
                         gstate[e.span],
@@ -1932,7 +1932,7 @@ pub enum ExprKind {
             kind => {
                 match ty.kind() {
                     rustc_middle::ty::TyKind::FnPtr(..) => {
-                        (e.sinto(gstate), None)
+                        (e.sinto(gstate), None, vec![])
                     },
                     ty_kind => {
                         supposely_unreachable!(
@@ -1948,6 +1948,7 @@ pub enum ExprKind {
         TO_TYPE::Call {
             ty: ty.sinto(gstate),
             args: args.sinto(gstate),
+            generic_args,
             from_hir_call: from_hir_call.sinto(gstate),
             fn_span: fn_span.sinto(gstate),
             r#impl,
@@ -1960,6 +1961,8 @@ pub enum ExprKind {
         args: Vec<Expr>,
         from_hir_call: bool,
         fn_span: Span,
+        #[not_in_source]
+        generic_args: Vec<GenericArg>,
         #[not_in_source]
         r#impl: Option<ImplExpr>,
     },

--- a/tests/generics/src/lib.rs
+++ b/tests/generics/src/lib.rs
@@ -16,9 +16,26 @@ fn repeat<const LEN: usize, T: Copy>(x: T) -> [T; LEN] {
     [x; LEN]
 }
 
-fn g() -> usize {
+fn call_f() -> usize {
     f::<10>(3) + 3
 }
 fn f<const N: usize>(x: usize) -> usize {
     N + N + x
+}
+
+fn call_g() -> usize {
+    g::<3, [usize; 3]>([42, 3, 49]) + 3
+}
+fn g<const N: usize, T: Into<[usize; N]>>(arr: T) -> usize {
+    arr.into().into_iter().max().unwrap_or(N) + N
+}
+
+trait Foo {
+    fn const_add<const N: usize>(self) -> usize;
+}
+
+impl Foo for usize {
+    fn const_add<const N: usize>(self) -> usize {
+        self + N
+    }
 }

--- a/tests/generics/src/lib.rs
+++ b/tests/generics/src/lib.rs
@@ -15,3 +15,10 @@ fn foo<const LEN: usize>(arr: [usize; LEN]) -> usize {
 fn repeat<const LEN: usize, T: Copy>(x: T) -> [T; LEN] {
     [x; LEN]
 }
+
+fn g() -> usize {
+    f::<10>(3) + 3
+}
+fn f<const N: usize>(x: usize) -> usize {
+    N + N + x
+}


### PR DESCRIPTION
This is particularly important for generic constants: if a generic constant on a function is not constrained enough (in terms of type), and if we extract it as an implicit parameter, then the target language might not be able to infer it.

Thus, we need those const generics to be explicit.

This PR propagates the (until then implicit) information about generics (constants, but also types and lifetimes). 

Now, I need to either:
 - [x] ~~write a phase that transforms each generic const of functions (definitions and call) into plain values;~~
 - [x] just tweak the backends.

EDIT: tweaking the backends is the way to go, we cannot always convert const-generics to normal terms.