### PR TITLE
[ProVerif] Translate crate-internal names

### DIFF
--- a/engine/backends/proverif/proverif_backend.ml
+++ b/engine/backends/proverif/proverif_backend.ml
@@ -285,6 +285,24 @@ module Print = struct
                 | None -> super#pat' ctx pat)
             | _ -> super#pat' ctx pat
 
+      method! expr_app f args _generic_args =
+        let args =
+          separate_map
+            (comma ^^ break 1)
+            (print#expr_at Expr_App_arg >> group)
+            args
+        in
+        let f =
+          match f with
+          | { e = GlobalVar name; _ } -> (
+              match name with
+              | `Projector (`Concrete i) | `Concrete i ->
+                  super#concrete_ident' ~under_current_ns:true i |> group
+              | _ -> super#expr_at Expr_App_f f |> group)
+        in
+
+        f ^^ iblock parens args
+
       method! expr' : Generic_printer_base.par_state -> expr' fn =
         fun ctx e ->
           let wrap_parens =

--- a/engine/backends/proverif/proverif_backend.ml
+++ b/engine/backends/proverif/proverif_backend.ml
@@ -446,15 +446,14 @@ module Print = struct
         fun ~is_record ~is_struct:_ ~constructor ~base:_ args ->
           if is_record then
             string "t_"
-            (* FIXME: How do I get at the ident from the struct definition instead? *)
-            ^^ print#concrete_ident constructor
+            ^^ print#concrete_ident' ~under_current_ns:true constructor
             ^^ iblock parens
                  (separate_map
                     (break 0 ^^ comma)
                     (fun (field, body) -> iblock Fn.id body |> group)
                     args)
           else
-            print#concrete_ident constructor
+            print#concrete_ident' ~under_current_ns:true constructor
             ^^ iblock parens (separate_map (comma ^^ break 1) snd args)
 
       method ty_app f args =

--- a/engine/backends/proverif/proverif_backend.ml
+++ b/engine/backends/proverif/proverif_backend.ml
@@ -500,7 +500,7 @@ module Print = struct
 end
 
 let filter_crate_functions (items : AST.item list) =
-  CrateFns {List.filter ~f:(fun item -> [%matches? Fn _] item.v) items}
+  List.filter ~f:(fun item -> [%matches? Fn _] item.v) items
 
 let is_process_read : attrs -> bool =
   Attr_payloads.payloads >> List.exists ~f:(fst >> [%matches? Types.ProcessRead])
@@ -560,8 +560,12 @@ module Letfuns = MkSubprinter (struct
     let process_letfuns, pure_letfuns =
       List.partition_tf ~f:is_process (filter_crate_functions items)
     in
-    let pure_letfuns_print, _ = Print.items (filter_crate_functions items) pure_letfuns in
-    let process_letfuns_print, _ = Print.items (filter_crate_functions items) process_letfuns in
+    let pure_letfuns_print, _ =
+      Print.items (CrateFns (filter_crate_functions items)) pure_letfuns
+    in
+    let process_letfuns_print, _ =
+      Print.items (CrateFns (filter_crate_functions items)) process_letfuns
+    in
     pure_letfuns_print ^ process_letfuns_print
 end)
 

--- a/engine/backends/proverif/proverif_backend.ml
+++ b/engine/backends/proverif/proverif_backend.ml
@@ -304,7 +304,7 @@ module Print = struct
                 }
     end
 
-  type proverif_aux_info = AstItems of AST.item list | NoAuxInfo
+  type proverif_aux_info = CrateFns of AST.item list | NoAuxInfo
 
   include Api (struct
     type aux_info = proverif_aux_info
@@ -314,7 +314,7 @@ module Print = struct
 end
 
 let filter_crate_functions (items : AST.item list) =
-  List.filter ~f:(fun item -> [%matches? Fn _] item.v) items
+  CrateFns {List.filter ~f:(fun item -> [%matches? Fn _] item.v) items}
 
 let is_process_read : attrs -> bool =
   Attr_payloads.payloads >> List.exists ~f:(fst >> [%matches? Types.ProcessRead])
@@ -374,8 +374,8 @@ module Letfuns = MkSubprinter (struct
     let process_letfuns, pure_letfuns =
       List.partition_tf ~f:is_process (filter_crate_functions items)
     in
-    let pure_letfuns_print, _ = Print.items NoAuxInfo pure_letfuns in
-    let process_letfuns_print, _ = Print.items NoAuxInfo process_letfuns in
+    let pure_letfuns_print, _ = Print.items (filter_crate_functions items) pure_letfuns in
+    let process_letfuns_print, _ = Print.items (filter_crate_functions items) process_letfuns in
     pure_letfuns_print ^ process_letfuns_print
 end)
 

--- a/engine/backends/proverif/proverif_backend.ml
+++ b/engine/backends/proverif/proverif_backend.ml
@@ -471,7 +471,6 @@ module Print = struct
               match translate_known_name ident ~dict:library_types with
               | Some (_, translation) -> translation
               | None -> super#ty ctx ty)
-          | TApp _ -> super#ty ctx ty
           | _ -> string "bitstring"
 
       method! literal : Generic_printer_base.literal_ctx -> literal fn =

--- a/engine/backends/proverif/proverif_backend.ml
+++ b/engine/backends/proverif/proverif_backend.ml
@@ -401,8 +401,8 @@ module Print = struct
             in
             string "letfun" ^^ space
             ^^ align
-                 (print#concrete_ident name
-                 ^^ params_string ^^ space ^^ equals ^^ hardline
+                 (print#concrete_ident name ^^ params_string ^^ space ^^ equals
+                ^^ hardline
                  ^^ print#expr_at Item_Fn_body body
                  ^^ dot)
         (* `struct` definitions are transformed into simple constructors and `reduc`s for accessing fields. *)
@@ -467,9 +467,7 @@ module Print = struct
             print#concrete_ident constructor
             ^^ iblock parens (separate_map (comma ^^ break 1) snd args)
 
-      method ty_app f args =
-        print#concrete_ident f
-        ^^ print#generic_values args
+      method ty_app f args = print#concrete_ident f ^^ print#generic_values args
 
       method ty : Generic_printer_base.par_state -> ty fn =
         fun ctx ty ->

--- a/engine/backends/proverif/proverif_backend.ml
+++ b/engine/backends/proverif/proverif_backend.ml
@@ -297,7 +297,7 @@ module Print = struct
           | { e = GlobalVar name; _ } -> (
               match name with
               | `Projector (`Concrete i) | `Concrete i ->
-                  print#concrete_ident' ~under_current_ns:false i |> group
+                  print#concrete_ident i |> group
               | _ -> super#expr_at Expr_App_f f |> group)
         in
 
@@ -401,7 +401,7 @@ module Print = struct
             in
             string "letfun" ^^ space
             ^^ align
-                 (print#concrete_ident' ~under_current_ns:false name
+                 (print#concrete_ident name
                  ^^ params_string ^^ space ^^ equals ^^ hardline
                  ^^ print#expr_at Item_Fn_body body
                  ^^ dot)
@@ -457,18 +457,18 @@ module Print = struct
             (global_ident * document) list fn =
         fun ~is_record ~is_struct:_ ~constructor ~base:_ args ->
           if is_record then
-            print#concrete_ident' ~under_current_ns:false constructor
+            print#concrete_ident constructor
             ^^ iblock parens
                  (separate_map
                     (break 0 ^^ comma)
                     (fun (field, body) -> iblock Fn.id body |> group)
                     args)
           else
-            print#concrete_ident' ~under_current_ns:false constructor
+            print#concrete_ident constructor
             ^^ iblock parens (separate_map (comma ^^ break 1) snd args)
 
       method ty_app f args =
-        print#concrete_ident' ~under_current_ns:false f
+        print#concrete_ident f
         ^^ print#generic_values args
 
       method ty : Generic_printer_base.par_state -> ty fn =

--- a/engine/backends/proverif/proverif_backend.ml
+++ b/engine/backends/proverif/proverif_backend.ml
@@ -457,6 +457,10 @@ module Print = struct
             print#concrete_ident constructor
             ^^ iblock parens (separate_map (comma ^^ break 1) snd args)
 
+      method ty_app f args =
+        print#concrete_ident' ~under_current_ns:true f
+        ^^ print#generic_values args
+
       method ty : Generic_printer_base.par_state -> ty fn =
         fun ctx ty ->
           match ty with


### PR DESCRIPTION
This PR provides coherent translation of crate-internal names, e.g. where before you had `some_function` at the definition site and `crate::some::mod::function` at the call site in another module, you now get `crate__some__mod__some_function` everywhere. Similar for types and their constructors.

Fixes #450.