### PR TITLE
Add `Self` implsource

### DIFF
--- a/engine/lib/ast.ml
+++ b/engine/lib/ast.ml
@@ -256,6 +256,7 @@ functor
       | GConst of expr
 
     and impl_expr =
+      | Self
       | Concrete of trait_ref
       | LocalBound of { id : string }
       | Parent of { impl : impl_expr; trait : trait_ref }
@@ -303,6 +304,7 @@ functor
           f : expr;
           args : expr list (* ; f_span: span *);
           generic_args : generic_value list;
+          impl : impl_expr option;
         }
       | Literal of literal
       | Array of expr list

--- a/engine/lib/generic_printer/generic_printer_base.ml
+++ b/engine/lib/generic_printer/generic_printer_base.ml
@@ -173,7 +173,9 @@ module Make (F : Features.T) = struct
       method expr' : par_state -> expr' fn =
         fun _ctx e ->
           match e with
-          | App { f = { e = GlobalVar i; _ } as f; args; generic_args } -> (
+          | App
+              { f = { e = GlobalVar i; _ } as f; args; generic_args; impl = _ }
+            -> (
               let expect_one_arg where =
                 match args with
                 | [ arg ] -> arg
@@ -189,7 +191,8 @@ module Make (F : Features.T) = struct
               | `Projector (`Concrete i) ->
                   let arg = expect_one_arg "projector concrete" in
                   print#field_projection i arg)
-          | App { f; args; generic_args } -> print#expr_app f args generic_args
+          | App { f; args; generic_args; _ } ->
+              print#expr_app f args generic_args
           | Construct { constructor; fields; base; is_record; is_struct } -> (
               match constructor with
               | `Concrete constructor ->

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -179,6 +179,7 @@ let resugar_index_mut (e : expr) : (expr * expr) option =
         f = { e = GlobalVar (`Concrete meth); _ };
         args = [ { e = Borrow { e = x; _ }; _ }; index ];
         generic_args = _ (* TODO: see issue #328 *);
+        impl = _ (* TODO: see issue #328 *);
       }
     when Concrete_ident.eq_name Core__ops__index__IndexMut__index_mut meth ->
       Some (x, index)
@@ -187,6 +188,7 @@ let resugar_index_mut (e : expr) : (expr * expr) option =
         f = { e = GlobalVar (`Concrete meth); _ };
         args = [ x; index ];
         generic_args = _ (* TODO: see issue #328 *);
+        impl = _ (* TODO: see issue #328 *);
       }
     when Concrete_ident.eq_name Core__ops__index__Index__index meth ->
       Some (x, index)
@@ -321,7 +323,7 @@ end) : EXPR = struct
   and c_expr_unwrapped (e : Thir.decorated_for__expr_kind) : expr =
     (* TODO: eliminate that `call`, use the one from `ast_utils` *)
     let call f args =
-      App { f; args = List.map ~f:c_expr args; generic_args = [] }
+      App { f; args = List.map ~f:c_expr args; generic_args = []; impl = None }
     in
     let typ = c_ty e.span e.ty in
     let span = Span.of_thir e.span in
@@ -385,7 +387,13 @@ end) : EXPR = struct
             | _ -> f
           in
           let args = if List.is_empty args then [ unit_expr span ] else args in
-          App { f; args; generic_args }
+          App
+            {
+              f;
+              args;
+              generic_args;
+              impl = Option.map ~f:(c_impl_expr e.span) impl;
+            }
       | Box { value } ->
           (U.call Rust_primitives__hax__box_new [ c_expr value ] span typ).e
       | Deref { arg } ->
@@ -512,6 +520,7 @@ end) : EXPR = struct
               f = { e = projector; typ = TArrow ([ lhs.typ ], typ); span };
               args = [ lhs ];
               generic_args = [] (* TODO: see issue #328 *);
+              impl = None (* TODO: see issue #328 *);
             }
       | TupleField { lhs; field } ->
           (* TODO: refactor *)
@@ -527,6 +536,7 @@ end) : EXPR = struct
               f = { e = projector; typ = TArrow ([ lhs.typ ], typ); span };
               args = [ lhs ];
               generic_args = [] (* TODO: see issue #328 *);
+              impl = None (* TODO: see issue #328 *);
             }
       | GlobalName { id } -> GlobalVar (def_id Value id)
       | UpvarRef { var_hir_id = id; _ } -> LocalVar (local_ident Expr id)
@@ -662,6 +672,7 @@ end) : EXPR = struct
                     };
                   args = [ e ];
                   generic_args = _;
+                  impl = _;
                 (* TODO: see issue #328 *)
                 } ->
                 LhsFieldAccessor
@@ -928,6 +939,7 @@ end) : EXPR = struct
         in
         List.fold ~init ~f path
     | Dyn { trait } -> Dyn (c_trait_ref span trait)
+    | SelfImpl -> Self
     | Builtin { trait } -> Builtin (c_trait_ref span trait)
     | Todo str -> failwith @@ "impl_expr_atom: Todo " ^ str
 

--- a/engine/lib/phases/phase_direct_and_mut.ml
+++ b/engine/lib/phases/phase_direct_and_mut.ml
@@ -97,8 +97,8 @@ struct
           LhsArbitraryExpr { witness = Features.On.arbitrary_lhs; e }
 
     and translate_app (span : span) (otype : A.ty) (f : A.expr)
-        (raw_args : A.expr list) (generic_args : B.generic_value list) : B.expr
-        =
+        (raw_args : A.expr list) (generic_args : B.generic_value list)
+        (impl : B.impl_expr option) : B.expr =
       (* `otype` and `_otype` (below) are supposed to be the same
          type, but sometimes `_otype` is less precise (i.e. an associated
          type while a concrete type is available) *)
@@ -135,7 +135,7 @@ struct
           (* there is no mutation, we can reconstruct the expression right away *)
           let f, typ = (dexpr f, dty span otype) in
           let args = List.map ~f:dexpr raw_args in
-          B.{ e = B.App { f; args; generic_args }; typ; span }
+          B.{ e = B.App { f; args; generic_args; impl }; typ; span }
       | _ -> (
           (* TODO: when LHS are better (issue #222), compress `p1 = tmp1; ...; pN = tmpN` in `(p1...pN) = ...` *)
           (* we are generating:
@@ -210,7 +210,7 @@ struct
             in
             B.
               {
-                e = App { f; args = unmut_args; generic_args };
+                e = App { f; args = unmut_args; generic_args; impl };
                 typ = pat.typ;
                 span = pat.span;
               }
@@ -260,9 +260,10 @@ struct
     and dexpr_unwrapped (expr : A.expr) : B.expr =
       let span = expr.span in
       match expr.e with
-      | App { f; args; generic_args } ->
+      | App { f; args; generic_args; impl } ->
           let generic_args = List.map ~f:(dgeneric_value span) generic_args in
-          translate_app span expr.typ f args generic_args
+          let impl = Option.map ~f:(dimpl_expr span) impl in
+          translate_app span expr.typ f args generic_args impl
       | _ ->
           let e = dexpr' span expr.e in
           B.{ e; typ = dty expr.span expr.typ; span = expr.span }

--- a/engine/lib/phases/phase_drop_references.ml
+++ b/engine/lib/phases/phase_drop_references.ml
@@ -110,13 +110,14 @@ struct
               body = dexpr body;
               captures = List.map ~f:dexpr captures;
             }
-      | App { f; args; generic_args } ->
+      | App { f; args; generic_args; impl } ->
           let f = dexpr f in
           let args = List.map ~f:dexpr args in
+          let impl = Option.map ~f:(dimpl_expr span) impl in
           let generic_args =
             List.filter_map ~f:(dgeneric_value span) generic_args
           in
-          App { f; args; generic_args }
+          App { f; args; generic_args; impl }
       | _ -> .
       [@@inline_ands bindings_of dexpr - dbinding_mode]
 

--- a/engine/lib/print_rust.ml
+++ b/engine/lib/print_rust.ml
@@ -211,7 +211,7 @@ module Raw = struct
           match else_ with Some e -> !" else {" & pexpr e & !"}" | None -> !""
         in
         !"(" & !"if " & pexpr cond & !"{" & pexpr then_ & !"}" & else_ & !")"
-    | App { f; args; generic_args } ->
+    | App { f; args; generic_args; impl = _ } ->
         let args = concat ~sep:!"," @@ List.map ~f:pexpr args in
         let generic_args =
           let f = pgeneric_value e.span in

--- a/engine/lib/side_effect_utils.ml
+++ b/engine/lib/side_effect_utils.ml
@@ -342,7 +342,7 @@ struct
                     m#plus (m#plus (no_lbs ethen) (no_lbs eelse)) effects
                   in
                   ({ e with e = If { cond; then_; else_ } }, effects))
-          | App { f; args; generic_args } ->
+          | App { f; args; generic_args; impl } ->
               HoistSeq.many env
                 (List.map ~f:(super#visit_expr env) (f :: args))
                 (fun l effects ->
@@ -351,7 +351,7 @@ struct
                     | f :: args -> (f, args)
                     | _ -> HoistSeq.err_hoist_invariant e.span Stdlib.__LOC__
                   in
-                  ({ e with e = App { f; args; generic_args } }, effects))
+                  ({ e with e = App { f; args; generic_args; impl } }, effects))
           | Literal _ -> (e, m#zero)
           | Block (inner, witness) ->
               HoistSeq.one env (super#visit_expr env inner)

--- a/engine/lib/subtype.ml
+++ b/engine/lib/subtype.ml
@@ -53,6 +53,7 @@ struct
 
   and dimpl_expr (span : span) (i : A.impl_expr) : B.impl_expr =
     match i with
+    | Self -> Self
     | Concrete tr -> Concrete (dtrait_ref span tr)
     | LocalBound { id } -> LocalBound { id }
     | Parent { impl; trait } ->
@@ -153,12 +154,13 @@ struct
             then_ = dexpr then_;
             else_ = Option.map ~f:dexpr else_;
           }
-    | App { f; args; generic_args } ->
+    | App { f; args; generic_args; impl } ->
         App
           {
             f = dexpr f;
             args = List.map ~f:dexpr args;
             generic_args = List.map ~f:(dgeneric_value span) generic_args;
+            impl = Option.map ~f:(dimpl_expr span) impl;
           }
     | Literal lit -> Literal lit
     | Array l -> Array (List.map ~f:dexpr l)

--- a/engine/utils/phase-debug-webapp/static/script.js
+++ b/engine/utils/phase-debug-webapp/static/script.js
@@ -16,7 +16,7 @@ let mk = (kind, body = [], classes = []) => {
         console.error('wrong type for body', body);
     }
     return e;
-}
+};
 
 function findNode(o, search){
     let h = o => o instanceof Object ? (search(o) ? o : Object.values(o).map(h).find(x => x)) : null;
@@ -49,16 +49,32 @@ function json(json) {
     let o = JSON.parse(JSON.stringify(json));
     let root = mk('div', [], ['json-viewer']);
     let state = {
-        open: new Map()
+        open: new Map(),
+        default_open: false,
     };
     function render_all() {
         root.replaceChildren(render(o, []));
+        let expand_button = mk('button', state.default_open ? '🡒🡐' : '🡘', ['expand-all']);
+        expand_button.style = `
+            position: absolute;
+            top: 1px;
+            right: 1px;
+            padding: 0 3px;
+            margin: 0;
+            line-height: 0;
+            height: 16px;
+        `;
+        expand_button.onclick = () => {
+            state.default_open = !state.default_open;
+            render_all();
+        };
+        root.prepend(expand_button);
     }
     let key_of_path = path => JSON.stringify(path);
     let set_open = (path, v) => state.open.set(key_of_path(path), v);
     let is_open = (path, def = path.length < 6) => {
         let b = state.open.get(key_of_path(path));
-        return b === undefined ? def : b;
+        return b === undefined ? (state.default_open || def) : b;
     };
     let swap = (path, def) => {
         set_open(path, !is_open(path, def), false);
@@ -71,7 +87,7 @@ function json(json) {
                 return true;
             }
         }
-        return false;   
+        return false;
     };
     let is_simple = o => {
         if (o instanceof Object) {

--- a/frontend/exporter/src/lib.rs
+++ b/frontend/exporter/src/lib.rs
@@ -8,6 +8,7 @@
 #![feature(let_chains)]
 #![allow(incomplete_features)]
 #![feature(specialization)]
+#![feature(return_position_impl_trait_in_trait)]
 
 extern crate rustc_abi;
 extern crate rustc_ast;

--- a/frontend/exporter/src/rustc_utils.rs
+++ b/frontend/exporter/src/rustc_utils.rs
@@ -23,6 +23,13 @@ impl<'tcx> ty::Predicate<'tcx> {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct AnnotatedPredicate<'tcx> {
+    pub is_extra_self_predicate: bool,
+    pub predicate: ty::Predicate<'tcx>,
+    pub span: rustc_span::Span,
+}
+
 #[extension_traits::extension(pub trait TyCtxtExtPredOrAbove)]
 impl<'tcx> ty::TyCtxt<'tcx> {
     /// Just like `TyCtxt::predicates_defined_on`, but in the case of
@@ -31,15 +38,45 @@ impl<'tcx> ty::TyCtxt<'tcx> {
     fn predicates_defined_on_or_above(
         self,
         did: rustc_span::def_id::DefId,
-    ) -> Vec<(ty::Predicate<'tcx>, rustc_span::Span)> {
+    ) -> Vec<AnnotatedPredicate<'tcx>> {
         let mut next_did = Some(did);
         let mut predicates = vec![];
         while let Some(did) = next_did {
-            let gen_preds = self.predicates_defined_on(did);
-            next_did = gen_preds.parent;
-            predicates.extend(gen_preds.predicates.into_iter())
+            let (preds, parent) = self.annotated_predicates_of(did);
+            next_did = parent;
+            predicates.extend(preds)
         }
         predicates
+    }
+
+    fn annotated_predicates_of(
+        self,
+        did: rustc_span::def_id::DefId,
+    ) -> (
+        impl Iterator<Item = AnnotatedPredicate<'tcx>>,
+        Option<rustc_span::def_id::DefId>,
+    ) {
+        let with_self = self.predicates_of(did);
+        let parent = with_self.parent;
+        let with_self = with_self.predicates;
+        let without_self: Vec<ty::Predicate> = self
+            .predicates_defined_on(did)
+            .predicates
+            .into_iter()
+            .cloned()
+            .map(|(pred, _)| pred)
+            .collect();
+        (
+            with_self
+                .into_iter()
+                .cloned()
+                .map(move |(predicate, span)| AnnotatedPredicate {
+                    is_extra_self_predicate: !without_self.contains(&predicate),
+                    predicate,
+                    span,
+                }),
+            parent,
+        )
     }
 }
 

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -90,8 +90,12 @@ mod search_clause {
     fn predicate_equality<'tcx, S: UnderOwnerState<'tcx>>(
         x: Predicate<'tcx>,
         y: Predicate<'tcx>,
+        param_env: rustc_middle::ty::ParamEnv<'tcx>,
         s: &S,
     ) -> bool {
+        let tcx = s.base().tcx;
+        let x = tcx.try_normalize_erasing_regions(param_env, x).unwrap_or(x);
+        let y = tcx.try_normalize_erasing_regions(param_env, y).unwrap_or(y);
         let result = format!("{:?}", x) == format!("{:?}", y);
         const DEBUG: bool = false;
         if DEBUG && result {
@@ -150,7 +154,12 @@ mod search_clause {
             param_env: rustc_middle::ty::ParamEnv<'tcx>,
         ) -> Option<Path<'tcx>> {
             let tcx = s.base().tcx;
-            if predicate_equality(self.to_predicate(tcx), target.to_predicate(tcx), s) {
+            if predicate_equality(
+                self.to_predicate(tcx),
+                target.to_predicate(tcx),
+                param_env,
+                s,
+            ) {
                 return Some(vec![]);
             }
 

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -22,6 +22,7 @@ pub enum ImplExprAtom {
         clause_id: u64,
         path: Vec<ImplExprPathChunk>,
     },
+    SelfImpl,
     /// `dyn TRAIT` is a wrapped value with a virtual table for trait
     /// `TRAIT`.  In other words, a value `dyn TRAIT` is a dependent
     /// triple that gathers a type τ, a value of type τ and an
@@ -116,7 +117,7 @@ mod search_clause {
             let predicates = tcx
                 .predicates_defined_on_or_above(self.def_id())
                 .into_iter()
-                .map(|(predicate, _)| predicate);
+                .map(|apred| apred.predicate);
             predicates_to_trait_predicates(tcx, predicates, self.trait_ref.substs).collect()
         }
         fn associated_items_trait_predicates(
@@ -243,26 +244,35 @@ impl<'tcx> IntoImplExpr<'tcx> for rustc_middle::ty::PolyTraitRef<'tcx> {
                 use search_clause::TraitPredicateExt;
                 let tcx = s.base().tcx;
                 let predicates = &tcx.predicates_defined_on_or_above(s.owner_id());
-                let Some((predicate, path)) = predicates.into_iter().find_map(|(predicate, _)| {
-                    predicate
+                let Some((apred, path)) = predicates.into_iter().find_map(|apred| {
+                    apred
+                        .predicate
                         .to_opt_poly_trait_pred()
                         .map(|poly_trait_predicate| poly_trait_predicate)
                         .and_then(|poly_trait_predicate| poly_trait_predicate.no_bound_vars())
                         .and_then(|trait_predicate| {
                             trait_predicate.path_to(s, self.clone(), param_env)
                         })
-                        .map(|path| (predicate, path))
+                        .map(|path| (apred, path))
                 }) else {
                     return ImplExprAtom::Todo(format!("implsource::param \n\n{:#?}", self))
                         .with_args(impl_exprs(s, &nested));
                 };
-                // .s_expect(s, format!("implsource::param \n\n{:#?}", self).as_str());
-                let clause_id: u64 = clause_id_of_predicate(*predicate);
-                ImplExprAtom::LocalBound {
-                    clause_id,
-                    path: path.sinto(s),
+                if apred.is_extra_self_predicate {
+                    if !path.is_empty() {
+                        supposely_unreachable_fatal!(s[apred.span], "SelfWithNonEmptyPath"; {
+                            self, apred, path
+                        });
+                    }
+                    ImplExprAtom::SelfImpl.with_args(vec![])
+                } else {
+                    let clause_id: u64 = clause_id_of_predicate(apred.predicate);
+                    ImplExprAtom::LocalBound {
+                        clause_id,
+                        path: path.sinto(s),
+                    }
+                    .with_args(impl_exprs(s, &nested))
                 }
-                .with_args(impl_exprs(s, &nested))
             }
             ImplSource::Object(data) => ImplExprAtom::Dyn {
                 r#trait: data.upcast_trait_ref.skip_binder().sinto(s),
@@ -272,7 +282,7 @@ impl<'tcx> IntoImplExpr<'tcx> for rustc_middle::ty::PolyTraitRef<'tcx> {
                 r#trait: self.skip_binder().sinto(s),
             }
             .with_args(impl_exprs(s, &x.nested)),
-            x => ImplExprAtom::Todo(format!("{:#?}\n\n{:#?}", x, self)).into(),
+            x => ImplExprAtom::Todo(format!("ImplExprAtom::Todo {:#?}\n\n{:#?}", x, self)).into(),
         }
     }
 }

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -237,9 +237,8 @@ impl<'tcx> IntoImplExpr<'tcx> for rustc_middle::ty::PolyTraitRef<'tcx> {
     ) -> ImplExpr {
         use rustc_trait_selection::traits::*;
         let Some(impl_source) = select_trait_candidate(s, param_env, *self) else {
-            supposely_unreachable_fatal!(s, "ImplExprSelectTraitCandidate"; {
-                self, param_env
-            })
+            report!(warn, s, "Warning: the frontend could not resolve using `select_trait_candidate`.\nThis is a bug documented in `https://github.com/hacspec/hax/issues/416`.\nCurrently, this bug is non-fatal at the exporter level.");
+            return ImplExprAtom::Todo(format!("impl_expr failed on {:#?}", self)).into();
         };
         match impl_source {
             ImplSource::UserDefined(ImplSourceUserDefinedData {

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -228,7 +228,9 @@ impl<'tcx> IntoImplExpr<'tcx> for rustc_middle::ty::PolyTraitRef<'tcx> {
     ) -> ImplExpr {
         use rustc_trait_selection::traits::*;
         let Some(impl_source) = select_trait_candidate(s, param_env, *self) else {
-            return ImplExprAtom::Todo(format!("impl_expr failed on {:#?}", self)).into();
+            supposely_unreachable_fatal!(s, "ImplExprSelectTraitCandidate"; {
+                self, param_env
+            })
         };
         match impl_source {
             ImplSource::UserDefined(ImplSourceUserDefinedData {
@@ -255,8 +257,9 @@ impl<'tcx> IntoImplExpr<'tcx> for rustc_middle::ty::PolyTraitRef<'tcx> {
                         })
                         .map(|path| (apred, path))
                 }) else {
-                    return ImplExprAtom::Todo(format!("implsource::param \n\n{:#?}", self))
-                        .with_args(impl_exprs(s, &nested));
+                    supposely_unreachable_fatal!(s, "ImplExprPredNotFound"; {
+                        self, nested, predicates
+                    })
                 };
                 if apred.is_extra_self_predicate {
                     if !path.is_empty() {
@@ -282,7 +285,11 @@ impl<'tcx> IntoImplExpr<'tcx> for rustc_middle::ty::PolyTraitRef<'tcx> {
                 r#trait: self.skip_binder().sinto(s),
             }
             .with_args(impl_exprs(s, &x.nested)),
-            x => ImplExprAtom::Todo(format!("ImplExprAtom::Todo {:#?}\n\n{:#?}", x, self)).into(),
+            x => ImplExprAtom::Todo(format!(
+                "ImplExprAtom::Todo(see https://github.com/hacspec/hax/issues/381) {:#?}\n\n{:#?}",
+                x, self
+            ))
+            .into(),
         }
     }
 }

--- a/test-harness/src/snapshots/toolchain__traits into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__traits into-fstar.snap
@@ -54,23 +54,23 @@ class t_Foo (v_Self: Type) = {
   f_AssocType:Core.Clone.t_Clone _;
   f_AssocType:Core.Marker.t_Sized _;
   f_N:usize;
-  f_assoc_f:Prims.unit;
+  f_assoc_f:Prims.unit -> Prims.unit;
   f_method_f:v_Self -> Prims.unit
 }
 
 let f
       (#v_T: Type)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] ii0: Core.Marker.t_Sized v_T)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] ii1: t_Foo v_T)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: Core.Marker.t_Sized v_T)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: t_Foo v_T)
       (x: v_T)
     : Prims.unit =
-  let _:Prims.unit = f_assoc_f in
+  let _:Prims.unit = f_assoc_f () in
   f_method_f x
 
 let g
       (#v_T: Type)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] ii0: Core.Marker.t_Sized v_T)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] ii1: t_Foo v_T)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: Core.Marker.t_Sized v_T)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: t_Foo v_T)
       (x: i1.f_AssocType)
     : u32 = f_function_of_super_trait x
 
@@ -80,7 +80,7 @@ let impl_Foo_for_tuple_: t_Foo Prims.unit =
     f_AssocType = i32;
     f_N = sz 32;
     f_assoc_f = () <: Prims.unit;
-    f_method_f = fun (self: Prims.unit) -> f_assoc_f
+    f_method_f = fun (self: Prims.unit) -> f_assoc_f ()
   }
 
 type t_Struct = | Struct : t_Struct

--- a/test-harness/src/snapshots/toolchain__traits into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__traits into-fstar.snap
@@ -33,6 +33,10 @@ module Traits
 open Core
 open FStar.Mul
 
+let impl_2__method (x: v_T) : Prims.unit = f_bar x
+
+class t_Bar (v_Self: Type) = { f_bar:v_Self -> Prims.unit }
+
 class t_SuperTrait (v_Self: Type) = {
   [@@@ FStar.Tactics.Typeclasses.no_method]_super_590399929:Core.Clone.t_Clone v_Self;
   f_function_of_super_trait:v_Self -> u32
@@ -78,4 +82,6 @@ let impl_Foo_for_tuple_: t_Foo Prims.unit =
     f_assoc_f = () <: Prims.unit;
     f_method_f = fun (self: Prims.unit) -> f_assoc_f
   }
+
+type t_Struct = | Struct : t_Struct
 '''

--- a/test-harness/src/snapshots/toolchain__traits into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__traits into-fstar.snap
@@ -16,9 +16,66 @@ info:
     positive: true
     snapshot:
       stderr: true
-      stdout: false
+      stdout: true
 ---
 exit = 0
 stderr = '''
 Compiling traits v0.1.0 (WORKSPACE_ROOT/traits)
     Finished dev [unoptimized + debuginfo] target(s) in XXs'''
+
+[stdout]
+diagnostics = []
+
+[stdout.files]
+"Traits.fst" = '''
+module Traits
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+class t_SuperTrait (v_Self: Type) = {
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_590399929:Core.Clone.t_Clone v_Self;
+  f_function_of_super_trait:v_Self -> u32
+}
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_SuperTrait_for_i32: t_SuperTrait i32 =
+  {
+    f_function_of_super_trait = fun (self: i32) -> cast (Core.Num.impl__i32__abs self <: i32) <: u32
+  }
+
+class t_Foo (v_Self: Type) = {
+  f_AssocType:Type;
+  f_AssocType:t_SuperTrait _;
+  f_AssocType:Core.Clone.t_Clone _;
+  f_AssocType:Core.Marker.t_Sized _;
+  f_N:usize;
+  f_assoc_f:Prims.unit;
+  f_method_f:v_Self -> Prims.unit
+}
+
+let f
+      (#v_T: Type)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] ii0: Core.Marker.t_Sized v_T)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] ii1: t_Foo v_T)
+      (x: v_T)
+    : Prims.unit =
+  let _:Prims.unit = f_assoc_f in
+  f_method_f x
+
+let g
+      (#v_T: Type)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] ii0: Core.Marker.t_Sized v_T)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] ii1: t_Foo v_T)
+      (x: i1.f_AssocType)
+    : u32 = f_function_of_super_trait x
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_Foo_for_tuple_: t_Foo Prims.unit =
+  {
+    f_AssocType = i32;
+    f_N = sz 32;
+    f_assoc_f = () <: Prims.unit;
+    f_method_f = fun (self: Prims.unit) -> f_assoc_f
+  }
+'''

--- a/tests/traits/Cargo.toml
+++ b/tests/traits/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [dependencies]
 
 [package.metadata.hax-tests]
-into."fstar" = { snapshot = "stderr" }
+into."fstar" = { }
 

--- a/tests/traits/src/lib.rs
+++ b/tests/traits/src/lib.rs
@@ -1,12 +1,24 @@
 #![allow(dead_code)]
 
+pub trait SuperTrait: Clone {
+    fn function_of_super_trait(self) -> u32;
+}
+
 pub trait Foo {
+    type AssocType: SuperTrait;
     const N: usize;
     fn assoc_f() -> ();
     fn method_f(&self) -> ();
 }
 
+impl SuperTrait for i32 {
+    fn function_of_super_trait(self) -> u32 {
+        self.abs() as u32
+    }
+}
+
 impl Foo for () {
+    type AssocType = i32;
     const N: usize = 32;
     fn assoc_f() {
         ()
@@ -19,4 +31,8 @@ impl Foo for () {
 fn f<T: Foo>(x: T) {
     T::assoc_f();
     x.method_f()
+}
+
+fn g<T: Foo>(x: T::AssocType) -> u32 {
+    x.function_of_super_trait()
 }

--- a/tests/traits/src/lib.rs
+++ b/tests/traits/src/lib.rs
@@ -36,3 +36,15 @@ fn f<T: Foo>(x: T) {
 fn g<T: Foo>(x: T::AssocType) -> u32 {
     x.function_of_super_trait()
 }
+
+struct Struct;
+
+trait Bar<'a> {
+    fn bar(self);
+}
+
+impl<'a> Struct {
+    fn method<T: Bar<'a>>(x: T) {
+        x.bar()
+    }
+}


### PR DESCRIPTION
Fixes #370

This PR:
 - adds a `Self` kind for `ImplSource`. This is useful for generic information within a trait.
 - propagate `impl` on function calls.  

Fixes #20


**Note**: this PR failing is blocking for @cmester0's #349 and #348.
Since this is a bit urgent, my plan is to make failure silent for now: any backend that relies on this feature will then possibly generate bad code if we hit the edge case that currently makes this PR fails.