### PR TITLE
feat(engine/fstar): `let`s instead of typing lambdas

### DIFF
--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -496,10 +496,28 @@ struct
           (F.term @@ F.AST.Name (pglobal_ident e.span constructor))
           [ r ]
     | Closure { params; body } ->
-        let ppat_ascribed pat =
-          F.pat @@ F.AST.PatAscribed (ppat pat, (pty pat.span pat.typ, None))
+        let params =
+          List.mapi
+            ~f:(fun i p ->
+              match p.p with
+              | PBinding { var; subpat = None; _ } -> (var, p)
+              | _ ->
+                  ( Local_ident.
+                      { name = "temp_" ^ Int.to_string i; id = mk_id Expr (-1) },
+                    p ))
+            params
         in
-        F.mk_e_abs (List.map ~f:ppat_ascribed params) (pexpr body)
+        let body =
+          let f (lid, (pat : pat)) =
+            let rhs = { e = LocalVar lid; span = pat.span; typ = pat.typ } in
+            U.make_let pat rhs
+          in
+          List.fold_right ~init:body ~f params
+        in
+        let mk_pat ((lid, pat) : local_ident * pat) =
+          ppat (U.make_var_pat lid pat.typ pat.span)
+        in
+        F.mk_e_abs (List.map ~f:mk_pat params) (pexpr body)
     | Return { e } ->
         F.term @@ F.AST.App (F.term_of_lid [ "RETURN_STMT" ], pexpr e, Nothing)
     | MacroInvokation { macro; args; witness } ->

--- a/examples/chacha20/proofs/fstar/extraction/Chacha20.Hacspec_helper.fst
+++ b/examples/chacha20/proofs/fstar/extraction/Chacha20.Hacspec_helper.fst
@@ -2,67 +2,25 @@ module Chacha20.Hacspec_helper
 #set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
 open Core
 
-let to_le_u32s_3_ (bytes: t_Slice u8) : t_Array u32 (sz 3) =
-  let out:t_Array u32 (sz 3) = Rust_primitives.Hax.repeat 0ul (sz 3) in
-  let out:t_Array u32 (sz 3) =
+let add_state (state other: t_Array u32 (sz 16)) : t_Array u32 (sz 16) =
+  let state:t_Array u32 (sz 16) =
     Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
               Core.Ops.Range.f_start = sz 0;
-              Core.Ops.Range.f_end = sz 3
+              Core.Ops.Range.f_end = sz 16
             })
         <:
         Core.Ops.Range.t_Range usize)
-      out
-      (fun out i ->
-          Rust_primitives.Hax.update_at out
+      state
+      (fun state i ->
+          let state:t_Array u32 (sz 16) = state in
+          let i:usize = i in
+          Rust_primitives.Hax.update_at state
             i
-            (Core.Num.impl__u32__from_le_bytes (Core.Result.impl__unwrap (Core.Convert.f_try_into (bytes.[
-                            {
-                              Core.Ops.Range.f_start = sz 4 *! i <: usize;
-                              Core.Ops.Range.f_end = (sz 4 *! i <: usize) +! sz 4 <: usize
-                            } ]
-                          <:
-                          t_Slice u8)
-                      <:
-                      Core.Result.t_Result (t_Array u8 (sz 4)) Core.Array.t_TryFromSliceError)
-                  <:
-                  t_Array u8 (sz 4))
-              <:
-              u32)
+            (Core.Num.impl__u32__wrapping_add (state.[ i ] <: u32) (other.[ i ] <: u32) <: u32)
           <:
-          t_Array u32 (sz 3))
+          t_Array u32 (sz 16))
   in
-  out
-
-let to_le_u32s_8_ (bytes: t_Slice u8) : t_Array u32 (sz 8) =
-  let out:t_Array u32 (sz 8) = Rust_primitives.Hax.repeat 0ul (sz 8) in
-  let out:t_Array u32 (sz 8) =
-    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
-              Core.Ops.Range.f_start = sz 0;
-              Core.Ops.Range.f_end = sz 8
-            })
-        <:
-        Core.Ops.Range.t_Range usize)
-      out
-      (fun out i ->
-          Rust_primitives.Hax.update_at out
-            i
-            (Core.Num.impl__u32__from_le_bytes (Core.Result.impl__unwrap (Core.Convert.f_try_into (bytes.[
-                            {
-                              Core.Ops.Range.f_start = sz 4 *! i <: usize;
-                              Core.Ops.Range.f_end = (sz 4 *! i <: usize) +! sz 4 <: usize
-                            } ]
-                          <:
-                          t_Slice u8)
-                      <:
-                      Core.Result.t_Result (t_Array u8 (sz 4)) Core.Array.t_TryFromSliceError)
-                  <:
-                  t_Array u8 (sz 4))
-              <:
-              u32)
-          <:
-          t_Array u32 (sz 8))
-  in
-  out
+  state
 
 let to_le_u32s_16_ (bytes: t_Slice u8) : t_Array u32 (sz 16) =
   let out:t_Array u32 (sz 16) = Rust_primitives.Hax.repeat 0ul (sz 16) in
