### PR TITLE
fix(engine/fstar): mark `impl`s as F* instances (with an attribute)

### DIFF
--- a/engine/backends/fstar/fstar_ast.ml
+++ b/engine/backends/fstar/fstar_ast.ml
@@ -21,10 +21,10 @@ let lid_of_id id = Ident.lid_of_ids [ id ]
 let term (tm : AST.term') = AST.{ tm; range = dummyRange; level = Expr }
 let generate_fresh_ident () = Ident.gen dummyRange
 
-let decl ?(quals = []) (d : AST.decl') =
-  `Item AST.{ d; drange = dummyRange; quals = []; attrs = [] }
+let decl ?(quals = []) ?(attrs = []) (d : AST.decl') =
+  `Item AST.{ d; drange = dummyRange; quals; attrs }
 
-let decls ?(quals = []) x = [ decl ~quals x ]
+let decls ?(quals = []) ?(attrs = []) x = [ decl ~quals ~attrs x ]
 let pat (pat : AST.pattern') = AST.{ pat; prange = dummyRange }
 
 module Attrs = struct

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -1067,7 +1067,7 @@ struct
         in
         let body = F.term @@ F.AST.Record (None, fields) in
         let tcinst = F.term @@ F.AST.Var FStar_Parser_Const.tcinstance_lid in
-        F.decls ~quals:[ tcinst ]
+        F.decls ~attrs:[ tcinst ]
         @@ F.AST.TopLevelLet (NoLetQualifier, [ (pat, body) ])
     | HaxError details ->
         [

--- a/examples/chacha20/proofs/fstar/extraction/Chacha20.Hacspec_helper.fst
+++ b/examples/chacha20/proofs/fstar/extraction/Chacha20.Hacspec_helper.fst
@@ -25,6 +25,53 @@ let add_state (state other: t_Array u32 (sz 16)) : t_Array u32 (sz 16) =
   in
   state
 
+let update_array (array: t_Array u8 (sz 64)) (v_val: t_Slice u8) : t_Array u8 (sz 64) =
+  let _:Prims.unit =
+    if ~.(sz 64 >=. (Core.Slice.impl__len v_val <: usize) <: bool)
+    then
+      Rust_primitives.Hax.never_to_any (Core.Panicking.panic "assertion failed: 64 >= val.len()"
+          <:
+          Rust_primitives.Hax.t_Never)
+  in
+  let array:t_Array u8 (sz 64) =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+              Core.Ops.Range.f_start = sz 0;
+              Core.Ops.Range.f_end = Core.Slice.impl__len v_val <: usize
+            }
+            <:
+            Core.Ops.Range.t_Range usize)
+        <:
+        Core.Ops.Range.t_Range usize)
+      array
+      (fun array i ->
+          let array:t_Array u8 (sz 64) = array in
+          let i:usize = i in
+          Rust_primitives.Hax.update_at array i (v_val.[ i ] <: u8) <: t_Array u8 (sz 64))
+  in
+  array
+
+let xor_state (state other: t_Array u32 (sz 16)) : t_Array u32 (sz 16) =
+  let state:t_Array u32 (sz 16) =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+              Core.Ops.Range.f_start = sz 0;
+              Core.Ops.Range.f_end = sz 16
+            }
+            <:
+            Core.Ops.Range.t_Range usize)
+        <:
+        Core.Ops.Range.t_Range usize)
+      state
+      (fun state i ->
+          let state:t_Array u32 (sz 16) = state in
+          let i:usize = i in
+          Rust_primitives.Hax.update_at state
+            i
+            ((state.[ i ] <: u32) ^. (other.[ i ] <: u32) <: u32)
+          <:
+          t_Array u32 (sz 16))
+  in
+  state
+
 let to_le_u32s_16_ (bytes: t_Slice u8) : t_Array u32 (sz 16) =
   let out:t_Array u32 (sz 16) = Rust_primitives.Hax.repeat 0ul (sz 16) in
   let out:t_Array u32 (sz 16) =
@@ -61,91 +108,6 @@ let to_le_u32s_16_ (bytes: t_Slice u8) : t_Array u32 (sz 16) =
           t_Array u32 (sz 16))
   in
   out
