### PR TITLE
Allow using hax-lib in #![no_std] environments

### DIFF
--- a/hax-lib/src/lib.rs
+++ b/hax-lib/src/lib.rs
@@ -13,6 +13,8 @@
 //! }
 //! ```
 
+#![no_std]
+
 #[doc(hidden)]
 #[cfg(hax)]
 #[macro_export]
@@ -48,7 +50,7 @@ macro_rules! proxy_macro_if_not_hax {
 /// disappears.
 macro_rules! debug_assert {
     ($($arg:tt)*) => {
-        $crate::proxy_macro_if_not_hax!(::std::debug_assert, no, $($arg)*)
+        $crate::proxy_macro_if_not_hax!(::core::debug_assert, no, $($arg)*)
     };
 }
 
@@ -57,7 +59,7 @@ macro_rules! debug_assert {
 /// into a `assert` in the backend.
 macro_rules! assert {
     ($($arg:tt)*) => {
-        $crate::proxy_macro_if_not_hax!(::std::assert, $crate::assert, $($arg)*)
+        $crate::proxy_macro_if_not_hax!(::core::assert, $crate::assert, $($arg)*)
     };
 }
 


### PR DESCRIPTION
This tiny PR allows using `hax-lib` in Rust `#![no_std]` environments. These environments are common in embedded devices, low-level operating system contexts, etc.

This PR does not have any sort of penalty or cost for environments that do not use `#![no_std]`.
