### PR TITLE
fix(nix/devshell): make devshell much lighter

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -79,7 +79,14 @@
         devShells = let
           inputsFrom = [
             packages.hax-rust-frontend.unwrapped
-            packages.hax-engine
+            # `hax-engine`'s build requires `hax-rust-frontend` and
+            # `hax-engine-names-extract`, but in a dev environment,
+            # those two packages are supposed to be built locally,
+            # thus we kill them here
+            (packages.hax-engine.override {
+              hax-rust-frontend = pkgs.hello;
+              hax-engine-names-extract = pkgs.hello;
+            })
           ];
         in let
           packages = [


### PR DESCRIPTION
PR #428 added a heavy local dependency to `hax-engine`, a dependency that is expected to be built locally when developing on hax, making compiling the dev environment dependent on the frontend and thus slow.