-
-let u32s_to_le_bytes (state: t_Array u32 (sz 16)) : t_Array u8 (sz 64) =
-  let out:t_Array u8 (sz 64) = Rust_primitives.Hax.repeat 0uy (sz 64) in
-  let out:t_Array u8 (sz 64) =
-    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
-              Core.Ops.Range.f_start = sz 0;
-              Core.Ops.Range.f_end
-              =
-              Core.Slice.impl__len (Rust_primitives.unsize state <: t_Slice u32) <: usize
-            }
-            <:
-            Core.Ops.Range.t_Range usize)
-        <:
-        Core.Ops.Range.t_Range usize)
-      out
-      (fun out i ->
-          let out:t_Array u8 (sz 64) = out in
-          let i:usize = i in
-          let tmp:t_Array u8 (sz 4) = Core.Num.impl__u32__to_le_bytes (state.[ i ] <: u32) in
-          Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
-                    Core.Ops.Range.f_start = sz 0;
-                    Core.Ops.Range.f_end = sz 4
-                  }
-                  <:
-                  Core.Ops.Range.t_Range usize)
-              <:
-              Core.Ops.Range.t_Range usize)
-            out
-            (fun out j ->
-                let out:t_Array u8 (sz 64) = out in
-                let j:usize = j in
-                Rust_primitives.Hax.update_at out
-                  ((i *! sz 4 <: usize) +! j <: usize)
-                  (tmp.[ j ] <: u8)
-                <:
-                t_Array u8 (sz 64)))
-  in
-  out
-
-let xor_state (state other: t_Array u32 (sz 16)) : t_Array u32 (sz 16) =
-  let state:t_Array u32 (sz 16) =
-    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
-              Core.Ops.Range.f_start = sz 0;
-              Core.Ops.Range.f_end = sz 16
-            }
-            <:
-            Core.Ops.Range.t_Range usize)
-        <:
-        Core.Ops.Range.t_Range usize)
-      state
-      (fun state i ->
-          let state:t_Array u32 (sz 16) = state in
-          let i:usize = i in
-          Rust_primitives.Hax.update_at state
-            i
-            ((state.[ i ] <: u32) ^. (other.[ i ] <: u32) <: u32)
-          <:
-          t_Array u32 (sz 16))
-  in
-  state
-
-let update_array (array: t_Array u8 (sz 64)) (v_val: t_Slice u8) : t_Array u8 (sz 64) =
-  let _:Prims.unit =
-    if ~.(sz 64 >=. (Core.Slice.impl__len v_val <: usize) <: bool)
-    then
-      Rust_primitives.Hax.never_to_any (Core.Panicking.panic "assertion failed: 64 >= val.len()"
-          <:
-          Rust_primitives.Hax.t_Never)
-  in
-  let array:t_Array u8 (sz 64) =
-    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
-              Core.Ops.Range.f_start = sz 0;
-              Core.Ops.Range.f_end = Core.Slice.impl__len v_val <: usize
-            }
-            <:
-            Core.Ops.Range.t_Range usize)
-        <:
-        Core.Ops.Range.t_Range usize)
-      array
-      (fun array i ->
-          let array:t_Array u8 (sz 64) = array in
-          let i:usize = i in
-          Rust_primitives.Hax.update_at array i (v_val.[ i ] <: u8) <: t_Array u8 (sz 64))
-  in
-  array
 
 let to_le_u32s_3_ (bytes: t_Slice u8) : t_Array u32 (sz 3) =
   let out:t_Array u32 (sz 3) = Rust_primitives.Hax.repeat 0ul (sz 3) in
@@ -218,5 +180,43 @@ let to_le_u32s_8_ (bytes: t_Slice u8) : t_Array u32 (sz 8) =
               u32)
           <:
           t_Array u32 (sz 8))
+  in
+  out
+
+let u32s_to_le_bytes (state: t_Array u32 (sz 16)) : t_Array u8 (sz 64) =
+  let out:t_Array u8 (sz 64) = Rust_primitives.Hax.repeat 0uy (sz 64) in
+  let out:t_Array u8 (sz 64) =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+              Core.Ops.Range.f_start = sz 0;
+              Core.Ops.Range.f_end
+              =
+              Core.Slice.impl__len (Rust_primitives.unsize state <: t_Slice u32) <: usize
+            }
+            <:
+            Core.Ops.Range.t_Range usize)
+        <:
+        Core.Ops.Range.t_Range usize)
+      out
+      (fun out i ->
+          let out:t_Array u8 (sz 64) = out in
+          let i:usize = i in
+          let tmp:t_Array u8 (sz 4) = Core.Num.impl__u32__to_le_bytes (state.[ i ] <: u32) in
+          Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+                    Core.Ops.Range.f_start = sz 0;
+                    Core.Ops.Range.f_end = sz 4
+                  }
+                  <:
+                  Core.Ops.Range.t_Range usize)
+              <:
+              Core.Ops.Range.t_Range usize)
+            out
+            (fun out j ->
+                let out:t_Array u8 (sz 64) = out in
+                let j:usize = j in
+                Rust_primitives.Hax.update_at out
+                  ((i *! sz 4 <: usize) +! j <: usize)
+                  (tmp.[ j ] <: u8)
+                <:
+                t_Array u8 (sz 64)))
   in
   out

--- a/examples/chacha20/proofs/fstar/extraction/Chacha20.fst
+++ b/examples/chacha20/proofs/fstar/extraction/Chacha20.fst
@@ -3,6 +3,14 @@ module Chacha20
 open Core
 open FStar.Mul
 
+let t_Block = t_Array u8 (sz 64)
+
+let t_ChaChaIV = t_Array u8 (sz 12)
+
+let t_ChaChaKey = t_Array u8 (sz 32)
+
+let t_State = t_Array u32 (sz 16)
+
 let chacha20_line (a b d: usize) (s: u32) (m: t_Array u32 (sz 16))
     : Prims.Pure (t_Array u32 (sz 16))
       (requires a <. sz 16 && b <. sz 16 && d <. sz 16)
@@ -118,6 +126,10 @@ let chacha20_key_block (state: t_Array u32 (sz 16)) : t_Array u8 (sz 64) =
   let state:t_Array u32 (sz 16) = chacha20_core 0ul state in
   Chacha20.Hacspec_helper.u32s_to_le_bytes state
 
+let chacha20_key_block0 (key: t_Array u8 (sz 32)) (iv: t_Array u8 (sz 12)) : t_Array u8 (sz 64) =
+  let state:t_Array u32 (sz 16) = chacha20_init key iv 0ul in
+  chacha20_key_block state
+
 let chacha20_update (st0: t_Array u32 (sz 16)) (m: t_Slice u8)
     : Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
   let blocks_out:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global = Alloc.Vec.impl__new in
@@ -182,19 +194,7 @@ let chacha20_update (st0: t_Array u32 (sz 16)) (m: t_Slice u8)
   in
   blocks_out
 
-let chacha20_key_block0 (key: t_Array u8 (sz 32)) (iv: t_Array u8 (sz 12)) : t_Array u8 (sz 64) =
-  let state:t_Array u32 (sz 16) = chacha20_init key iv 0ul in
-  chacha20_key_block state
-
 let chacha20 (m: t_Slice u8) (key: t_Array u8 (sz 32)) (iv: t_Array u8 (sz 12)) (ctr: u32)
     : Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
   let state:t_Array u32 (sz 16) = chacha20_init key iv ctr in
   chacha20_update state m
