### PR TITLE
disable debug asserts in lib

### DIFF
--- a/hax-lib/src/lib.rs
+++ b/hax-lib/src/lib.rs
@@ -24,6 +24,16 @@ macro_rules! proxy_macro_if_not_hax {
         $f($cond)
     };
 }
+
+#[cfg(not(debug_assertions))]
+#[doc(hidden)]
+#[cfg(not(hax))]
+#[macro_export]
+macro_rules! proxy_macro_if_not_hax {
+    ($macro:path, $f:expr, $($arg:tt)*) => {};
+}
+
+#[cfg(debug_assertions)]
 #[doc(hidden)]
 #[cfg(not(hax))]
 #[macro_export]


### PR DESCRIPTION
When not compiling with debug asserts we don't even want the debug_assert macro