### PR TITLE
fix(engine/import-thir): fix leaking errors

### DIFF
--- a/engine/lib/diagnostics.ml
+++ b/engine/lib/diagnostics.ml
@@ -121,7 +121,11 @@ end = struct
 
   let capture (type a) (f : unit -> a) : a * t list =
     let previous_state = !state in
-    let result = (f (), !state) in
+    state := [];
+    let result =
+      let x = f () in
+      (x, !state)
+    in
     state := previous_state;
     result
 end


### PR DESCRIPTION
The `capture` function of `diagnostics.ml` was badly implemented. Seems like in the expression `(f (), g ())` OCaml first runs `g` and then `f`! (see https://try.ocamlpro.com/#code/((fun'_'-$.'prerr_endline'$(A$()'(),'(fun'_'-$.'prerr_endline'$(B$()'()) )

I'm using a state to capture errors, and using `(f (), !state)`, I was ignoring the side effects of `f`, which is... the only point of that `capture` function.