-
-let t_State = t_Array u32 (sz 16)
-
-let t_ChaChaKey = t_Array u8 (sz 32)
-
-let t_ChaChaIV = t_Array u8 (sz 12)
-
-let t_Block = t_Array u8 (sz 64)

--- a/examples/limited-order-book/proofs/fstar/extraction/Lob_backend.fst
+++ b/examples/limited-order-book/proofs/fstar/extraction/Lob_backend.fst
@@ -1,17 +1,11 @@
 module Lob_backend
 #set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
 open Core
+open FStar.Mul
 
 type t_Side =
   | Side_Buy : t_Side
   | Side_Sell : t_Side
-
-type t_Order = {
-  f_id:u64;
-  f_side:t_Side;
-  f_price:u64;
-  f_quantity:u64
-}
 
 type t_Match = {
   f_bid_id:u64;
@@ -20,21 +14,34 @@ type t_Match = {
   f_quantity:u64
 }
 
+type t_Order = {
+  f_id:u64;
+  f_side:t_Side;
+  f_price:u64;
+  f_quantity:u64
+}
+
 let is_match (order other: t_Order) : bool =
   order.f_quantity >. 0uL && other.f_quantity >. 0uL && order.f_side <>. other.f_side &&
-  (order.f_side =. Side_Buy && order.f_price >=. other.f_price ||
-  order.f_side =. Side_Sell && order.f_price <=. other.f_price)
+  (order.f_side =. (Side_Buy <: t_Side) && order.f_price >=. other.f_price ||
+  order.f_side =. (Side_Sell <: t_Side) && order.f_price <=. other.f_price)
 
 let impl__Order__try_match (self other: t_Order) : Core.Option.t_Option t_Match =
   if is_match self other
   then
     let quantity:u64 = Core.Cmp.min self.f_quantity other.f_quantity in
     let bid_id, ask_id:(u64 & u64) =
-      if self.f_side =. Side_Buy then self.f_id, other.f_id else other.f_id, self.f_id
+      if self.f_side =. (Side_Buy <: t_Side)
+      then self.f_id, other.f_id <: (u64 & u64)
+      else other.f_id, self.f_id <: (u64 & u64)
     in
     Core.Option.Option_Some
-    ({ f_bid_id = bid_id; f_ask_id = ask_id; f_price = self.f_price; f_quantity = quantity })
-  else Core.Option.Option_None
+    ({ f_bid_id = bid_id; f_ask_id = ask_id; f_price = self.f_price; f_quantity = quantity }
+      <:
+      t_Match)
+    <:
+    Core.Option.t_Option t_Match
+  else Core.Option.Option_None <: Core.Option.t_Option t_Match
 
 let process_order
       (#v_T: Type)
@@ -55,23 +62,30 @@ let process_order
     Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
               Core.Ops.Range.f_start = sz 1;
               Core.Ops.Range.f_end = Alloc.Collections.Binary_heap.impl_10__len other_side <: usize
-            })
+            }
+            <:
+            Core.Ops.Range.t_Range usize)
         <:
         Core.Ops.Range.t_Range usize)
