### PR TITLE
feat(hax-lib): intro hax-lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,6 +509,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "hax-lib"
+version = "0.1.0-pre.1"
+
+[[package]]
 name = "hax-lib-macros"
 version = "0.1.0-pre.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
      "cli/driver",
      "test-harness",
      "engine/utils/phase-debug-webapp",
+     "hax-lib",
      "hax-lib-macros",
      "hax-lib-macros/types",
 ]

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -496,28 +496,7 @@ struct
           (F.term @@ F.AST.Name (pglobal_ident e.span constructor))
           [ r ]
     | Closure { params; body } ->
-        let params =
-          List.mapi
-            ~f:(fun i p ->
-              match p.p with
-              | PBinding { var; subpat = None; _ } -> (var, p)
-              | _ ->
-                  ( Local_ident.
-                      { name = "temp_" ^ Int.to_string i; id = mk_id Expr (-1) },
-                    p ))
-            params
-        in
-        let body =
-          let f (lid, (pat : pat)) =
-            let rhs = { e = LocalVar lid; span = pat.span; typ = pat.typ } in
-            U.make_let pat rhs
-          in
-          List.fold_right ~init:body ~f params
-        in
-        let mk_pat ((lid, pat) : local_ident * pat) =
-          ppat (U.make_var_pat lid pat.typ pat.span)
-        in
-        F.mk_e_abs (List.map ~f:mk_pat params) (pexpr body)
+        F.mk_e_abs (List.map ~f:ppat params) (pexpr body)
     | Return { e } ->
         F.term @@ F.AST.App (F.term_of_lid [ "RETURN_STMT" ], pexpr e, Nothing)
     | MacroInvokation { macro; args; witness } ->

--- a/hax-lib/Cargo.toml
+++ b/hax-lib/Cargo.toml
@@ -6,7 +6,8 @@ license.workspace = true
 homepage.workspace = true
 edition.workspace = true
 repository.workspace = true
-readme.workspace = true
+readme = "README.md"
+description = "Hax-specific helpers for Rust programs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/hax-lib/Cargo.toml
+++ b/hax-lib/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "hax-lib"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+edition.workspace = true
+repository.workspace = true
+readme.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/hax-lib/proofs/fstar/extraction/Hax_lib.fst
+++ b/hax-lib/proofs/fstar/extraction/Hax_lib.fst
@@ -1,6 +1,5 @@
 module Hax_lib
 #set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
-
 open FStar.Tactics
 
 val v_assert (p: bool) : Pure unit (requires p) (ensures (fun x -> p))
@@ -8,3 +7,8 @@ let v_assert (v__formula: bool) = ()
 
 val v_assume (p: bool) : Pure unit (requires True) (ensures (fun x -> p))
 let v_assume (v__formula: bool) = assume v__formula
+
+
+unfold let v_exists (v__f: 'a -> Type0): Type0 = exists (x: 'a). v__f x
+unfold let v_forall (v__f: 'a -> Type0): Type0 = forall (x: 'a). v__f x
+unfold let implies (lhs: Type0) (rhs: unit -> Type0): Type0 = lhs ==> rhs ()

--- a/hax-lib/proofs/fstar/extraction/Hax_lib.fst
+++ b/hax-lib/proofs/fstar/extraction/Hax_lib.fst
@@ -1,0 +1,10 @@
+module Hax_lib
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+
+open FStar.Tactics
+
+val v_assert (p: bool) : Pure unit (requires p) (ensures (fun x -> p))
+let v_assert (v__formula: bool) = ()
+
+val v_assume (p: bool) : Pure unit (requires True) (ensures (fun x -> p))
+let v_assume (v__formula: bool) = assume v__formula

--- a/hax-lib/src/lib.rs
+++ b/hax-lib/src/lib.rs
@@ -1,6 +1,17 @@
 //! Hax-specific helpers for Rust programs. Those helpers are usually
 //! no-ops when compiled normally but meaningful when compiled under
 //! hax.
+//!
+//! # Example:
+//!
+//! ```rust
+//! fn sum(x: Vec<u32>, y: Vec<u32>) -> Vec<u32> {
+//!   hax_lib::assume!(x.len() == y.len());
+//!   hax_lib::assert!(hax_lib::forall(|i: usize| hax_lib::implies(i < x.len(), || x[i] < 4242)));
+//!   hax_lib::debug_assert!(hax_lib::exists(|i: usize| hax_lib::implies(i < x.len(), || x[i] > 123)));
+//!   x.into_iter().zip(y.into_iter()).map(|(x, y)| x + y).collect()
+//! }
+//! ```
 
 #[doc(hidden)]
 #[cfg(hax)]
