### PR TITLE
Frontend: fix `Self`

### DIFF
--- a/test-harness/src/snapshots/toolchain__traits into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__traits into-fstar.snap
@@ -55,7 +55,8 @@ class t_Foo (v_Self: Type) = {
   f_AssocType:Core.Marker.t_Sized _;
   f_N:usize;
   f_assoc_f:Prims.unit -> Prims.unit;
-  f_method_f:v_Self -> Prims.unit
+  f_method_f:v_Self -> Prims.unit;
+  f_assoc_type:{| i3: Core.Marker.t_Copy _ |} -> _ -> Prims.unit
 }
 
 let closure_impl_expr
@@ -103,7 +104,8 @@ let impl_Foo_for_tuple_: t_Foo Prims.unit =
     f_AssocType = i32;
     f_N = sz 32;
     f_assoc_f = () <: Prims.unit;
-    f_method_f = fun (self: Prims.unit) -> f_assoc_f ()
+    f_method_f = (fun (self: Prims.unit) -> f_assoc_f ());
+    f_assoc_type = fun (_: i32) -> ()
   }
 
 type t_Struct = | Struct : t_Struct

--- a/tests/traits/src/lib.rs
+++ b/tests/traits/src/lib.rs
@@ -9,6 +9,9 @@ pub trait Foo {
     const N: usize;
     fn assoc_f() -> ();
     fn method_f(&self) -> ();
+    fn assoc_type(_: Self::AssocType) -> ()
+    where
+        Self::AssocType: Copy;
 }
 
 impl SuperTrait for i32 {
@@ -26,6 +29,7 @@ impl Foo for () {
     fn method_f(&self) {
         Self::assoc_f()
     }
+    fn assoc_type(_: Self::AssocType) -> () {}
 }
 
 fn f<T: Foo>(x: T) {


### PR DESCRIPTION
This PR allows to the `Self` impl expression to carry a subpath.
For example with a where clause `where Self::AssocType: SomeTrait`, calling a method `foo` that belongs to `SomeTrait` will use the implementation located at path "Self/AssocItem("AssocType")/Parent("SomeTrait")".

Fixes #482.