-      (done, matches, order, other_side)
-      (fun
-          (done, matches, order, other_side:
-            (bool & Alloc.Vec.t_Vec t_Match Alloc.Alloc.t_Global & t_Order &
-              Alloc.Collections.Binary_heap.t_BinaryHeap v_T))
-          (v__i: usize)
-          ->
+      (done, matches, order, other_side
+        <:
+        (bool & Alloc.Vec.t_Vec t_Match Alloc.Alloc.t_Global & t_Order &
+          Alloc.Collections.Binary_heap.t_BinaryHeap v_T))
+      (fun temp_0_ v__i ->
+          let done, matches, order, other_side:(bool & Alloc.Vec.t_Vec t_Match Alloc.Alloc.t_Global &
+            t_Order &
+            Alloc.Collections.Binary_heap.t_BinaryHeap v_T) =
+            temp_0_
+          in
+          let v__i:usize = v__i in
           if ~.done <: bool
           then
             match
               Core.Option.impl__and_then (Alloc.Collections.Binary_heap.impl_10__peek other_side
                   <:
                   Core.Option.t_Option v_T)
-                (fun (other: v_T) ->
+                (fun other ->
+                    let other:v_T = other in
                     impl__Order__try_match (Core.Convert.f_into (Core.Clone.f_clone other <: v_T)
                         <:
                         t_Order)
@@ -82,7 +96,9 @@ let process_order
               Core.Option.t_Option t_Match
             with
             | Core.Option.Option_Some m ->
-              let order:t_Order = { order with f_quantity = order.f_quantity -! m.f_quantity } in
+              let order:t_Order =
+                { order with f_quantity = order.f_quantity -! m.f_quantity } <: t_Order
+              in
               let tmp0, out:(Alloc.Collections.Binary_heap.t_BinaryHeap v_T &
                 Core.Option.t_Option v_T) =
                 Alloc.Collections.Binary_heap.impl_9__pop other_side
@@ -91,7 +107,9 @@ let process_order
               let hoist1:Core.Option.t_Option v_T = out in
               let hoist2:v_T = Core.Option.impl__unwrap hoist1 in
               let (other: t_Order):t_Order = Core.Convert.f_into hoist2 in
-              let other:t_Order = { other with f_quantity = other.f_quantity -! m.f_quantity } in
+              let other:t_Order =
+                { other with f_quantity = other.f_quantity -! m.f_quantity } <: t_Order
+              in
               let other_side:Alloc.Collections.Binary_heap.t_BinaryHeap v_T =
                 if other.f_quantity >. 0uL
                 then
@@ -106,13 +124,30 @@ let process_order
                 Alloc.Vec.impl_1__push matches m
               in
               done, matches, order, other_side
+              <:
+              (bool & Alloc.Vec.t_Vec t_Match Alloc.Alloc.t_Global & t_Order &
+                Alloc.Collections.Binary_heap.t_BinaryHeap v_T)
             | _ ->
               let done:bool = true in
               done, matches, order, other_side
-          else done, matches, order, other_side)
+              <:
+              (bool & Alloc.Vec.t_Vec t_Match Alloc.Alloc.t_Global & t_Order &
+                Alloc.Collections.Binary_heap.t_BinaryHeap v_T)
+          else
+            done, matches, order, other_side
+            <:
+            (bool & Alloc.Vec.t_Vec t_Match Alloc.Alloc.t_Global & t_Order &
+              Alloc.Collections.Binary_heap.t_BinaryHeap v_T))
   in
   let output:(Alloc.Vec.t_Vec t_Match Alloc.Alloc.t_Global & Core.Option.t_Option t_Order) =
     matches,
-    (if order.f_quantity >. 0uL then Core.Option.Option_Some order else Core.Option.Option_None)
+    (if order.f_quantity >. 0uL
+      then Core.Option.Option_Some order <: Core.Option.t_Option t_Order
+      else Core.Option.Option_None <: Core.Option.t_Option t_Order)
+    <:
+    (Alloc.Vec.t_Vec t_Match Alloc.Alloc.t_Global & Core.Option.t_Option t_Order)
   in
   other_side, output
+  <:
+  (Alloc.Collections.Binary_heap.t_BinaryHeap v_T &
+    (Alloc.Vec.t_Vec t_Match Alloc.Alloc.t_Global & Core.Option.t_Option t_Order))

--- a/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
@@ -38,16 +38,23 @@ module Mut_ref_functionalization
 open Core
 open FStar.Mul
 
-type t_Bar = {
-  f_a:u8;
-  f_b:u8
-}
+class t_FooTrait (v_Self: Type) = { f_z:v_Self -> v_Self }
+
+let array (x: t_Array u8 (sz 10)) : t_Array u8 (sz 10) =
+  let x:t_Array u8 (sz 10) = Rust_primitives.Hax.update_at x (sz 1) (x.[ sz 2 ] <: u8) in
+  x
+
+let f: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
+  let vec:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global = Alloc.Vec.impl__new in
+  let vec:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global = Alloc.Vec.impl_1__push vec 1uy in
+  let vec:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global = Alloc.Vec.impl_1__push vec 2uy in
+  let vec:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global = Core.Slice.impl__swap vec (sz 0) (sz 1) in
+  let vec:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global = Core.Slice.impl__swap vec (sz 0) (sz 1) in
+  vec
 
 let h (x: u8) : u8 =
   let x:u8 = x +! 10uy in
   x
-
-type t_Foo = { f_field:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global }
 
 let build_vec: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
   Alloc.Slice.impl__into_vec (Rust_primitives.unsize (Rust_primitives.Hax.box_new (let list =
@@ -60,20 +67,49 @@ let build_vec: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
       <:
       Alloc.Boxed.t_Box (t_Slice u8) Alloc.Alloc.t_Global)
 
-let i (bar: t_Bar) : (t_Bar & u8) =
-  let bar:t_Bar = { bar with f_b = bar.f_b +! bar.f_a } <: t_Bar in
-  let bar:t_Bar = { bar with f_a = h bar.f_a } <: t_Bar in
-  let output:u8 = bar.f_a +! bar.f_b in
-  bar, output <: (t_Bar & u8)
+let index_mutation (x: Core.Ops.Range.t_Range usize) (a: t_Slice u8) : Prims.unit =
+  let v:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
+    Alloc.Slice.impl__into_vec (Rust_primitives.unsize (Rust_primitives.Hax.box_new (let list =
+                  [1uy]
+                in
+                FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 1);
+                Rust_primitives.Hax.array_of_list list)
+            <:
+            Alloc.Boxed.t_Box (t_Array u8 (sz 1)) Alloc.Alloc.t_Global)
+        <:
+        Alloc.Boxed.t_Box (t_Slice u8) Alloc.Alloc.t_Global)
+  in
+  let v:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
+    Rust_primitives.Hax.update_at v
+      x
+      (Core.Slice.impl__copy_from_slice (v.[ x ] <: t_Slice u8) a <: t_Slice u8)
+  in
+  let v:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global = Rust_primitives.Hax.update_at v (sz 1) 3uy in
+  ()
 
-type t_Pair (v_T: Type) {| _: Core.Marker.t_Sized v_T |} = {
-  f_a:v_T;
-  f_b:t_Foo
-}
-
-type t_S = { f_b:t_Array u8 (sz 5) }
-
-class t_FooTrait (v_Self: Type) = { f_z:v_Self -> v_Self }
+let index_mutation_unsize (x: t_Array u8 (sz 12)) : u8 =
+  let x:t_Array u8 (sz 12) =
+    Rust_primitives.Hax.update_at x
+      ({ Core.Ops.Range.f_start = sz 4; Core.Ops.Range.f_end = sz 5 }
+        <:
+        Core.Ops.Range.t_Range usize)
+      (Core.Slice.impl__copy_from_slice (x.[ {
+                Core.Ops.Range.f_start = sz 4;
+                Core.Ops.Range.f_end = sz 5
+              }
+              <:
+              Core.Ops.Range.t_Range usize ]
+            <:
+            t_Slice u8)
+          (Rust_primitives.unsize (let list = [1uy; 2uy] in
+                FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
+                Rust_primitives.Hax.array_of_list list)
+            <:
+            t_Slice u8)
+        <:
+        t_Slice u8)
+  in
+  42uy
 
 let test_append: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
   let vec1:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global = Alloc.Vec.impl__new in
@@ -100,55 +136,66 @@ let test_append: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
   in
   vec1
 
+type t_Bar = {
+  f_a:u8;
+  f_b:u8
+}
+
+type t_Foo = { f_field:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global }
+
+let impl_FooTrait_for_Foo: t_FooTrait t_Foo = { f_z = fun (self: t_Foo) -> self }
+
+type t_S = { f_b:t_Array u8 (sz 5) }
+
+let impl__S__update (self: t_S) (x: u8) : t_S =
+  let self:t_S = { self with f_b = Rust_primitives.Hax.update_at self.f_b (sz 0) x } <: t_S in
+  self
+
+let foo (lhs rhs: t_S) : t_S =
+  let lhs:t_S =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+              Core.Ops.Range.f_start = sz 0;
+              Core.Ops.Range.f_end = sz 1
+            }
+            <:
+            Core.Ops.Range.t_Range usize)
+        <:
+        Core.Ops.Range.t_Range usize)
+      lhs
+      (fun lhs i ->
+          let lhs:t_S = lhs in
+          let i:usize = i in
+          {
+            lhs with
+            f_b
+            =
+            Rust_primitives.Hax.update_at lhs.f_b
+              i
+              ((lhs.f_b.[ i ] <: u8) +! (rhs.f_b.[ i ] <: u8) <: u8)
+            <:
+            t_Array u8 (sz 5)
+          }
+          <:
+          t_S)
+  in
+  lhs
+
+let i (bar: t_Bar) : (t_Bar & u8) =
+  let bar:t_Bar = { bar with f_b = bar.f_b +! bar.f_a } <: t_Bar in
+  let bar:t_Bar = { bar with f_a = h bar.f_a } <: t_Bar in
+  let output:u8 = bar.f_a +! bar.f_b in
+  bar, output <: (t_Bar & u8)
+
 let j (x: t_Bar) : (t_Bar & u8) =
   let tmp0, out:(t_Bar & u8) = i x in
   let x:t_Bar = tmp0 in
   let output:u8 = out in
   x, output <: (t_Bar & u8)
 
