### PR TITLE
Minimal example test for ProVerif backend

### DIFF
--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -266,6 +266,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "proverif-minimal"
+version = "0.1.0"
+
+[[package]]
 name = "quote"
 version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -22,5 +22,6 @@ members = [
         "traits",
         "reordering",
         "nested-derefs",
+        "proverif-minimal"
 ]
 resolver = "2"

--- a/tests/proverif-minimal/Cargo.toml
+++ b/tests/proverif-minimal/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "proverif-minimal"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+[package.metadata.hax-tests]
+into."pro-verif" = { broken = false, snapshot = "none" }

--- a/tests/proverif-minimal/src/lib.rs
+++ b/tests/proverif-minimal/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}


### PR DESCRIPTION
Include a test in the toolchain test harness that checks whether extraction works for the output of  `cargo new --lib proverif-minimal`.