### PR TITLE
fix(engine): `NamedConsts` are `GlobalVar`s of kind `AssociatedItem Value`

### DIFF
--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -602,7 +602,11 @@ end) : EXPR = struct
                        typ = TInt { size = S8; signedness = Unsigned };
                      })
                    l))
-      | NamedConst { def_id = id; _ } -> GlobalVar (def_id Value id)
+      | NamedConst { def_id = id; impl; _ } ->
+          let kind : Concrete_ident.Kind.t =
+            match impl with Some _ -> AssociatedItem Value | _ -> Value
+          in
+          GlobalVar (def_id kind id)
       | Closure { body; params; upvars; _ } ->
           let params =
             List.filter_map ~f:(fun p -> Option.map ~f:c_pat p.pat) params

--- a/test-harness/src/snapshots/toolchain__naming into-coq.snap
+++ b/test-harness/src/snapshots/toolchain__naming into-coq.snap
@@ -60,6 +60,10 @@ Inductive t_Foo2 : Type :=
 | Foo2_At_Foo2
 | Foo2_B : Foo2_B -> t_Foo2.
 
+Class t_FooTrait Self := {
+  f_ASSOCIATED_CONSTANT:uint_size ;
+}.
+
 Class t_T1 Self := {
 }.
 
@@ -79,6 +83,12 @@ Instance t_Foo_t_t_T3_e_for_a : t_T3_e_for_a t_Foo_t := {
 }.
 
 (*Not implemented yet? todo(item)*)
+
+Definition v_INHERENT_CONSTANT : uint_size :=
+  (@repr WORDSIZE32 3).
+
+Definition constants : uint_size :=
+  f_ASSOCIATED_CONSTANT.+v_INHERENT_CONSTANT.
 
 Definition ff__g : unit :=
   tt.

--- a/test-harness/src/snapshots/toolchain__naming into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__naming into-fstar.snap
@@ -48,6 +48,8 @@ type t_Foo2 =
   | Foo2_A : t_Foo2
   | Foo2_B { f_x:usize }: t_Foo2
 
+class t_FooTrait (v_Self: Type) = { f_ASSOCIATED_CONSTANT:usize }
+
 class t_T1 (v_Self: Type) = { __marker_trait_t_T1:Prims.unit }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
@@ -62,6 +64,14 @@ class t_T3_e_for_a (v_Self: Type) = { __marker_trait_t_T3_e_for_a:Prims.unit }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 let impl_T3_e_e_for_a_for_Foo: t_T3_e_for_a t_Foo = { __marker_trait = () }
+
+let v_INHERENT_CONSTANT: usize = sz 3
+
+let constants
+      (#v_T: Type)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] ii0: Core.Marker.t_Sized v_T)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] ii1: t_FooTrait v_T)
+    : usize = f_ASSOCIATED_CONSTANT +! v_INHERENT_CONSTANT
 
 let ff__g: Prims.unit = ()
 

--- a/tests/naming/src/lib.rs
+++ b/tests/naming/src/lib.rs
@@ -96,3 +96,12 @@ fn construct_structs(a: usize, b: usize) {
     let _ = StructC { a };
     let _ = StructD { a, b };
 }
+
+const INHERENT_CONSTANT: usize = 3;
+trait FooTrait {
+    const ASSOCIATED_CONSTANT: usize;
+}
+
+fn constants<T: FooTrait>() -> usize {
+    <T as FooTrait>::ASSOCIATED_CONSTANT + INHERENT_CONSTANT
+}


### PR DESCRIPTION
This is related to https://github.com/hacspec/hax/pull/362#issuecomment-1812810205. While working with constants, @cmester0 noticed associated constants (i.e. constants in traits) were extracted with different naming schemes according to context.
In Hax, global names are tagged with a kind that gives information about the nature of the identifier: is that an associated item, a type, a field, a value, ...?

The issue is the following:
```rust
const INHERENT_CONSTANT: usize = 3;
trait FooTrait {
    const ASSOCIATED_CONSTANT: usize;
}

fn constants<T: FooTrait>() -> usize {
    <T as FooTrait>::ASSOCIATED_CONSTANT + INHERENT_CONSTANT
}
```
`ASSOCIATED_CONSTANT` was prefixed with `f_` (this is the prefix for associated items) in `FooTrait` definition, but then prefixed with `v_` in `constants`.

This was due to a bad `kind` while importing ASTs in the engine.


This PR:
 - fixes this issue;
 - add a test.