-let index_mutation_unsize (x: t_Array u8 (sz 12)) : u8 =
-  let x:t_Array u8 (sz 12) =
-    Rust_primitives.Hax.update_at x
-      ({ Core.Ops.Range.f_start = sz 4; Core.Ops.Range.f_end = sz 5 }
-        <:
-        Core.Ops.Range.t_Range usize)
-      (Core.Slice.impl__copy_from_slice (x.[ {
-                Core.Ops.Range.f_start = sz 4;
-                Core.Ops.Range.f_end = sz 5
-              }
-              <:
-              Core.Ops.Range.t_Range usize ]
-            <:
-            t_Slice u8)
-          (Rust_primitives.unsize (let list = [1uy; 2uy] in
-                FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
-                Rust_primitives.Hax.array_of_list list)
-            <:
-            t_Slice u8)
-        <:
-        t_Slice u8)
-  in
-  42uy
-
-let index_mutation (x: Core.Ops.Range.t_Range usize) (a: t_Slice u8) : Prims.unit =
-  let v:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
-    Alloc.Slice.impl__into_vec (Rust_primitives.unsize (Rust_primitives.Hax.box_new (let list =
-                  [1uy]
-                in
-                FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 1);
-                Rust_primitives.Hax.array_of_list list)
-            <:
-            Alloc.Boxed.t_Box (t_Array u8 (sz 1)) Alloc.Alloc.t_Global)
-        <:
-        Alloc.Boxed.t_Box (t_Slice u8) Alloc.Alloc.t_Global)
-  in
-  let v:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
-    Rust_primitives.Hax.update_at v
-      x
-      (Core.Slice.impl__copy_from_slice (v.[ x ] <: t_Slice u8) a <: t_Slice u8)
-  in
-  let v:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global = Rust_primitives.Hax.update_at v (sz 1) 3uy in
-  ()
+type t_Pair (v_T: Type) {| _: Core.Marker.t_Sized v_T |} = {
+  f_a:v_T;
+  f_b:t_Foo
+}
 
 let g (x: t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global))
     : Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
@@ -184,51 +231,4 @@ let g (x: t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global))
     t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global)
   in
   x.f_a