@@ -75,6 +33,8 @@ let to_le_u32s_16_ (bytes: t_Slice u8) : t_Array u32 (sz 16) =
         Core.Ops.Range.t_Range usize)
       out
       (fun out i ->
+          let out:t_Array u32 (sz 16) = out in
+          let i:usize = i in
           Rust_primitives.Hax.update_at out
             i
             (Core.Num.impl__u32__from_le_bytes (Core.Result.impl__unwrap (Core.Convert.f_try_into (bytes.[
@@ -108,6 +68,8 @@ let u32s_to_le_bytes (state: t_Array u32 (sz 16)) : t_Array u8 (sz 64) =
         Core.Ops.Range.t_Range usize)
       out
       (fun out i ->
+          let out:t_Array u8 (sz 64) = out in
+          let i:usize = i in
           let tmp:t_Array u8 (sz 4) = Core.Num.impl__u32__to_le_bytes (state.[ i ] <: u32) in
           Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
                     Core.Ops.Range.f_start = sz 0;
@@ -117,6 +79,8 @@ let u32s_to_le_bytes (state: t_Array u32 (sz 16)) : t_Array u8 (sz 64) =
               Core.Ops.Range.t_Range usize)
             out
             (fun out j ->
+                let out:t_Array u8 (sz 64) = out in
+                let j:usize = j in
                 Rust_primitives.Hax.update_at out
                   ((i *! sz 4 <: usize) +! j <: usize)
                   (tmp.[ j ] <: u8)
@@ -135,27 +99,11 @@ let xor_state (state other: t_Array u32 (sz 16)) : t_Array u32 (sz 16) =
         Core.Ops.Range.t_Range usize)
       state
       (fun state i ->
+          let state:t_Array u32 (sz 16) = state in
+          let i:usize = i in
           Rust_primitives.Hax.update_at state
             i
             ((state.[ i ] <: u32) ^. (other.[ i ] <: u32) <: u32)
-          <:
-          t_Array u32 (sz 16))
-  in
-  state
-
-let add_state (state other: t_Array u32 (sz 16)) : t_Array u32 (sz 16) =
-  let state:t_Array u32 (sz 16) =
-    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
-              Core.Ops.Range.f_start = sz 0;
-              Core.Ops.Range.f_end = sz 16
-            })
-        <:
-        Core.Ops.Range.t_Range usize)
-      state
-      (fun state i ->
-          Rust_primitives.Hax.update_at state
-            i
-            (Core.Num.impl__u32__wrapping_add (state.[ i ] <: u32) (other.[ i ] <: u32) <: u32)
           <:
           t_Array u32 (sz 16))
   in
@@ -178,6 +126,74 @@ let update_array (array: t_Array u8 (sz 64)) (v_val: t_Slice u8) : t_Array u8 (s
         Core.Ops.Range.t_Range usize)
       array
       (fun array i ->
+          let array:t_Array u8 (sz 64) = array in
+          let i:usize = i in
           Rust_primitives.Hax.update_at array i (v_val.[ i ] <: u8) <: t_Array u8 (sz 64))
   in
   array
+
+let to_le_u32s_3_ (bytes: t_Slice u8) : t_Array u32 (sz 3) =
+  let out:t_Array u32 (sz 3) = Rust_primitives.Hax.repeat 0ul (sz 3) in
+  let out:t_Array u32 (sz 3) =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+              Core.Ops.Range.f_start = sz 0;
+              Core.Ops.Range.f_end = sz 3
+            })
+        <:
+        Core.Ops.Range.t_Range usize)
+      out
+      (fun out i ->
+          let out:t_Array u32 (sz 3) = out in
+          let i:usize = i in
+          Rust_primitives.Hax.update_at out
+            i
+            (Core.Num.impl__u32__from_le_bytes (Core.Result.impl__unwrap (Core.Convert.f_try_into (bytes.[
+                            {
+                              Core.Ops.Range.f_start = sz 4 *! i <: usize;
+                              Core.Ops.Range.f_end = (sz 4 *! i <: usize) +! sz 4 <: usize
+                            } ]
+                          <:
+                          t_Slice u8)
+                      <:
+                      Core.Result.t_Result (t_Array u8 (sz 4)) Core.Array.t_TryFromSliceError)
+                  <:
+                  t_Array u8 (sz 4))
+              <:
+              u32)
+          <:
+          t_Array u32 (sz 3))
+  in
+  out
+
+let to_le_u32s_8_ (bytes: t_Slice u8) : t_Array u32 (sz 8) =
+  let out:t_Array u32 (sz 8) = Rust_primitives.Hax.repeat 0ul (sz 8) in
+  let out:t_Array u32 (sz 8) =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+              Core.Ops.Range.f_start = sz 0;
+              Core.Ops.Range.f_end = sz 8
+            })
+        <:
+        Core.Ops.Range.t_Range usize)
+      out
+      (fun out i ->
+          let out:t_Array u32 (sz 8) = out in
+          let i:usize = i in
+          Rust_primitives.Hax.update_at out
+            i
+            (Core.Num.impl__u32__from_le_bytes (Core.Result.impl__unwrap (Core.Convert.f_try_into (bytes.[
+                            {
+                              Core.Ops.Range.f_start = sz 4 *! i <: usize;
+                              Core.Ops.Range.f_end = (sz 4 *! i <: usize) +! sz 4 <: usize
+                            } ]
+                          <:
+                          t_Slice u8)
+                      <:
+                      Core.Result.t_Result (t_Array u8 (sz 4)) Core.Array.t_TryFromSliceError)
+                  <:
+                  t_Array u8 (sz 4))
+              <:
+              u32)
+          <:
+          t_Array u32 (sz 8))
+  in
+  out

