### PR TITLE
fix: reapply badly merged PR #333

### DIFF
--- a/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
@@ -161,6 +161,8 @@ let g (x: t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global))
         Core.Ops.Range.t_Range u8)
       x
       (fun x i ->
+          let x:t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) = x in
+          let i:u8 = i in
           { x with f_a = Alloc.Vec.impl_1__push x.f_a i <: Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global }
           <:
           t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global))
@@ -192,6 +194,8 @@ let foo (lhs rhs: t_S) : t_S =
         Core.Ops.Range.t_Range usize)
       lhs
       (fun lhs i ->
+          let lhs:t_S = lhs in
+          let i:usize = i in
           {
             lhs with
             f_b


### PR DESCRIPTION
I badly merged or rebased something, and that resulted in reverting most of #333, basically :disappointed:

This reapplies the missing bits