### PR TITLE
feat(engine/fstar): annotate records w/ types for fields disambiguation

### DIFF
--- a/engine/lib/ast_utils.ml
+++ b/engine/lib/ast_utils.ml
@@ -265,8 +265,10 @@ module Make (F : Features.T) = struct
                 ascribe
                   { e with e = App { f; args = [ ascribe arg ]; generic_args } }
             | _ ->
-                (* Ascribe the return type of a function application *)
-                if ascribe_app && is_app e.e then ascribe e else e
+                (* Ascribe the return type of a function application & constructors *)
+                if (ascribe_app && is_app e.e) || [%matches? Construct _] e.e
+                then ascribe e
+                else e
         end
       in
       o#visit_item false

--- a/engine/lib/generic_printer/generic_printer.mli
+++ b/engine/lib/generic_printer/generic_printer.mli
@@ -1,5 +1,6 @@
 module Make (F : Features.T) (View : Concrete_ident.VIEW_API) : sig
   open Generic_printer_base.Make(F)
   include API
-  class print: print_class
+
+  class print : print_class
 end

--- a/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
@@ -58,10 +58,10 @@ let build_vec: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
       Alloc.Boxed.t_Box (t_Slice u8) Alloc.Alloc.t_Global)
 
 let i (bar: t_Bar) : (t_Bar & u8) =
-  let bar:t_Bar = { bar with f_b = bar.f_b +! bar.f_a } in
-  let bar:t_Bar = { bar with f_a = h bar.f_a } in
+  let bar:t_Bar = { bar with f_b = bar.f_b +! bar.f_a } <: t_Bar in
+  let bar:t_Bar = { bar with f_a = h bar.f_a } <: t_Bar in
   let output:u8 = bar.f_a +! bar.f_b in
-  bar, output
+  bar, output <: (t_Bar & u8)
 
 type t_Pair (v_T: Type) {| _: Core.Marker.t_Sized v_T |} = {
   f_a:v_T;
@@ -101,16 +101,20 @@ let j (x: t_Bar) : (t_Bar & u8) =
   let tmp0, out:(t_Bar & u8) = i x in
   let x:t_Bar = tmp0 in
   let output:u8 = out in
-  x, output
+  x, output <: (t_Bar & u8)
 
 let index_mutation_unsize (x: t_Array u8 (sz 12)) : u8 =
   let x:t_Array u8 (sz 12) =
     Rust_primitives.Hax.update_at x
-      ({ Core.Ops.Range.f_start = sz 4; Core.Ops.Range.f_end = sz 5 })
+      ({ Core.Ops.Range.f_start = sz 4; Core.Ops.Range.f_end = sz 5 }
+        <:
+        Core.Ops.Range.t_Range usize)
       (Core.Slice.impl__copy_from_slice (x.[ {
                 Core.Ops.Range.f_start = sz 4;
                 Core.Ops.Range.f_end = sz 5
-              } ]
+              }
+              <:
+              Core.Ops.Range.t_Range usize ]
             <:
             t_Slice u8)
           (Rust_primitives.unsize (let list = [1uy; 2uy] in
@@ -150,7 +154,9 @@ let g (x: t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global))
     Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
               Core.Ops.Range.f_start = 1uy;
               Core.Ops.Range.f_end = 10uy
-            })
+            }
+            <:
+            Core.Ops.Range.t_Range u8)
         <:
         Core.Ops.Range.t_Range u8)
       x
@@ -158,13 +164,21 @@ let g (x: t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global))
           let x:t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) = x in
           let i:u8 = i in
           { x with f_a = Alloc.Vec.impl_1__push x.f_a i <: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global }
-      )
+          <:
+          t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global))
   in
   let x:t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) =
     { x with f_a = Core.Slice.impl__swap x.f_a (sz 0) (sz 1) }
+    <:
+    t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
   in
   let x:t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) =
-    { x with f_b = { x.f_b with f_field = Core.Slice.impl__swap x.f_b.f_field (sz 0) (sz 1) } }
+    {
+      x with
+      f_b = { x.f_b with f_field = Core.Slice.impl__swap x.f_b.f_field (sz 0) (sz 1) } <: t_Foo
+    }
+    <:
+    t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
   in
   x.f_a
 
@@ -173,7 +187,9 @@ let foo (lhs rhs: t_S) : t_S =
     Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
               Core.Ops.Range.f_start = sz 0;
               Core.Ops.Range.f_end = sz 1
-            })
+            }
+            <:
+            Core.Ops.Range.t_Range usize)
         <:
         Core.Ops.Range.t_Range usize)
       lhs
@@ -189,7 +205,9 @@ let foo (lhs rhs: t_S) : t_S =
               ((lhs.f_b.[ i ] <: u8) +! (rhs.f_b.[ i ] <: u8) <: u8)
             <:
             t_Array u8 (sz 5)
-          })
+          }
+          <:
+          t_S)
   in
   lhs
 
@@ -208,5 +226,5 @@ let array (x: t_Array u8 (sz 10)) : t_Array u8 (sz 10) =
 let impl_FooTrait_for_Foo: t_FooTrait t_Foo = { f_z = fun (self: t_Foo) -> self }
 
 let impl__S__update (self: t_S) (x: u8) : t_S =