-
-let foo (lhs rhs: t_S) : t_S =
-  let lhs:t_S =
-    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
-              Core.Ops.Range.f_start = sz 0;
-              Core.Ops.Range.f_end = sz 1
-            }
-            <:
-            Core.Ops.Range.t_Range usize)
-        <:
-        Core.Ops.Range.t_Range usize)
-      lhs
-      (fun lhs i ->
-          let lhs:t_S = lhs in
-          let i:usize = i in
-          {
-            lhs with
-            f_b
-            =
-            Rust_primitives.Hax.update_at lhs.f_b
-              i
-              ((lhs.f_b.[ i ] <: u8) +! (rhs.f_b.[ i ] <: u8) <: u8)
-            <:
-            t_Array u8 (sz 5)
-          }
-          <:
-          t_S)
-  in
-  lhs
-
-let f: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
-  let vec:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global = Alloc.Vec.impl__new in
-  let vec:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global = Alloc.Vec.impl_1__push vec 1uy in
-  let vec:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global = Alloc.Vec.impl_1__push vec 2uy in
-  let vec:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global = Core.Slice.impl__swap vec (sz 0) (sz 1) in
-  let vec:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global = Core.Slice.impl__swap vec (sz 0) (sz 1) in
-  vec
-
-let array (x: t_Array u8 (sz 10)) : t_Array u8 (sz 10) =
-  let x:t_Array u8 (sz 10) = Rust_primitives.Hax.update_at x (sz 1) (x.[ sz 2 ] <: u8) in
-  x
-
-let impl_FooTrait_for_Foo: t_FooTrait t_Foo = { f_z = fun (self: t_Foo) -> self }
-
-let impl__S__update (self: t_S) (x: u8) : t_S =
-  let self:t_S = { self with f_b = Rust_primitives.Hax.update_at self.f_b (sz 0) x } <: t_S in
-  self
 '''

--- a/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
@@ -143,6 +143,7 @@ type t_Bar = {
 
 type t_Foo = { f_field:Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global }
 
+[@@ FStar.Tactics.Typeclasses.tcinstance]
 let impl_FooTrait_for_Foo: t_FooTrait t_Foo = { f_z = fun (self: t_Foo) -> self }
 
 type t_S = { f_b:t_Array u8 (sz 5) }

--- a/test-harness/src/snapshots/toolchain__naming into-coq.snap
+++ b/test-harness/src/snapshots/toolchain__naming into-coq.snap
@@ -50,22 +50,74 @@ Inductive t_Foo : Type :=
 | Foo_At_Foo
 | Foo_B : Foo_B -> t_Foo.
 
-Record t_C : Type :={
+Definition impl__Foo__f (self : t_Foo_t) : t_Foo_t :=
+  Foo_At_Foo_t.
+
+Record Foo2_B : Type :={
   f_x : uint_size;
 }.
+Inductive t_Foo2 : Type :=
+| Foo2_At_Foo2
+| Foo2_B : Foo2_B -> t_Foo2.
 
-Record t_X : Type :={
+Class t_T1 Self := {
+}.
+
+Instance t_Foo_t_t_T1 : t_T1 t_Foo_t := {
+}.
+
+Instance (t_Foo_t × int8)_t_T1 : t_T1 (t_Foo_t × int8) := {
+}.
+
+Class t_T2_for_a Self := {
+}.
+
+Class t_T3_e_for_a Self := {
+}.
+
+Instance t_Foo_t_t_T3_e_for_a : t_T3_e_for_a t_Foo_t := {
+}.
+
+(*Not implemented yet? todo(item)*)
+
+Definition ff__g : unit :=
+  tt.
+
+Record C_f__g__impl__g__Foo_B : Type :={
+  f_x : uint_size;
+}.
+Inductive t_f__g__impl__g__Foo : Type :=
+| C_f__g__impl__g__Foo_At_f__g__impl__g__Foo
+| C_f__g__impl__g__Foo_B : C_f__g__impl__g__Foo_B -> t_f__g__impl__g__Foo.
+
+Definition ff__g__impl_1__g (self : t_Foo_t) : uint_size :=
+  (@repr WORDSIZE32 1).
+
+(*Not implemented yet? todo(item)*)
+
+Definition reserved_names (val : int8) (noeq : int8) (of : int8) : int8 :=
+  (val.+noeq).+of.
+
+Record t_Arity1 : Type :={
+  0 : T;
+}.
+
+Instance t_Arity1_t (t_Foo_t × int8)_t_T2_for_a : t_T2_for_a t_Arity1_t (t_Foo_t × int8) := {
 }.
 
 Record t_B : Type :={
 }.
 
+Definition impl__B__f (self : t_B_t) : t_B_t :=
+  Bt_B_t.
+
+Record t_C : Type :={
+  f_x : uint_size;
+}.
+
 Record t_Foobar : Type :={
   f_a : t_Foo_t;
 }.
-
-Definition ff__g__impl_1__g (self : t_Foo_t) : uint_size :=
-  (@repr WORDSIZE32 1).
 
 Record t_StructA : Type :={
   f_a : uint_size;
@@ -85,44 +137,8 @@ Record t_StructD : Type :={
   f_a : uint_size;
 }.
 
-Class t_T3_e_for_a Self := {
+Record t_X : Type :={
 }.
-
-Record t_Arity1 : Type :={
-  0 : T;
-}.
-
-Class t_T2_for_a Self := {
-}.
-
-Class t_T1 Self := {
-}.
-
-Definition reserved_names (val : int8) (noeq : int8) (of : int8) : int8 :=
-  (val.+noeq).+of.
-
-Definition mk_c : t_C_t :=
-  let _ := (Build_Foo_B (@repr WORDSIZE32 3)) : t_Foo_t in
-  let _ := (Xt_X_t) : t_X_t in
-  Build_C (@repr WORDSIZE32 3).
-
-(*Not implemented yet? todo(item)*)
-
-Record C_f__g__impl__g__Foo_B : Type :={
-  f_x : uint_size;
-}.
-Inductive t_f__g__impl__g__Foo : Type :=
-| C_f__g__impl__g__Foo_At_f__g__impl__g__Foo
-| C_f__g__impl__g__Foo_B : C_f__g__impl__g__Foo_B -> t_f__g__impl__g__Foo.
-
-Definition ff__g__impl__g (self : t_B_t) : uint_size :=
-  (@repr WORDSIZE32 0).
-
-Definition ff__g : unit :=
-  tt.
-
-Definition f (x : t_Foobar_t) : uint_size :=
-  ff__g__impl_1__g (f_a x).
 
 Definition construct_structs (a : uint_size) (b : uint_size) : unit :=
   let _ := (Build_StructA a) : t_StructA_t in
@@ -131,30 +147,14 @@ Definition construct_structs (a : uint_size) (b : uint_size) : unit :=
   let _ := (Build_StructD ab) : t_StructD_t in
   tt.
 
-(*Not implemented yet? todo(item)*)
+Definition f (x : t_Foobar_t) : uint_size :=
+  ff__g__impl_1__g (f_a x).
 
-Record Foo2_B : Type :={
-  f_x : uint_size;
-}.
-Inductive t_Foo2 : Type :=
-| Foo2_At_Foo2
-| Foo2_B : Foo2_B -> t_Foo2.
+Definition ff__g__impl__g (self : t_B_t) : uint_size :=
+  (@repr WORDSIZE32 0).
 
-Instance t_Foo_t_t_T3_e_for_a : t_T3_e_for_a t_Foo_t := {
-}.
-
-Instance t_Arity1_t (t_Foo_t × int8)_t_T2_for_a : t_T2_for_a t_Arity1_t (t_Foo_t × int8) := {
-}.
-
-Instance (t_Foo_t × int8)_t_T1 : t_T1 (t_Foo_t × int8) := {
-}.
-
-Instance t_Foo_t_t_T1 : t_T1 t_Foo_t := {
-}.
-
-Definition impl__B__f (self : t_B_t) : t_B_t :=
-  Bt_B_t.
-
-Definition impl__Foo__f (self : t_Foo_t) : t_Foo_t :=
-  Foo_At_Foo_t.
+Definition mk_c : t_C_t :=
+  let _ := (Build_Foo_B (@repr WORDSIZE32 3)) : t_Foo_t in
+  let _ := (Xt_X_t) : t_X_t in
+  Build_C (@repr WORDSIZE32 3).
 '''

