### PR TITLE
fix(engine/dune): disable js build by default

### DIFF
--- a/.github/workflows/engine_js_build.yml
+++ b/.github/workflows/engine_js_build.yml
@@ -1,0 +1,18 @@
+name: Test JS build
+
+on:
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    
+jobs:
+  engine-js-build:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group' }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: DeterminateSystems/magic-nix-cache-action@main
+    - run: nix build .\#hax-engine.passthru.js -L  

--- a/CI.md
+++ b/CI.md
@@ -17,7 +17,9 @@
    FStar, we do not run Coq or FStar on the extractions.
  - [`test_installs`](./.github/workflows/test_installs.yml): compiles
    the toolchain on two versions of Ubuntu and two versions of MacOS
-   using `apt` or `homebrew` and the `setup.sh` script.
+   using `apt` or `homebrew` and the `setup.sh` script;
+ - [`engine-js-build`](./.github/workflows/engine_js_build.yml): tests
+   the build the JS version of the engine.
  
 ## Merge queue
 Additional actions are triggered on pull requests in the merge queue. They are

--- a/engine/bin/dune
+++ b/engine/bin/dune
@@ -25,14 +25,10 @@
  (modules native_driver)
  (libraries lib))
 
-(executable
- (optional)
- (name js_driver)
- (modes js)
- (modules js_driver)
- (js_of_ocaml
-  (javascript_files js_stubs/mutex.js js_stubs/stdint.js js_stubs/unix.js))
- (libraries zarith_stubs_js js_of_ocaml lib))
+; The following line is commented: by default, we don't want to
+; generate javascript.
+
+; (include dune-js)
 
 (env
  (_

--- a/engine/bin/dune-js
+++ b/engine/bin/dune-js
@@ -1,0 +1,8 @@
+(executable
+ (optional)
+ (name js_driver)
+ (modes js)
+ (modules js_driver)
+ (js_of_ocaml
+  (javascript_files js_stubs/mutex.js js_stubs/stdint.js js_stubs/unix.js))
+ (libraries zarith_stubs_js js_of_ocaml lib))

--- a/engine/default.nix
+++ b/engine/default.nix
@@ -111,6 +111,8 @@
         name = "hax-engine.js";
         nativeBuildInputs = old.nativeBuildInputs ++ [closurecompiler gnused];
         buildPhase = ''
+          # Enable JS build
+          sed -i "s/; (include dune-js)/(include dune-js)/g" bin/dune
           # Compile JS target
           dune build bin/js_driver.bc.js
           # Optimize the size of the JS file


### PR DESCRIPTION
This PR disables the dune JS build of the engine by default.
For now, this build is never used.