### PR TITLE
Syntactically correct extraction for one Bertie function

### DIFF
--- a/engine/backends/proverif/proverif_backend.ml
+++ b/engine/backends/proverif/proverif_backend.ml
@@ -656,11 +656,11 @@ let translate m (bo : BackendOptions.t) (items : AST.item list) :
     Preamble.print items ^ DataTypes.print items ^ Letfuns.print items
     ^ Processes.print items
   in
-  let analysis_contents =
-    Toplevel.print items
-  in
+  let analysis_contents = Toplevel.print items in
   let lib_file = Types.{ path = "lib.pvl"; contents = lib_contents } in
-  let analysis_file = Types.{ path = "analysis.pv"; contents = analysis_contents } in
+  let analysis_file =
+    Types.{ path = "analysis.pv"; contents = analysis_contents }
+  in
   [ lib_file; analysis_file ]
 
 open Phase_utils

--- a/engine/backends/proverif/proverif_backend.ml
+++ b/engine/backends/proverif/proverif_backend.ml
@@ -366,6 +366,18 @@ module Print = struct
                 (hardline ^^ string "else ")
                 (fun { arm; span } -> print#match_arm scrutinee arm)
                 arms
+          | If { cond; then_; else_ } ->
+              let if_then =
+                (string "if" ^//^ nest 2 (print#expr_at Expr_If_cond cond))
+                ^/^ string "then"
+                ^//^ (print#expr_at Expr_If_then then_ |> parens |> nest 1)
+              in
+              (match else_ with
+              | None -> if_then
+              | Some else_ ->
+                  if_then ^^ break 1 ^^ string "else" ^^ space
+                  ^^ (print#expr_at Expr_If_else else_ |> iblock parens))
+              |> wrap_parens
           | _ -> super#expr' ctx e
 
       method concrete_ident = print#concrete_ident' ~under_current_ns:false

--- a/engine/backends/proverif/proverif_backend.ml
+++ b/engine/backends/proverif/proverif_backend.ml
@@ -247,7 +247,7 @@ module Print = struct
     [
       (* (\* hax_lib_protocol::cal::(t_DHScalar *\) *)
       (* (Hax_lib_protocol__crypto__DHScalar, string "PLACEHOLDER_library_type"); *)
-      (Core__option__Option, string "PLACEHOLDER_library_type");
+      (* (Core__option__Option, string "PLACEHOLDER_library_type"); *)
       (* (Alloc__vec__Vec, string "PLACEHOLDER_library_type"); *)
     ]
 

--- a/engine/backends/proverif/proverif_backend.ml
+++ b/engine/backends/proverif/proverif_backend.ml
@@ -480,22 +480,6 @@ module Print = struct
               | Some (_, translation) -> translation
               | None -> super#ty ctx ty)
           | _ -> string "bitstring"
-
-      method! literal : Generic_printer_base.literal_ctx -> literal fn =
-        fun _ctx -> function
-          | Int { value; negative; _ } ->
-              string "int2bitstring"
-              ^^ iblock parens
-                   (string value |> precede (if negative then minus else empty))
-          | Bool b -> OCaml.bool b
-          | _ ->
-              Error.raise
-                {
-                  kind =
-                    ExplicitRejection
-                      { reason = "Literal unsupported by ProVerif backend." };
-                  span = current_span;
-                }
     end
 
   type proverif_aux_info = CrateFns of AST.item list | NoAuxInfo

--- a/engine/backends/proverif/proverif_backend.ml
+++ b/engine/backends/proverif/proverif_backend.ml
@@ -345,13 +345,6 @@ module Print = struct
               | Some (name, translation) -> translation args
               | None -> (
                   match name with
-                  | `Concrete name ->
-                      print#field_accessor name
-                      ^^ iblock parens
-                           (separate_map
-                              (comma ^^ break 1)
-                              (fun arg -> print#expr AlreadyPar arg)
-                              args)
                   | `Projector (`Concrete name) ->
                       print#field_accessor name
                       ^^ iblock parens

--- a/engine/backends/proverif/proverif_backend.ml
+++ b/engine/backends/proverif/proverif_backend.ml
@@ -415,6 +415,7 @@ module Print = struct
             ^^ iblock parens fun_args_types
             ^^ string ": "
             ^^ print#concrete_ident base_name
+            ^^ string "[data]"
             ^^ dot
           in
           let reduc_line =

--- a/engine/backends/proverif/proverif_backend.ml
+++ b/engine/backends/proverif/proverif_backend.ml
@@ -652,12 +652,16 @@ end)
 
 let translate m (bo : BackendOptions.t) (items : AST.item list) :
     Types.file list =
-  let contents =
+  let lib_contents =
     Preamble.print items ^ DataTypes.print items ^ Letfuns.print items
-    ^ Processes.print items ^ Toplevel.print items
+    ^ Processes.print items
   in
-  let file = Types.{ path = "output.pv"; contents } in
-  [ file ]
+  let analysis_contents =
+    Toplevel.print items
+  in
+  let lib_file = Types.{ path = "lib.pvl"; contents = lib_contents } in
+  let analysis_file = Types.{ path = "analysis.pv"; contents = analysis_contents } in
+  [ lib_file; analysis_file ]
 
 open Phase_utils
 module DepGraph = Dependencies.Make (InputLanguage)

--- a/engine/backends/proverif/proverif_backend.ml
+++ b/engine/backends/proverif/proverif_backend.ml
@@ -343,7 +343,7 @@ module Print = struct
               super#expr' ctx (snd (Option.value_exn (List.hd fields))).e
           | Construct { constructor; _ }
             when Global_ident.eq_name Core__result__Result__Err constructor ->
-              string "fail"
+              string "construct_fail()"
           (* Translate known constructors *)
           | Construct { constructor; fields } -> (
               match
@@ -568,7 +568,7 @@ end
 
 module Preamble = MkSubprinter (struct
   let banner = "Preamble"
-  let preamble items = "channel c.\nfun int2bitstring(nat): bitstring.\n"
+  let preamble items = "channel c.\nfun int2bitstring(nat): bitstring.\ntype err.\nfun construct_fail() : err\nreduc construct_fail() = fail.\n"
   let contents items = ""
 end)
 

--- a/engine/backends/proverif/proverif_backend.ml
+++ b/engine/backends/proverif/proverif_backend.ml
@@ -275,7 +275,7 @@ module Print = struct
             ^^ string " in " ^^ body
 
       method ty_bool = string "bool"
-      method ty_int _ = string "bitstring"
+      method ty_int _ = string "nat"
 
       method pat' : Generic_printer_base.par_state -> pat' fn =
         fun ctx ->
@@ -536,6 +536,7 @@ module Print = struct
           match ty with
           | TBool -> print#ty_bool
           | TParam i -> print#local_ident i
+          | TInt kind -> print#ty_int kind
           (* Translate known types, no args at the moment *)
           | TApp { ident; args } -> super#ty ctx ty
           (*(

--- a/engine/backends/proverif/proverif_backend.ml
+++ b/engine/backends/proverif/proverif_backend.ml
@@ -265,7 +265,9 @@ module Print = struct
 
   class print aux =
     object (print)
-      inherit GenericPrint.print as super
+    inherit GenericPrint.print as super
+
+      method field_accessor field_name = string "accessor" ^^ underscore ^^ print#concrete_ident field_name
       method ty_bool = string "bool"
       method ty_int _ = string "bitstring"
 
@@ -300,7 +302,6 @@ module Print = struct
                   print#concrete_ident i |> group
               | _ -> super#expr_at Expr_App_f f |> group)
         in
-
         f ^^ iblock parens args
 
       method! expr' : Generic_printer_base.par_state -> expr' fn =

--- a/engine/backends/proverif/proverif_backend.ml
+++ b/engine/backends/proverif/proverif_backend.ml
@@ -244,12 +244,10 @@ module Print = struct
       (*   fun args -> string "PLACEHOLDER_library_constructor" ); *) ]
 
   let library_types : (Concrete_ident_generated.name * document) list =
-    [
-      (* (\* hax_lib_protocol::cal::(t_DHScalar *\) *)
+    [ (* (\* hax_lib_protocol::cal::(t_DHScalar *\) *)
       (* (Hax_lib_protocol__crypto__DHScalar, string "PLACEHOLDER_library_type"); *)
       (* (Core__option__Option, string "PLACEHOLDER_library_type"); *)
-      (* (Alloc__vec__Vec, string "PLACEHOLDER_library_type"); *)
-    ]
+      (* (Alloc__vec__Vec, string "PLACEHOLDER_library_type"); *) ]
 
   let assoc_known_name name (known_name, _) =
     Global_ident.eq_name known_name name

--- a/engine/backends/proverif/proverif_backend.ml
+++ b/engine/backends/proverif/proverif_backend.ml
@@ -114,147 +114,141 @@ module Print = struct
   (* TODO: Give definitions for core / known library functions, cf issues #447, #448 *)
   let library_functions :
       (Concrete_ident_generated.name * (AST.expr list -> document)) list =
-    [
-      (* Core dependencies *)
-      (Alloc__vec__from_elem, fun args -> string "PLACEHOLDER_library_function");
-      ( Alloc__slice__Impl__to_vec,
-        fun args -> string "PLACEHOLDER_library_function" );
-      (Core__slice__Impl__len, fun args -> string "PLACEHOLDER_library_function");
-      ( Core__ops__deref__Deref__deref,
-        fun args -> string "PLACEHOLDER_library_function" );
-      ( Core__ops__index__Index__index,
-        fun args -> string "PLACEHOLDER_library_function" );
-      ( Rust_primitives__unsize,
-        fun args -> string "PLACEHOLDER_library_function" );
-      ( Core__num__Impl_9__to_le_bytes,
-        fun args -> string "PLACEHOLDER_library_function" );
-      ( Alloc__slice__Impl__into_vec,
-        fun args -> string "PLACEHOLDER_library_function" );
-      ( Alloc__vec__Impl_1__truncate,
-        fun args -> string "PLACEHOLDER_library_function" );
-      ( Alloc__vec__Impl_2__extend_from_slice,
-        fun args -> string "PLACEHOLDER_library_function" );
-      ( Alloc__slice__Impl__concat,
-        fun args -> string "PLACEHOLDER_library_function" );
-      ( Core__option__Impl__is_some,
-        fun args -> string "PLACEHOLDER_library_function" );
-      (* core::clone::Clone_f_clone *)
-      ( Core__clone__Clone__clone,
-        fun args -> string "PLACEHOLDER_library_function" );
-      (* core::cmp::PartialEq::eq *)
-      ( Core__cmp__PartialEq__eq,
-        fun args -> string "PLACEHOLDER_library_function" );
-      (* core::cmp::PartialEq_f_ne *)
-      ( Core__cmp__PartialEq__ne,
-        fun args -> string "PLACEHOLDER_library_function" );
-      (* core::cmp::PartialOrd::lt *)
-      ( Core__cmp__PartialOrd__lt,
-        fun args -> string "PLACEHOLDER_library_function" );
-      (* core::ops::arith::Add::add *)
-      ( Core__ops__arith__Add__add,
-        fun args -> string "PLACEHOLDER_library_function" );
-      (* core::ops::arith::Sub::sub *)
-      ( Core__ops__arith__Sub__sub,
-        fun args -> string "PLACEHOLDER_library_function" );
-      (* core::option::Option_Option_None_c *)
-      ( Core__option__Option__None,
-        fun args -> string "PLACEHOLDER_library_function" );
-      (* core::option::Option_Option_Some_c *)
-      ( Core__option__Option__Some,
-        fun args -> string "PLACEHOLDER_library_function" );
-      (* core::result::impl__map_err *)
-      ( Core__result__Impl__map_err,
-        fun args -> string "PLACEHOLDER_library_function" );
-      (* Crypto dependencies *)
-      (* hax_lib_protocol::cal::hash *)
-      ( Hax_lib_protocol__crypto__hash,
-        fun args -> string "PLACEHOLDER_library_function" );
-      (* hax_lib_protocol::cal::hmac *)
-      ( Hax_lib_protocol__crypto__hmac,
-        fun args -> string "PLACEHOLDER_library_function" );
-      (* hax_lib_protocol::cal::aead_decrypt *)
-      ( Hax_lib_protocol__crypto__aead_decrypt,
-        fun args -> string "PLACEHOLDER_library_function" );
-      (* hax_lib_protocol::cal::aead_encrypt *)
-      ( Hax_lib_protocol__crypto__aead_encrypt,
-        fun args -> string "PLACEHOLDER_library_function" );
-      (* hax_lib_protocol::cal::dh_scalar_multiply *)
-      ( Hax_lib_protocol__crypto__dh_scalar_multiply,
-        fun args -> string "PLACEHOLDER_library_function" );
-      (* hax_lib_protocol::cal::dh_scalar_multiply_base *)
-      ( Hax_lib_protocol__crypto__dh_scalar_multiply_base,
-        fun args -> string "PLACEHOLDER_library_function" );
-      (* hax_lib_protocol::cal::impl__DHScalar__from_bytes *)
-      ( Hax_lib_protocol__crypto__Impl__from_bytes,
-        fun args -> string "PLACEHOLDER_library_function" );
-      (* hax_lib_protocol::cal::impl__DHElement__from_bytes *)
-      ( Hax_lib_protocol__crypto__Impl_1__from_bytes,
-        fun args -> string "PLACEHOLDER_library_function" );
-      (* hax_lib_protocol::cal::impl__AEADKey__from_bytes *)
-      ( Hax_lib_protocol__crypto__Impl_4__from_bytes,
-        fun args -> string "PLACEHOLDER_library_function" );
-      (* hax_lib_protocol::cal::impl__AEADIV__from_bytes *)
-      ( Hax_lib_protocol__crypto__Impl_5__from_bytes,
-        fun args -> string "PLACEHOLDER_library_function" );
-      (* hax_lib_protocol::cal::impl__AEADTag__from_bytes *)
-      ( Hax_lib_protocol__crypto__Impl_6__from_bytes,
-        fun args -> string "PLACEHOLDER_library_function" );
-    ]
+    [ (* (\* Core dependencies *\) *)
+      (* (Alloc__vec__from_elem, fun args -> string "PLACEHOLDER_library_function"); *)
+      (* ( Alloc__slice__Impl__to_vec, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* (Core__slice__Impl__len, fun args -> string "PLACEHOLDER_library_function"); *)
+      (* ( Core__ops__deref__Deref__deref, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* ( Core__ops__index__Index__index, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* ( Rust_primitives__unsize, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* ( Core__num__Impl_9__to_le_bytes, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* ( Alloc__slice__Impl__into_vec, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* ( Alloc__vec__Impl_1__truncate, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* ( Alloc__vec__Impl_2__extend_from_slice, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* ( Alloc__slice__Impl__concat, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* ( Core__option__Impl__is_some, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* (\* core::clone::Clone_f_clone *\) *)
+      (* ( Core__clone__Clone__clone, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* (\* core::cmp::PartialEq::eq *\) *)
+      (* ( Core__cmp__PartialEq__eq, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* (\* core::cmp::PartialEq_f_ne *\) *)
+      (* ( Core__cmp__PartialEq__ne, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* (\* core::cmp::PartialOrd::lt *\) *)
+      (* ( Core__cmp__PartialOrd__lt, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* (\* core::ops::arith::Add::add *\) *)
+      (* ( Core__ops__arith__Add__add, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* (\* core::ops::arith::Sub::sub *\) *)
+      (* ( Core__ops__arith__Sub__sub, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* (\* core::option::Option_Option_None_c *\) *)
+      (* ( Core__option__Option__None, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* (\* core::option::Option_Option_Some_c *\) *)
+      (* ( Core__option__Option__Some, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* (\* core::result::impl__map_err *\) *)
+      (* ( Core__result__Impl__map_err, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* (\* Crypto dependencies *\) *)
+      (* (\* hax_lib_protocol::cal::hash *\) *)
+      (* ( Hax_lib_protocol__crypto__hash, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* (\* hax_lib_protocol::cal::hmac *\) *)
+      (* ( Hax_lib_protocol__crypto__hmac, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* (\* hax_lib_protocol::cal::aead_decrypt *\) *)
+      (* ( Hax_lib_protocol__crypto__aead_decrypt, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* (\* hax_lib_protocol::cal::aead_encrypt *\) *)
+      (* ( Hax_lib_protocol__crypto__aead_encrypt, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* (\* hax_lib_protocol::cal::dh_scalar_multiply *\) *)
+      (* ( Hax_lib_protocol__crypto__dh_scalar_multiply, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* (\* hax_lib_protocol::cal::dh_scalar_multiply_base *\) *)
+      (* ( Hax_lib_protocol__crypto__dh_scalar_multiply_base, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* (\* hax_lib_protocol::cal::impl__DHScalar__from_bytes *\) *)
+      (* ( Hax_lib_protocol__crypto__Impl__from_bytes, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* (\* hax_lib_protocol::cal::impl__DHElement__from_bytes *\) *)
+      (* ( Hax_lib_protocol__crypto__Impl_1__from_bytes, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* (\* hax_lib_protocol::cal::impl__AEADKey__from_bytes *\) *)
+      (* ( Hax_lib_protocol__crypto__Impl_4__from_bytes, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* (\* hax_lib_protocol::cal::impl__AEADIV__from_bytes *\) *)
+      (* ( Hax_lib_protocol__crypto__Impl_5__from_bytes, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *)
+      (* (\* hax_lib_protocol::cal::impl__AEADTag__from_bytes *\) *)
+      (* ( Hax_lib_protocol__crypto__Impl_6__from_bytes, *)
+      (*   fun args -> string "PLACEHOLDER_library_function" ); *) ]
 
   let library_constructors :
       (Concrete_ident_generated.name
       * ((global_ident * AST.expr) list -> document))
       list =
-    [
-      ( Core__option__Option__Some,
-        fun args -> string "PLACEHOLDER_library_constructor" );
-      ( Core__option__Option__None,
-        fun args -> string "PLACEHOLDER_library_constructor" );
-      ( Core__ops__range__Range,
-        fun args -> string "PLACEHOLDER_library_constructor" );
-      (* hax_lib_protocol::cal::(HashAlgorithm_HashAlgorithm_Sha256_c *)
-      ( Hax_lib_protocol__crypto__HashAlgorithm__Sha256,
-        fun args -> string "PLACEHOLDER_library_constructor" );
-      (* hax_lib_protocol::cal::DHGroup_DHGroup_X25519_c *)
-      ( Hax_lib_protocol__crypto__DHGroup__X25519,
-        fun args -> string "PLACEHOLDER_library_constructor" );
-      (* hax_lib_protocol::cal::AEADAlgorithm_AEADAlgorithm_Chacha20Poly1305_c *)
-      ( Hax_lib_protocol__crypto__AEADAlgorithm__Chacha20Poly1305,
-        fun args -> string "PLACEHOLDER_library_constructor" );
-      (* hax_lib_protocol::cal::HMACAlgorithm_HMACAlgorithm_Sha256_c *)
-      ( Hax_lib_protocol__crypto__HMACAlgorithm__Sha256,
-        fun args -> string "PLACEHOLDER_library_constructor" );
-    ]
+    [ (* ( Core__option__Option__Some, *)
+      (*   fun args -> string "PLACEHOLDER_library_constructor" ); *)
+      (* ( Core__option__Option__None, *)
+      (*   fun args -> string "PLACEHOLDER_library_constructor" ); *)
+      (* ( Core__ops__range__Range, *)
+      (*   fun args -> string "PLACEHOLDER_library_constructor" ); *)
+      (* (\* hax_lib_protocol::cal::(HashAlgorithm_HashAlgorithm_Sha256_c *\) *)
+      (* ( Hax_lib_protocol__crypto__HashAlgorithm__Sha256, *)
+      (*   fun args -> string "PLACEHOLDER_library_constructor" ); *)
+      (* (\* hax_lib_protocol::cal::DHGroup_DHGroup_X25519_c *\) *)
+      (* ( Hax_lib_protocol__crypto__DHGroup__X25519, *)
+      (*   fun args -> string "PLACEHOLDER_library_constructor" ); *)
+      (* (\* hax_lib_protocol::cal::AEADAlgorithm_AEADAlgorithm_Chacha20Poly1305_c *\) *)
+      (* ( Hax_lib_protocol__crypto__AEADAlgorithm__Chacha20Poly1305, *)
+      (*   fun args -> string "PLACEHOLDER_library_constructor" ); *)
+      (* (\* hax_lib_protocol::cal::HMACAlgorithm_HMACAlgorithm_Sha256_c *\) *)
+      (* ( Hax_lib_protocol__crypto__HMACAlgorithm__Sha256, *)
+      (*   fun args -> string "PLACEHOLDER_library_constructor" ); *) ]
 
   let library_constructor_patterns :
       (Concrete_ident_generated.name * (field_pat list -> document)) list =
-    [
-      ( Core__option__Option__Some,
-        fun args -> string "PLACEHOLDER_library_constructor" );
-      ( Core__option__Option__None,
-        fun args -> string "PLACEHOLDER_library_constructor" );
-      ( Core__ops__range__Range,
-        fun args -> string "PLACEHOLDER_library_constructor" );
-      (* hax_lib_protocol::cal::(HashAlgorithm_HashAlgorithm_Sha256_c *)
-      ( Hax_lib_protocol__crypto__HashAlgorithm__Sha256,
-        fun args -> string "PLACEHOLDER_library_constructor" );
-      (* hax_lib_protocol::cal::DHGroup_DHGroup_X25519_c *)
-      ( Hax_lib_protocol__crypto__DHGroup__X25519,
-        fun args -> string "PLACEHOLDER_library_constructor" );
-      (* hax_lib_protocol::cal::AEADAlgorithm_AEADAlgorithm_Chacha20Poly1305_c *)
-      ( Hax_lib_protocol__crypto__AEADAlgorithm__Chacha20Poly1305,
-        fun args -> string "PLACEHOLDER_library_constructor" );
-      (* hax_lib_protocol::cal::HMACAlgorithm_HMACAlgorithm_Sha256_c *)
-      ( Hax_lib_protocol__crypto__HMACAlgorithm__Sha256,
-        fun args -> string "PLACEHOLDER_library_constructor" );
-    ]
+    [ (* ( Core__option__Option__Some, *)
+      (*   fun args -> string "PLACEHOLDER_library_constructor" ); *)
+      (* ( Core__option__Option__None, *)
+      (*   fun args -> string "PLACEHOLDER_library_constructor" ); *)
+      (* ( Core__ops__range__Range, *)
+      (*   fun args -> string "PLACEHOLDER_library_constructor" ); *)
+      (* (\* hax_lib_protocol::cal::(HashAlgorithm_HashAlgorithm_Sha256_c *\) *)
+      (* ( Hax_lib_protocol__crypto__HashAlgorithm__Sha256, *)
+      (*   fun args -> string "PLACEHOLDER_library_constructor" ); *)
+      (* (\* hax_lib_protocol::cal::DHGroup_DHGroup_X25519_c *\) *)
+      (* ( Hax_lib_protocol__crypto__DHGroup__X25519, *)
+      (*   fun args -> string "PLACEHOLDER_library_constructor" ); *)
+      (* (\* hax_lib_protocol::cal::AEADAlgorithm_AEADAlgorithm_Chacha20Poly1305_c *\) *)
+      (* ( Hax_lib_protocol__crypto__AEADAlgorithm__Chacha20Poly1305, *)
+      (*   fun args -> string "PLACEHOLDER_library_constructor" ); *)
+      (* (\* hax_lib_protocol::cal::HMACAlgorithm_HMACAlgorithm_Sha256_c *\) *)
+      (* ( Hax_lib_protocol__crypto__HMACAlgorithm__Sha256, *)
+      (*   fun args -> string "PLACEHOLDER_library_constructor" ); *) ]
 
   let library_types : (Concrete_ident_generated.name * document) list =
     [
-      (* hax_lib_protocol::cal::(t_DHScalar *)
-      (Hax_lib_protocol__crypto__DHScalar, string "PLACEHOLDER_library_type");
+      (* (\* hax_lib_protocol::cal::(t_DHScalar *\) *)
+      (* (Hax_lib_protocol__crypto__DHScalar, string "PLACEHOLDER_library_type"); *)
       (Core__option__Option, string "PLACEHOLDER_library_type");
-      (Alloc__vec__Vec, string "PLACEHOLDER_library_type");
+      (* (Alloc__vec__Vec, string "PLACEHOLDER_library_type"); *)
     ]
 
   let assoc_known_name name (known_name, _) =

--- a/engine/backends/proverif/proverif_backend.ml
+++ b/engine/backends/proverif/proverif_backend.ml
@@ -259,7 +259,10 @@ module Print = struct
 
   class print aux =
     object (print)
-    inherit GenericPrint.print as super
+      inherit GenericPrint.print as super
+
+      method field_accessor field_name =
+        string "accessor" ^^ underscore ^^ print#concrete_ident field_name
 
       method match_arm scrutinee { arm_pat; body } =
         let body = print#expr_at Arm_body body in
@@ -271,7 +274,6 @@ module Print = struct
             string "let" ^^ space ^^ pat ^^ string " = " ^^ scrutinee
             ^^ string " in " ^^ body
 
-      method field_accessor field_name = string "accessor" ^^ underscore ^^ print#concrete_ident field_name
       method ty_bool = string "bool"
       method ty_int _ = string "bitstring"
 
@@ -407,7 +409,7 @@ module Print = struct
             string "reduc forall " ^^ iblock Fn.id fun_args_full ^^ semi
           in
           let build_accessor (ident, ty, attr) =
-            string "accessor" ^^ underscore ^^ print#concrete_ident ident
+            print#field_accessor ident
             ^^ iblock parens (constructor_name ^^ iblock parens fun_args_names)
             ^^ blank 1 ^^ equals ^^ blank 1 ^^ print#concrete_ident ident
           in

--- a/engine/backends/proverif/proverif_backend.ml
+++ b/engine/backends/proverif/proverif_backend.ml
@@ -568,7 +568,14 @@ end
 
 module Preamble = MkSubprinter (struct
   let banner = "Preamble"
-  let preamble items = "channel c.\nfun int2bitstring(nat): bitstring.\ntype err.\nfun construct_fail() : err\nreduc construct_fail() = fail.\n"
+
+  let preamble items =
+    "channel c.\n\
+     fun int2bitstring(nat): bitstring.\n\
+     type err.\n\
+     fun construct_fail() : err\n\
+     reduc construct_fail() = fail.\n"
+
   let contents items = ""
 end)
 

--- a/engine/backends/proverif/proverif_backend.ml
+++ b/engine/backends/proverif/proverif_backend.ml
@@ -507,6 +507,11 @@ module Print = struct
             print#concrete_ident constructor
             ^^ iblock parens (separate_map (comma ^^ break 1) snd args)
 
+      method generic_values : generic_value list fn =
+          function
+          | [] -> empty
+          | values -> string "_of" ^^ underscore ^^ separate_map underscore print#generic_value values
+
       method ty_app f args = print#concrete_ident f ^^ print#generic_values args
 
       method ty : Generic_printer_base.par_state -> ty fn =
@@ -515,10 +520,11 @@ module Print = struct
           | TBool -> print#ty_bool
           | TParam i -> print#local_ident i
           (* Translate known types, no args at the moment *)
-          | TApp { ident } -> (
+          | TApp { ident; args } -> super#ty ctx ty
+          (*(
               match translate_known_name ident ~dict:library_types with
               | Some (_, translation) -> translation
-              | None -> super#ty ctx ty)
+              | None -> super#ty ctx ty)*)
           | _ -> string "bitstring"
     end
 

--- a/engine/lib/generic_printer/generic_printer.ml
+++ b/engine/lib/generic_printer/generic_printer.ml
@@ -265,7 +265,7 @@ module Make (F : Features.T) (View : Concrete_ident.VIEW_API) = struct
             f ^^ iblock parens args
 
         method doc_construct_tuple : document list fn =
-          separate comma >> iblock parens
+          separate (comma ^^ break 1) >> iblock parens
 
         method expr_construct_tuple : expr list fn =
           List.map ~f:(print#expr_at Expr_ConstructTuple)


### PR DESCRIPTION
This PR includes a number of updates to the ProVerif backend in order to get syntactically correct ProVerif output when extracting a single function (and some of its dependencies) from the `bertie` codebase. Concretely, the extraction target is `-** +**::tls13handshake::put_server_hello -**::tls13utils::** -**::tls13formats::** -**::tls13crypto::** -**::tls13cert::**`.

The PR includes:
- inserting the already generated field accessor when encountering a field access
- translation of `match`:
  ```rust
   match scrutinee {
      pat1 => body1,
      pat2 => body2,
      ...}
  ```

  is translated as

  ```text
  let pat1 = scrutinee in body1
  else let pat2 = scrutinee in body2
  else ...
  ```
  NB: Translation of patterns is still lacking, anything other than simple binding patterns, which work "by accident" is unlikely to be correctly translated. 
- inserting parens instead of braces around translated if-then-else bodies
- inserting a failing destructor when encountering a `Result::Err`
- commenting out the library replacements for now, to see more clearly what's going on in the extracted output (also not all of them are relevant for this specific case)
- "flattening" of generic types: e.g. `Option<Bytes>' becomes `core__option__t_Option_of_bertie__tls13utils__t_Bytes`
- turning any constructor into a `[data]` constructor so we can translate destructuring pattern matching on it
- adding type annotations in the case of destructuring tuple patterns
- translating Rust integer types as `nat` in ProVerif
- separating output of the model, i.e. types and letfuns, from the analysis, i.e. any queries + top-level process