### PR TITLE
Extend generic printer API with auxiliary information

### DIFF
--- a/engine/bin/dune
+++ b/engine/bin/dune
@@ -2,7 +2,14 @@
  (name lib)
  (modules lib)
  (wrapped false)
- (libraries hax_engine fstar_backend coq_backend easycrypt_backend proverif_backend logs core)
+ (libraries
+  hax_engine
+  fstar_backend
+  coq_backend
+  easycrypt_backend
+  proverif_backend
+  logs
+  core)
  (preprocess
   (pps
    ppx_yojson_conv

--- a/engine/doc/dune
+++ b/engine/doc/dune
@@ -1,3 +1,3 @@
 (documentation
-  (package hax-engine)
-  (mld_files index))
+ (package hax-engine)
+ (mld_files index))

--- a/engine/lib/generic_printer/generic_printer.ml
+++ b/engine/lib/generic_printer/generic_printer.ml
@@ -429,6 +429,8 @@ module Make (F : Features.T) (View : Concrete_ident.VIEW_API) = struct
   include Class
 
   include Api (struct
+    type aux_info = unit
+
     let new_print () = (new Class.print :> print_object)
   end)
 end

--- a/engine/lib/generic_printer/generic_printer_base.ml
+++ b/engine/lib/generic_printer/generic_printer_base.ml
@@ -346,30 +346,37 @@ module Make (F : Features.T) = struct
     end
 
   module type API = sig
-    val items : item list -> annot_str
-    val item : item -> annot_str
-    val expr : expr -> annot_str
-    val pat : pat -> annot_str
-    val ty : ty -> annot_str
+    type aux_info
+
+    val items : aux_info -> item list -> annot_str
+    val item : aux_info -> item -> annot_str
+    val expr : aux_info -> expr -> annot_str
+    val pat : aux_info -> pat -> annot_str
+    val ty : aux_info -> ty -> annot_str
   end
 
   module Api (NewPrint : sig
-    val new_print : unit -> print_object
+    type aux_info
+
+    val new_print : aux_info -> print_object
   end) =
   struct
     open NewPrint
 
-    let mk (f : print_object -> 'a -> PPrint.document) (x : 'a) : annot_str =
-      let printer = new_print () in
+    let mk (f : print_object -> 'a -> PPrint.document) (aux : aux_info) (x : 'a)
+        : annot_str =
+      let printer = new_print aux in
       let doc = f printer x in
       let buf = Buffer.create 0 in
       PPrint.ToBuffer.pretty 1.0 80 buf doc;
       (Buffer.contents buf, printer#get_span_data ())
 
-    let items : item list -> annot_str = mk (fun p -> p#items)
-    let item : item -> annot_str = mk (fun p -> p#item)
-    let expr : expr -> annot_str = mk (fun p -> p#expr AlreadyPar)
-    let pat : pat -> annot_str = mk (fun p -> p#pat AlreadyPar)
-    let ty : ty -> annot_str = mk (fun p -> p#ty AlreadyPar)
+    type aux_info = NewPrint.aux_info
+
+    let items : aux_info -> item list -> annot_str = mk (fun p -> p#items)
+    let item : aux_info -> item -> annot_str = mk (fun p -> p#item)
+    let expr : aux_info -> expr -> annot_str = mk (fun p -> p#expr AlreadyPar)
+    let pat : aux_info -> pat -> annot_str = mk (fun p -> p#pat AlreadyPar)
+    let ty : aux_info -> ty -> annot_str = mk (fun p -> p#ty AlreadyPar)
   end
 end


### PR DESCRIPTION
This PR allows passing in auxiliary information on creation of a `print` object. This is useful if a generic-printer-based backend requires some information to be collected before doing a certain print pass on the AST, e.g. in the ProVerif backend I want to first scan the AST for function definitions so that I can recognize them during printing at the call-site.

I can imagine other uses as well, e.g. we might not need to insert a full preamble of pre-defined models every time, but only those that are really necessary to model the contents of the AST. Being able to go through the AST once, collecting this information and making it available on later print passes that construct the preamble is a simple solution here as well.