--- a/test-harness/src/snapshots/toolchain__naming into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__naming into-fstar.snap
@@ -42,15 +42,46 @@ type t_Foo =
   | Foo_A : t_Foo
   | Foo_B { f_x:usize }: t_Foo
 
-type t_C = { f_x:usize }
+let impl__Foo__f (self: t_Foo) : t_Foo = Foo_A <: t_Foo
 
-type t_X = | X : t_X
+type t_Foo2 =
+  | Foo2_A : t_Foo2
+  | Foo2_B { f_x:usize }: t_Foo2
+
+class t_T1 (v_Self: Type) = { __marker_trait_t_T1:Prims.unit }
+
+let impl_T1_for_Foo: t_T1 t_Foo = { __marker_trait = () }
+
+let impl_T1_for_tuple_Foo_u8: t_T1 (t_Foo & u8) = { __marker_trait = () }
+
+class t_T2_for_a (v_Self: Type) = { __marker_trait_t_T2_for_a:Prims.unit }
+
+class t_T3_e_for_a (v_Self: Type) = { __marker_trait_t_T3_e_for_a:Prims.unit }
+
+let impl_T3_e_e_for_a_for_Foo: t_T3_e_for_a t_Foo = { __marker_trait = () }
+
+let ff__g: Prims.unit = ()
+
+type t_f__g__impl__g__Foo =
+  | C_f__g__impl__g__Foo_A : t_f__g__impl__g__Foo
+  | C_f__g__impl__g__Foo_B { f_x:usize }: t_f__g__impl__g__Foo
+
+let ff__g__impl_1__g (self: t_Foo) : usize = sz 1
+
+let reserved_names (v_val v_noeq v_of: u8) : u8 = (v_val +! v_noeq <: u8) +! v_of
+
+type t_Arity1 (v_T: Type) {| _: Core.Marker.t_Sized v_T |} = | Arity1 : v_T -> t_Arity1 v_T
+
+let impl_T2_e_for_a_for_Arity1_of_tuple_Foo_u8: t_T2_for_a (t_Arity1 (t_Foo & u8)) =
+  { __marker_trait = () }
 
 type t_B = | B : t_B
 
-type t_Foobar = { f_a:t_Foo }
+let impl__B__f (self: t_B) : t_B = B <: t_B
 
-let ff__g__impl_1__g (self: t_Foo) : usize = sz 1
+type t_C = { f_x:usize }
+
+type t_Foobar = { f_a:t_Foo }
 
 type t_StructA = { f_a:usize }
 
@@ -66,30 +97,7 @@ type t_StructD = {
   f_b:usize
 }
 
-class t_T3_e_for_a (v_Self: Type) = { __marker_trait_t_T3_e_for_a:Prims.unit }
-
-type t_Arity1 (v_T: Type) {| _: Core.Marker.t_Sized v_T |} = | Arity1 : v_T -> t_Arity1 v_T
-
-class t_T2_for_a (v_Self: Type) = { __marker_trait_t_T2_for_a:Prims.unit }
-
-class t_T1 (v_Self: Type) = { __marker_trait_t_T1:Prims.unit }
-
-let reserved_names (v_val v_noeq v_of: u8) : u8 = (v_val +! v_noeq <: u8) +! v_of
-
-let mk_c: t_C =
-  let _:t_Foo = Foo_B ({ Naming.Foo.f_x = sz 3 }) <: t_Foo in
-  let _:t_X = X <: t_X in
-  { f_x = sz 3 } <: t_C
-
-type t_f__g__impl__g__Foo =
-  | C_f__g__impl__g__Foo_A : t_f__g__impl__g__Foo
-  | C_f__g__impl__g__Foo_B { f_x:usize }: t_f__g__impl__g__Foo
-
-let ff__g__impl__g (self: t_B) : usize = sz 0
-
-let ff__g: Prims.unit = ()
-
-let f (x: t_Foobar) : usize = ff__g__impl_1__g x.f_a
+type t_X = | X : t_X
 
 let construct_structs (a b: usize) : Prims.unit =
   let _:t_StructA = { f_a = a } <: t_StructA in
@@ -98,20 +106,12 @@ let construct_structs (a b: usize) : Prims.unit =
   let _:t_StructD = { f_a = a; f_b = b } <: t_StructD in
   ()
 
-type t_Foo2 =
-  | Foo2_A : t_Foo2
-  | Foo2_B { f_x:usize }: t_Foo2
+let f (x: t_Foobar) : usize = ff__g__impl_1__g x.f_a
 
-let impl_T3_e_e_for_a_for_Foo: t_T3_e_for_a t_Foo = { __marker_trait = () }
+let ff__g__impl__g (self: t_B) : usize = sz 0
 