-  let self:t_S = { self with f_b = Rust_primitives.Hax.update_at self.f_b (sz 0) x } in
+  let self:t_S = { self with f_b = Rust_primitives.Hax.update_at self.f_b (sz 0) x } <: t_S in
   self'''

--- a/test-harness/src/snapshots/toolchain__naming into-coq.snap
+++ b/test-harness/src/snapshots/toolchain__naming into-coq.snap
@@ -67,6 +67,24 @@ Record t_Foobar : Type :={
 Definition ff__g__impl_1__g (self : t_Foo_t) : uint_size :=
   (@repr WORDSIZE32 1).
 
+Record t_StructA : Type :={
+  f_a : uint_size;
+}.
+
+Record t_StructB : Type :={
+  f_b : uint_size;
+  f_a : uint_size;
+}.
+
+Record t_StructC : Type :={
+  f_a : uint_size;
+}.
+
+Record t_StructD : Type :={
+  f_b : uint_size;
+  f_a : uint_size;
+}.
+
 Class t_T3_e_for_a Self := {
 }.
 
@@ -105,6 +123,13 @@ Definition ff__g : unit :=
 
 Definition f (x : t_Foobar_t) : uint_size :=
   ff__g__impl_1__g (f_a x).
+
+Definition construct_structs (a : uint_size) (b : uint_size) : unit :=
+  let _ := (Build_StructA a) : t_StructA_t in
+  let _ := (Build_StructB ab) : t_StructB_t in
+  let _ := (Build_StructC a) : t_StructC_t in
+  let _ := (Build_StructD ab) : t_StructD_t in
+  tt.
 
 (*Not implemented yet? todo(item)*)
 

--- a/test-harness/src/snapshots/toolchain__naming into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__naming into-fstar.snap
@@ -49,6 +49,20 @@ type t_Foobar = { f_a:t_Foo }
 
 let ff__g__impl_1__g (self: t_Foo) : usize = sz 1
 
+type t_StructA = { f_a:usize }
+
+type t_StructB = {
+  f_a:usize;
+  f_b:usize
+}
+
+type t_StructC = { f_a:usize }
+
+type t_StructD = {
+  f_a:usize;
+  f_b:usize
+}
+
 class t_T3_e_for_a (v_Self: Type) = { __marker_trait_t_T3_e_for_a:Prims.unit }
 
 type t_Arity1 (v_T: Type) {| _: Core.Marker.t_Sized v_T |} = | Arity1 : v_T -> t_Arity1 v_T
@@ -60,9 +74,9 @@ class t_T1 (v_Self: Type) = { __marker_trait_t_T1:Prims.unit }
 let reserved_names (v_val v_noeq v_of: u8) : u8 = (v_val +! v_noeq <: u8) +! v_of
 
 let mk_c: t_C =
-  let _:t_Foo = Foo_B ({ Naming.Foo.f_x = sz 3 }) in
-  let _:t_X = X in
-  { f_x = sz 3 }
+  let _:t_Foo = Foo_B ({ Naming.Foo.f_x = sz 3 }) <: t_Foo in
+  let _:t_X = X <: t_X in
+  { f_x = sz 3 } <: t_C
 
 type t_f__g__impl__g__Foo =
   | C_f__g__impl__g__Foo_A : t_f__g__impl__g__Foo
@@ -73,6 +87,13 @@ let ff__g__impl__g (self: t_B) : usize = sz 0
 let ff__g: Prims.unit = ()
 
 let f (x: t_Foobar) : usize = ff__g__impl_1__g x.f_a
+
+let construct_structs (a b: usize) : Prims.unit =
+  let _:t_StructA = { f_a = a } <: t_StructA in
+  let _:t_StructB = { f_a = a; f_b = b } <: t_StructB in
+  let _:t_StructC = { f_a = a } <: t_StructC in
+  let _:t_StructD = { f_a = a; f_b = b } <: t_StructD in
+  ()
 
 type t_Foo2 =
   | Foo2_A : t_Foo2
@@ -87,6 +108,6 @@ let impl_T1_for_tuple_Foo_u8: t_T1 (t_Foo & u8) = { __marker_trait = () }
 
 let impl_T1_for_Foo: t_T1 t_Foo = { __marker_trait = () }
 
-let impl__B__f (self: t_B) : t_B = B
+let impl__B__f (self: t_B) : t_B = B <: t_B
 
-let impl__Foo__f (self: t_Foo) : t_Foo = Foo_A'''
+let impl__Foo__f (self: t_Foo) : t_Foo = Foo_A <: t_Foo'''

--- a/test-harness/src/snapshots/toolchain__reordering into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__reordering into-fstar.snap
@@ -35,6 +35,6 @@ type t_Foo =
 
 type t_Bar = | Bar : t_Foo -> t_Bar
 
-let f (_: u32) : t_Foo = Foo_A
+let f (_: u32) : t_Foo = Foo_A <: t_Foo
 
-let g: t_Bar = Bar (f 32ul)'''
+let g: t_Bar = Bar (f 32ul) <: t_Bar'''

--- a/tests/naming/src/lib.rs
+++ b/tests/naming/src/lib.rs
@@ -75,3 +75,24 @@ trait T2_for_a {}
 impl T2_for_a for Arity1<(Foo, u8)> {}
 trait T3_e_for_a {}
 impl T3_e_for_a for Foo {}
+
+struct StructA {
+    a: usize,
+}
+struct StructB {
+    a: usize,
+    b: usize,
+}
+struct StructC {
+    a: usize,
+}
+struct StructD {
+    a: usize,
+    b: usize,
+}
+fn construct_structs(a: usize, b: usize) {
+    let _ = StructA { a };
+    let _ = StructB { a, b };
+    let _ = StructC { a };
+    let _ = StructD { a, b };
+}


### PR DESCRIPTION
This commit disambiguates record fields by adding type information.

If two record types share some fields, F* just picks the record type that was defined last. This is not fine, thus we add type ascriptions so that F* picks the right type.