### PR TITLE
refactor(exporter): get rid of `opt_def_id` as much as possible

### DIFF
--- a/frontend/exporter/src/rustc_utils.rs
+++ b/frontend/exporter/src/rustc_utils.rs
@@ -164,10 +164,7 @@ pub fn translate_span(span: rustc_span::Span, sess: &rustc_session::Session) -> 
 
 #[tracing::instrument(skip(s))]
 pub(crate) fn get_param_env<'tcx, S: UnderOwnerState<'tcx>>(s: &S) -> ty::ParamEnv<'tcx> {
-    match s.base().opt_def_id {
-        Some(id) => s.base().tcx.param_env(id),
-        None => ty::ParamEnv::empty(),
-    }
+    s.base().tcx.param_env(s.owner_id())
 }
 
 #[tracing::instrument]

--- a/frontend/exporter/src/state.rs
+++ b/frontend/exporter/src/state.rs
@@ -143,6 +143,8 @@ mod types {
                 macro_infos: Rc::new(HashMap::new()),
                 cached_thirs: Rc::new(HashMap::new()),
                 options: Rc::new(options),
+                /// Always prefer `s.owner_id()` to `s.base().opt_def_id`.
+                /// `opt_def_id` is used in `utils` for error reporting
                 opt_def_id: None,
                 local_ctx: Rc::new(RefCell::new(LocalContextS::new())),
                 exported_spans: Rc::new(RefCell::new(HashSet::new())),
@@ -199,7 +201,6 @@ impl<'tcx> State<Base<'tcx>, (), Rc<rustc_middle::mir::Body<'tcx>>, ()> {
 }
 
 /// Updates the OnwerId in a state, making sure to override `opt_def_id` in base as well.
-// TODO: is `opt_def_id` useful at all? (see https://github.com/hacspec/hacspec-v2/issues/273)
 pub fn with_owner_id<'tcx, THIR, MIR>(
     mut base: types::Base<'tcx>,
     thir: THIR,

--- a/frontend/exporter/src/types/copied.rs
+++ b/frontend/exporter/src/types/copied.rs
@@ -897,11 +897,7 @@ impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, AliasTy> for rustc_middle::ty::Ali
         .then(|| {
             let trait_ref = self.trait_ref(tcx);
             let poly_trait_ref = rustc_middle::ty::Binder::dummy(trait_ref);
-            let param_env = s
-                .base()
-                .opt_def_id
-                .map(|did| tcx.param_env(did))
-                .unwrap_or(rustc_middle::ty::ParamEnv::empty());
+            let param_env = tcx.param_env(s.owner_id());
             (
                 self.trait_def_id(tcx).sinto(s),
                 poly_trait_ref.impl_expr(s, param_env),


### PR DESCRIPTION
This is related to #273. `opt_def_id` is useful for error reporting, but should not be used anywhere else.

Fixes #273.