@@ -103,6 +114,6 @@ pub fn exists<T>(_f: impl Fn(T) -> bool) -> bool {
 }
 
 /// The logical implication `a ==> b`.
-pub fn implies(lhs: bool, rhs: bool) -> bool {
-    !lhs || rhs
+pub fn implies(lhs: bool, rhs: impl Fn() -> bool) -> bool {
+    !lhs || rhs()
 }

--- a/hax-lib/src/lib.rs
+++ b/hax-lib/src/lib.rs
@@ -1,3 +1,7 @@
+//! Hax-specific helpers for Rust programs. Those helpers are usually
+//! no-ops when compiled normally but meaningful when compiled under
+//! hax.
+
 #[cfg(hax)]
 #[macro_export]
 macro_rules! proxy_macro_if_not_hax {

--- a/hax-lib/src/lib.rs
+++ b/hax-lib/src/lib.rs
@@ -1,0 +1,52 @@
+#[cfg(hax_compilation)]
+#[macro_export]
+macro_rules! proxy_macro_if_not_hax {
+    ($macro:path, no, $($arg:tt)*) => {
+        ()
+    };
+    ($macro:path, $f:expr, $cond:expr$(, $($arg:tt)*)?) => {
+        $f($cond)
+    };
+}
+#[cfg(not(hax_compilation))]
+#[macro_export]
+macro_rules! proxy_macro_if_not_hax {
+    ($macro:path, $f:expr, $($arg:tt)*) => {
+        $macro!($($arg)*)
+    };
+}
+
+#[macro_export]
+macro_rules! debug_assert {
+    ($($arg:tt)*) => {
+        $crate::proxy_macro_if_not_hax!(::std::debug_assert, no, $($arg)*)
+    };
+}
+
+#[macro_export]
+macro_rules! assert {
+    ($($arg:tt)*) => {
+        $crate::proxy_macro_if_not_hax!(::std::assert, $crate::assert, $($arg)*)
+    };
+}
+
+#[cfg(hax_compilation)]
+pub fn assert(_formula: bool) {}
+
+#[cfg(hax_compilation)]
+pub fn assume(_formula: bool) {}
+
+#[cfg(hax_compilation)]
+#[macro_export]
+macro_rules! assume {
+    ($formula:expr) => {
+        $crate::assume($formula)
+    };
+}
+#[cfg(not(hax_compilation))]
+#[macro_export]
+macro_rules! assume {
+    ($formula:expr) => {
+        ()
+    };
+}

--- a/hax-lib/src/lib.rs
+++ b/hax-lib/src/lib.rs
@@ -1,4 +1,4 @@
-#[cfg(hax_compilation)]
+#[cfg(hax)]
 #[macro_export]
 macro_rules! proxy_macro_if_not_hax {
     ($macro:path, no, $($arg:tt)*) => {
@@ -8,7 +8,7 @@ macro_rules! proxy_macro_if_not_hax {
         $f($cond)
     };
 }
-#[cfg(not(hax_compilation))]
+#[cfg(not(hax))]
 #[macro_export]
 macro_rules! proxy_macro_if_not_hax {
     ($macro:path, $f:expr, $($arg:tt)*) => {
@@ -30,20 +30,20 @@ macro_rules! assert {
     };
 }
 
-#[cfg(hax_compilation)]
+#[cfg(hax)]
 pub fn assert(_formula: bool) {}
 
-#[cfg(hax_compilation)]
+#[cfg(hax)]
 pub fn assume(_formula: bool) {}
 
-#[cfg(hax_compilation)]
+#[cfg(hax)]
 #[macro_export]
 macro_rules! assume {
     ($formula:expr) => {
         $crate::assume($formula)
     };
 }
-#[cfg(not(hax_compilation))]
+#[cfg(not(hax))]
 #[macro_export]
 macro_rules! assume {
     ($formula:expr) => {

--- a/hax-lib/src/lib.rs
+++ b/hax-lib/src/lib.rs
@@ -17,6 +17,8 @@ macro_rules! proxy_macro_if_not_hax {
 }
 
 #[macro_export]
+/// Proxy to `std::debug_assert!`. Compiled with `hax`, this
+/// disappears.
 macro_rules! debug_assert {
     ($($arg:tt)*) => {
         $crate::proxy_macro_if_not_hax!(::std::debug_assert, no, $($arg)*)
@@ -24,6 +26,8 @@ macro_rules! debug_assert {
 }
 
 #[macro_export]
+/// Proxy to `std::assert!`. Compiled with `hax`, this is transformed
+/// into a `assert` in the backend.
 macro_rules! assert {
     ($($arg:tt)*) => {
         $crate::proxy_macro_if_not_hax!(::std::assert, $crate::assert, $($arg)*)
@@ -31,9 +35,15 @@ macro_rules! assert {
 }
 
 #[cfg(hax)]
+/// This function exists only when compiled with `hax`, and is not
+/// meant to be used directly. It is called by `assert!` only in
+/// appropriate situations.
 pub fn assert(_formula: bool) {}
 
 #[cfg(hax)]
+/// This function exists only when compiled with `hax`, and is not
+/// meant to be used directly. It is called by `assume!` only in
+/// appropriate situations.
 pub fn assume(_formula: bool) {}
 
 #[cfg(hax)]
@@ -43,10 +53,48 @@ macro_rules! assume {
         $crate::assume($formula)
     };
 }
+
+/// Assume a boolean formula holds. In Rust, this is expanded to the
+/// expression `()`. While extracted with Hax, this gets expanded to a
+/// call to an `assume` function.
+///
+/// # Example:
+///
+/// ```rust
+/// fn sum(x: u32, y: u32) -> u32 {
+///   hax_lib::assume!(x < 4242 && y < 424242);
+///   x + y
+/// }
+/// ```
 #[cfg(not(hax))]
 #[macro_export]
 macro_rules! assume {
     ($formula:expr) => {
         ()
     };
+}
+
+/// The universal quantifier. This should be used only for Hax code: in
+/// Rust, this is always true.
+///
+/// # Example:
+///
+/// The Rust expression `forall(|x: T| phi(x))` corresponds to `∀ (x: T), phi(x)`.
+pub fn forall<T>(_f: impl Fn(T) -> bool) -> bool {
+    true
+}
+
+/// The existential quantifier. This should be used only for Hax code: in
+/// Rust, this is always true.
+///
+/// # Example:
+///
+/// The Rust expression `exists(|x: T| phi(x))` corresponds to `∃ (x: T), phi(x)`.
+pub fn exists<T>(_f: impl Fn(T) -> bool) -> bool {
+    true
+}
+
+/// The logical implication `a ==> b`.
+pub fn implies(lhs: bool, rhs: bool) -> bool {
+    !lhs || rhs
 }

--- a/hax-lib/src/lib.rs
+++ b/hax-lib/src/lib.rs
@@ -2,6 +2,7 @@
 //! no-ops when compiled normally but meaningful when compiled under
 //! hax.
 
+#[doc(hidden)]
 #[cfg(hax)]
 #[macro_export]
 macro_rules! proxy_macro_if_not_hax {
@@ -12,6 +13,7 @@ macro_rules! proxy_macro_if_not_hax {
         $f($cond)
     };
 }
+#[doc(hidden)]
 #[cfg(not(hax))]
 #[macro_export]
 macro_rules! proxy_macro_if_not_hax {
@@ -38,12 +40,14 @@ macro_rules! assert {
     };
 }
 
+#[doc(hidden)]
 #[cfg(hax)]
 /// This function exists only when compiled with `hax`, and is not
 /// meant to be used directly. It is called by `assert!` only in
 /// appropriate situations.
 pub fn assert(_formula: bool) {}
 
+#[doc(hidden)]
 #[cfg(hax)]
 /// This function exists only when compiled with `hax`, and is not
 /// meant to be used directly. It is called by `assume!` only in

--- a/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
@@ -155,8 +155,6 @@ let g (x: t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global))
         Core.Ops.Range.t_Range u8)
       x
       (fun x i ->
-          let x:t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) = x in
-          let i:u8 = i in
           { x with f_a = Alloc.Vec.impl_1__push x.f_a i <: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global }
       )
   in
@@ -178,8 +176,6 @@ let foo (lhs rhs: t_S) : t_S =
         Core.Ops.Range.t_Range usize)
       lhs
       (fun lhs i ->
-          let lhs:t_S = lhs in
-          let i:usize = i in
           {
             lhs with
             f_b

--- a/tests/generics/src/lib.rs
+++ b/tests/generics/src/lib.rs
@@ -1,41 +1,45 @@
 #![allow(dead_code)]
 
-fn dup<T: Clone>(x: T) -> (T, T) {
-    (x.clone(), x.clone())
+fn f() -> bool {
+    vec![1, 2, 3].into_iter().all(|x| x > 3)
 }
 
-fn foo<const LEN: usize>(arr: [usize; LEN]) -> usize {
-    let mut acc = LEN + 9;
-    for i in 0..LEN {
-        acc += arr[i];
-    }
-    acc
-}
+// fn dup<T: Clone>(x: T) -> (T, T) {
+//     (x.clone(), x.clone())
+// }
 
-fn repeat<const LEN: usize, T: Copy>(x: T) -> [T; LEN] {
-    [x; LEN]
-}
+// fn foo<const LEN: usize>(arr: [usize; LEN]) -> usize {
+//     let mut acc = LEN + 9;
+//     for i in 0..LEN {
+//         acc += arr[i];
+//     }
+//     acc
+// }
 
-fn call_f() -> usize {
-    f::<10>(3) + 3
-}
-fn f<const N: usize>(x: usize) -> usize {
-    N + N + x
-}
+// fn repeat<const LEN: usize, T: Copy>(x: T) -> [T; LEN] {
+//     [x; LEN]
+// }
 
-fn call_g() -> usize {
-    g::<3, [usize; 3]>([42, 3, 49]) + 3
-}
-fn g<const N: usize, T: Into<[usize; N]>>(arr: T) -> usize {
-    arr.into().into_iter().max().unwrap_or(N) + N
-}
+// fn call_f() -> usize {
+//     f::<10>(3) + 3
+// }
+// fn f<const N: usize>(x: usize) -> usize {
+//     N + N + x
+// }
 
-trait Foo {
-    fn const_add<const N: usize>(self) -> usize;
-}
+// fn call_g() -> usize {
+//     g::<3, [usize; 3]>([42, 3, 49]) + 3
+// }
+// fn g<const N: usize, T: Into<[usize; N]>>(arr: T) -> usize {
+//     arr.into().into_iter().max().unwrap_or(N) + N
+// }
 
-impl Foo for usize {
-    fn const_add<const N: usize>(self) -> usize {
-        self + N
-    }
-}
+// trait Foo {
+//     fn const_add<const N: usize>(self) -> usize;
+// }
+
+// impl Foo for usize {
+//     fn const_add<const N: usize>(self) -> usize {
+//         self + N
+//     }
+// }

--- a/tests/generics/src/lib.rs
+++ b/tests/generics/src/lib.rs
@@ -1,45 +1,41 @@
 #![allow(dead_code)]
 
-fn f() -> bool {
-    vec![1, 2, 3].into_iter().all(|x| x > 3)
+fn dup<T: Clone>(x: T) -> (T, T) {
+    (x.clone(), x.clone())
 }
 
-// fn dup<T: Clone>(x: T) -> (T, T) {
-//     (x.clone(), x.clone())
-// }
+fn foo<const LEN: usize>(arr: [usize; LEN]) -> usize {
+    let mut acc = LEN + 9;
+    for i in 0..LEN {
+        acc += arr[i];
+    }
+    acc
+}
 
-// fn foo<const LEN: usize>(arr: [usize; LEN]) -> usize {
-//     let mut acc = LEN + 9;
-//     for i in 0..LEN {
-//         acc += arr[i];
-//     }
-//     acc
-// }
+fn repeat<const LEN: usize, T: Copy>(x: T) -> [T; LEN] {
+    [x; LEN]
+}
 
-// fn repeat<const LEN: usize, T: Copy>(x: T) -> [T; LEN] {
-//     [x; LEN]
-// }
+fn call_f() -> usize {
+    f::<10>(3) + 3
+}
+fn f<const N: usize>(x: usize) -> usize {
+    N + N + x
+}
 
-// fn call_f() -> usize {
-//     f::<10>(3) + 3
-// }
-// fn f<const N: usize>(x: usize) -> usize {
-//     N + N + x
-// }
+fn call_g() -> usize {
+    g::<3, [usize; 3]>([42, 3, 49]) + 3
+}
+fn g<const N: usize, T: Into<[usize; N]>>(arr: T) -> usize {
+    arr.into().into_iter().max().unwrap_or(N) + N
+}
 
-// fn call_g() -> usize {
-//     g::<3, [usize; 3]>([42, 3, 49]) + 3
-// }
-// fn g<const N: usize, T: Into<[usize; N]>>(arr: T) -> usize {
-//     arr.into().into_iter().max().unwrap_or(N) + N
-// }
+trait Foo {
+    fn const_add<const N: usize>(self) -> usize;
+}
 
-// trait Foo {
-//     fn const_add<const N: usize>(self) -> usize;
-// }
-
-// impl Foo for usize {
-//     fn const_add<const N: usize>(self) -> usize {
-//         self + N
-//     }
-// }
+impl Foo for usize {
+    fn const_add<const N: usize>(self) -> usize {
+        self + N
+    }
+}


### PR DESCRIPTION

    This commit adds a crate named `hax-lib`.

    This crate contains hax-specific helpers for Rust programs. Those
    helpers are usually no-ops when compiled normally but meaningful when
    compiled under hax.

    For now, essentially, this adds an assert and an assume macro.
