### PR TITLE
feat(macros): improve lemmas

### DIFF
--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -678,16 +678,19 @@ struct
       |> Option.map ~f:(pexpr >> f >> F.term)
     in
     let decreases = attr_term Decreases (fun t -> F.AST.Decreases (t, None)) in
+    let is_lemma = Attrs.lemma attrs in
     let prepost_bundle =
       let trivial_pre = F.term_of_lid [ "Prims"; "l_True" ] in
       let trivial_post =
-        F.mk_e_abs [ F.pat @@ F.AST.PatWild (None, []) ] trivial_pre
+        if is_lemma then trivial_pre
+        else F.mk_e_abs [ F.pat @@ F.AST.PatWild (None, []) ] trivial_pre
       in
       let pre = attr_term Requires (fun t -> F.AST.Requires (t, None)) in
       let post =
-        attr_term ~keep_last_args:1 Ensures (fun t -> F.AST.Ensures (t, None))
+        let keep_last_args = if is_lemma then 0 else 1 in
+        attr_term ~keep_last_args Ensures (fun t -> F.AST.Ensures (t, None))
       in
-      if Option.is_some pre || Option.is_some post then
+      if is_lemma || Option.is_some pre || Option.is_some post then
         Some
           ( Option.value ~default:trivial_pre pre,
             Option.value ~default:trivial_post post )
@@ -701,8 +704,14 @@ struct
     match args with
     | [] -> typ
     | _ ->
-        let effect = if Option.is_some prepost_bundle then "Pure" else "Tot" in
-        F.mk_e_app (F.term_of_lid [ "Prims"; effect ]) (typ :: args)
+        let mk namespace effect = F.term_of_lid (namespace @ [ effect ]) in
+        let prims = mk [ "Prims" ] in
+        let effect =
+          if Option.is_some prepost_bundle then
+            if is_lemma then mk [] "Lemma" else prims "Pure"
+          else prims "Tot"
+        in
+        F.mk_e_app effect (if is_lemma then args else typ :: args)
 
   let rec pitem (e : item) : [> `Item of F.AST.decl | `Comment of string ] list
       =
@@ -745,23 +754,9 @@ struct
               params
         in
         let pat = F.pat @@ F.AST.PatApp (pat, pat_args) in
-        if Attrs.lemma e.attrs then
-          let ty =
-            F.mk_e_app
-              (F.term_of_lid [ "FStar"; "Pervasives"; "Lemma" ])
-              [ pexpr body ]
-          in
-          let pat = F.pat @@ F.AST.PatAscribed (pat, (ty, None)) in
-          let admit =
-            F.mk_e_app
-              (F.term_of_lid [ "Prims"; "admit" ])
-              [ F.AST.unit_const F.dummyRange ]
-          in
-          F.decls @@ F.AST.TopLevelLet (NoLetQualifier, [ (pat, admit) ])
-        else
-          let ty = add_clauses_effect_type e.attrs (pty body.span body.typ) in
-          let pat = F.pat @@ F.AST.PatAscribed (pat, (ty, None)) in
-          F.decls @@ F.AST.TopLevelLet (NoLetQualifier, [ (pat, pexpr body) ])
+        let ty = add_clauses_effect_type e.attrs (pty body.span body.typ) in
+        let pat = F.pat @@ F.AST.PatAscribed (pat, (ty, None)) in
+        F.decls @@ F.AST.TopLevelLet (NoLetQualifier, [ (pat, pexpr body) ])
     | TyAlias { name; generics; ty } ->
         let pat =
           F.pat

--- a/tests/attributes/src/lib.rs
+++ b/tests/attributes/src/lib.rs
@@ -9,10 +9,8 @@ fn add3(x: u32, y: u32, z: u32) -> u32 {
     x + y + z
 }
 
-#[hax::lemma_statement]
-fn add3_lemma(x: u32) -> bool {
-    x <= 10 || x >= u32_max / 3 || add3(x, x, x) == x * 3
-}
+#[hax::lemma]
+fn add3_lemma(x: u32) -> Proof<{ x <= 10 || x >= u32_max / 3 || add3(x, x, x) == x * 3 }> {}
 
 #[hax::exclude]
 pub fn f<'a, T>(c: bool, x: &'a mut T, y: &'a mut T) -> &'a mut T {


### PR DESCRIPTION
Before, users were able to write lemma *statements* (that would in turn translate to lemmas in the backends), not lemmas themselves.

For instance, we could write:
```rust
#[hax::lemma_statement]
fn my_lemma(x: u32) -> bool {
    x * 2 == x + x
}
```

But from Rust's perspective, `my_lemma` was a `u32 -> bool` function, while it is extracted to `u32 -> Lemma ...` in F*.

This PR removes this type difference. Now we write:
```rust
#[hax::lemma]
fn my_lemma(x: u32) -> Proof<{ x * x == x + x }> {}
```

`Proof<*>` is a syntactic convenience, but for now, lemmas are really just unit-returning values.
This makes lemmas easy to call directly from Rust.