### PR TITLE
fix(cli/setup.sh): `cargo install`: use locked dependencies

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -47,7 +47,7 @@ install_rust_binaries() {
     for i in driver subcommands ../engine/names/extract; do
         (
             set -x
-            cargo install --force --path "cli/$i"
+            cargo install --locked --force --path "cli/$i"
         )
     done
 }


### PR DESCRIPTION
See https://github.com/rust-lang/cargo/issues/6983: by default `cargo install --path ...` doesn't use `Cargo.lock`.
In our case, this caused a rust compatibility issue, because of https://github.com/rust-lang/cargo/issues/9930