--- a/examples/chacha20/proofs/fstar/extraction/Chacha20.diff
+++ b/examples/chacha20/proofs/fstar/extraction/Chacha20.diff
@@ -1,14 +1,14 @@
---- Chacha20.fst	2023-10-19 14:27:45.792270343 +0200
-+++ /tmp/Chacha20.fst	2023-10-19 14:26:05.909081013 +0200
+--- Chacha20.fst	2023-11-10 11:27:38.259410207 +0100
++++ /tmp/Chacha20.fst	2023-11-10 11:27:32.638440011 +0100
 @@ -1,6 +1,7 @@
  module Chacha20
  #set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
  open Core
 +open FStar.Mul
  
- let t_State = t_Array u32 (sz 16)
- 
-@@ -152,10 +153,12 @@
+ let chacha20_line (a b d: usize) (s: u32) (m: t_Array u32 (sz 16))
+     : Prims.Pure (t_Array u32 (sz 16))
+@@ -144,10 +145,12 @@
                  t_Array u8 (sz 64))
            in
            let blocks_out:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
@@ -21,10 +21,10 @@
    let blocks_out:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
      if remainder_len <>. sz 0
      then
-@@ -180,4 +183,4 @@
- let chacha20 (m: t_Slice u8) (key: t_Array u8 (sz 32)) (iv: t_Array u8 (sz 12)) (ctr: u32)
-     : Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
-   let state:t_Array u32 (sz 16) = chacha20_init key iv ctr in
--  chacha20_update state m
+@@ -184,4 +187,4 @@
+ 
+ let t_ChaChaIV = t_Array u8 (sz 12)
+ 
+-let t_Block = t_Array u8 (sz 64)
 \ No newline at end of file
-+  chacha20_update state m
++let t_Block = t_Array u8 (sz 64)

--- a/examples/chacha20/src/lib.rs
+++ b/examples/chacha20/src/lib.rs
@@ -105,7 +105,6 @@ pub fn chacha20_update(st0: State, m: &[u8]) -> Vec<u8> {
     let num_blocks = m.len() / 64;
     let remainder_len = m.len() % 64;
     for i in 0..num_blocks {
-        let i: usize = i;
         // Full block
         let b =
             chacha20_encrypt_block(st0, i as u32, &m[64 * i..(64 * i + 64)].try_into().unwrap());

--- a/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
@@ -154,7 +154,9 @@ let g (x: t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global))
         <:
         Core.Ops.Range.t_Range u8)
       x
-      (fun (x: t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)) (i: u8) ->
+      (fun x i ->
+          let x:t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) = x in
+          let i:u8 = i in
           { x with f_a = Alloc.Vec.impl_1__push x.f_a i <: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global }
       )
   in
@@ -175,7 +177,9 @@ let foo (lhs rhs: t_S) : t_S =
         <:
         Core.Ops.Range.t_Range usize)
       lhs
-      (fun (lhs: t_S) (i: usize) ->
+      (fun lhs i ->
+          let lhs:t_S = lhs in
+          let i:usize = i in
           {
             lhs with
             f_b


### PR DESCRIPTION
We used to have closure like `|x: T, y: U| body` extract to `fun (x:
T) (y: U) -> body` in the F* backend.

When such a typed lambda is consumed by a higer-order function, we sometimes face issues with unification in F*.

This commit introduce a trick that allows for better unification in F*: we now generate a let binding per input in lambdas. For example, `|x: T, y: U| body` now extracts to:
```fstar
fun x y ->
    let x: T = x in
    let y: T = y in
    body
```