-let impl_T2_e_for_a_for_Arity1_of_tuple_Foo_u8: t_T2_for_a (t_Arity1 (t_Foo & u8)) =
-  { __marker_trait = () }
-
-let impl_T1_for_tuple_Foo_u8: t_T1 (t_Foo & u8) = { __marker_trait = () }
-
-let impl_T1_for_Foo: t_T1 t_Foo = { __marker_trait = () }
-
-let impl__B__f (self: t_B) : t_B = B <: t_B
-
-let impl__Foo__f (self: t_Foo) : t_Foo = Foo_A <: t_Foo
+let mk_c: t_C =
+  let _:t_Foo = Foo_B ({ Naming.Foo.f_x = sz 3 }) <: t_Foo in
+  let _:t_X = X <: t_X in
+  { f_x = sz 3 } <: t_C
 '''

--- a/test-harness/src/snapshots/toolchain__naming into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__naming into-fstar.snap
@@ -50,14 +50,17 @@ type t_Foo2 =
 
 class t_T1 (v_Self: Type) = { __marker_trait_t_T1:Prims.unit }
 
+[@@ FStar.Tactics.Typeclasses.tcinstance]
 let impl_T1_for_Foo: t_T1 t_Foo = { __marker_trait = () }
 
+[@@ FStar.Tactics.Typeclasses.tcinstance]
 let impl_T1_for_tuple_Foo_u8: t_T1 (t_Foo & u8) = { __marker_trait = () }
 
 class t_T2_for_a (v_Self: Type) = { __marker_trait_t_T2_for_a:Prims.unit }
 
 class t_T3_e_for_a (v_Self: Type) = { __marker_trait_t_T3_e_for_a:Prims.unit }
 
+[@@ FStar.Tactics.Typeclasses.tcinstance]
 let impl_T3_e_e_for_a_for_Foo: t_T3_e_for_a t_Foo = { __marker_trait = () }
 
 let ff__g: Prims.unit = ()
@@ -72,6 +75,7 @@ let reserved_names (v_val v_noeq v_of: u8) : u8 = (v_val +! v_noeq <: u8) +! v_o
 
 type t_Arity1 (v_T: Type) {| _: Core.Marker.t_Sized v_T |} = | Arity1 : v_T -> t_Arity1 v_T
 
+[@@ FStar.Tactics.Typeclasses.tcinstance]
 let impl_T2_e_for_a_for_Arity1_of_tuple_Foo_u8: t_T2_for_a (t_Arity1 (t_Foo & u8)) =
   { __marker_trait = () }
 

--- a/test-harness/src/snapshots/toolchain__reordering into-coq.snap
+++ b/test-harness/src/snapshots/toolchain__reordering into-coq.snap
@@ -36,15 +36,21 @@ Inductive t_Foo : Type :=
 | Foo_At_Foo
 | Foo_Bt_Foo.
 
-Record t_Bar : Type :={
-  0 : t_Foo_t;
-}.
+(*Not implemented yet? todo(item)*)
 
 Definition f (_ : int32) : t_Foo_t :=
   Foo_At_Foo_t.
 
+Definition no_dependency_1_ : unit :=
+  tt.
+
+Definition no_dependency_2_ : unit :=
+  tt.
+
+Record t_Bar : Type :={
+  0 : t_Foo_t;
+}.
+
 Definition g : t_Bar_t :=
   Bar (f (@repr WORDSIZE32 32)).
-
-(*Not implemented yet? todo(item)*)
 '''

--- a/test-harness/src/snapshots/toolchain__reordering into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__reordering into-fstar.snap
@@ -34,9 +34,13 @@ type t_Foo =
   | Foo_A : t_Foo
   | Foo_B : t_Foo
 
-type t_Bar = | Bar : t_Foo -> t_Bar
-
 let f (_: u32) : t_Foo = Foo_A <: t_Foo
+
+let no_dependency_1_: Prims.unit = ()
+
+let no_dependency_2_: Prims.unit = ()
+
+type t_Bar = | Bar : t_Foo -> t_Bar
 
 let g: t_Bar = Bar (f 32ul) <: t_Bar
 '''

--- a/test-harness/src/snapshots/toolchain__traits into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__traits into-fstar.snap
@@ -1,0 +1,24 @@
+---
+source: test-harness/src/harness.rs
+expression: snapshot
+info:
+  kind:
+    Translate:
+      backend: fstar
+  info:
+    name: traits
+    manifest: traits/Cargo.toml
+    description: ~
+  spec:
+    optional: false
+    broken: false
+    issue_id: ~
+    positive: true
+    snapshot:
+      stderr: true
+      stdout: false
+---
+exit = 0
+stderr = '''
+Compiling traits v0.1.0 (WORKSPACE_ROOT/traits)
+    Finished dev [unoptimized + debuginfo] target(s) in XXs'''

--- a/tests/reordering/src/lib.rs
+++ b/tests/reordering/src/lib.rs
@@ -1,8 +1,13 @@
 #![allow(dead_code)]
 
+fn no_dependency_1() {}
+
 fn g() -> Bar {
     Bar(f(32))
 }
+
+fn no_dependency_2() {}
+
 fn f(_: u32) -> Foo {
     Foo::A
 }

--- a/tests/traits/Cargo.toml
+++ b/tests/traits/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [dependencies]
 
 [package.metadata.hax-tests]
-into."fstar" = { snapshot = "none" }
+into."fstar" = { snapshot = "stderr" }
 


### PR DESCRIPTION
Due to a very stupid bug, we were generating plain `let`s for instances while we really need `instance`s.

This PR generates now `[@@ FStar.Tactics.Typeclasses.tcinstance]let ...`, which is the same thing as `instance ...`.

F*'s pretty printer doesn't handle the `instance` keyword.
We'll get that prettier output when we'll switch to the generic printer.