### PR TITLE
fix(engine/import): missed generics on inherent impl `fn`s

### DIFF
--- a/engine/lib/ast_utils.ml
+++ b/engine/lib/ast_utils.ml
@@ -963,6 +963,16 @@ module Make (F : Features.T) = struct
           };
     }
 
+  (** Concatenates the generics [g1] and [g2], making sure lifetimes appear first *)
+  let concat_generics (g1 : generics) (g2 : generics) : generics =
+    let params = g1.params @ g2.params in
+    let constraints = g1.constraints @ g2.constraints in
+    let lifetimes, others =
+      List.partition_tf ~f:(fun p -> [%matches? GPLifetime _] p.kind) params
+    in
+    let params = lifetimes @ others in
+    { params; constraints }
+
   module Place = struct
     type t = { place : place'; span : span; typ : ty }
 

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -1261,6 +1261,7 @@ and c_item_unwrapped ~ident (item : Thir.item) : item list =
         List.map
           ~f:(fun (item : Thir.impl_item) ->
             let item_def_id = Concrete_ident.of_def_id Impl item.owner_id in
+
             let v =
               match (item.kind : Thir.impl_item_kind) with
               | Fn { body; params; _ } ->
@@ -1271,7 +1272,9 @@ and c_item_unwrapped ~ident (item : Thir.item) : item list =
                   Fn
                     {
                       name = item_def_id;
-                      generics = c_generics generics;
+                      generics =
+                        U.concat_generics (c_generics generics)
+                          (c_generics item.generics);
                       body = c_expr body;
                       params;
                     }

--- a/test-harness/src/snapshots/toolchain__generics into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__generics into-fstar.snap
@@ -1,0 +1,112 @@
+---
+source: test-harness/src/harness.rs
+expression: snapshot
+info:
+  kind:
+    Translate:
+      backend: fstar
+  info:
+    name: generics
+    manifest: generics/Cargo.toml
+    description: ~
+  spec:
+    optional: false
+    broken: false
+    issue_id: ~
+    positive: true
+    snapshot:
+      stderr: true
+      stdout: true
+    include_flag: ~
+---
+exit = 0
+stderr = '''
+Compiling generics v0.1.0 (WORKSPACE_ROOT/generics)
+    Finished dev [unoptimized + debuginfo] target(s) in XXs'''
+
+[stdout]
+diagnostics = []
+
+[stdout.files]
+"Generics.fst" = '''
+module Generics
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let impl__Bar__inherent_impl_generics (#v_T: Type) (v_N: usize) (x: t_Array v_T v_N) : Prims.unit =
+  ()
+
+class t_Foo (v_Self: Type) = { f_const_add:v_N: usize -> v_Self -> usize }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_Foo_for_usize: t_Foo usize =
+  { f_const_add = fun (v_N: usize) (self: usize) -> self +! v_N }
+
+let dup
+      (#v_T: Type)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: Core.Marker.t_Sized v_T)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Core.Clone.t_Clone v_T)
+      (x: v_T)
+    : (v_T & v_T) = Core.Clone.f_clone x, Core.Clone.f_clone x <: (v_T & v_T)
+
+let f (v_N x: usize) : usize = (v_N +! v_N <: usize) +! x
+
+let call_f (_: Prims.unit) : usize = (f (sz 10) (sz 3) <: usize) +! sz 3
+
+let g
+      (v_N: usize)
+      (#v_T: Type)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: Core.Marker.t_Sized v_T)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Core.Convert.t_Into v_T (t_Array usize v_N))
+      (arr: v_T)
+    : usize =
+  (Core.Option.impl__unwrap_or (Core.Iter.Traits.Iterator.f_max (Core.Iter.Traits.Collect.f_into_iter
+              (Core.Convert.f_into arr <: t_Array usize v_N)
+            <:
+            Core.Array.Iter.t_IntoIter usize v_N)
+        <:
+        Core.Option.t_Option usize)
+      v_N
+    <:
+    usize) +!
+  v_N
+
+let call_g (_: Prims.unit) : usize =
+  (g (sz 3)
+      (let list = [sz 42; sz 3; sz 49] in
+        FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 3);
+        Rust_primitives.Hax.array_of_list list)
+    <:
+    usize) +!
+  sz 3
+
+let foo (v_LEN: usize) (arr: t_Array usize v_LEN) : usize =
+  let acc:usize = v_LEN +! sz 9 in
+  let acc:usize =
+    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter ({
+              Core.Ops.Range.f_start = sz 0;
+              Core.Ops.Range.f_end = v_LEN
+            }
+            <:
+            Core.Ops.Range.t_Range usize)
+        <:
+        Core.Ops.Range.t_Range usize)
+      acc
+      (fun acc i ->
+          let acc:usize = acc in
+          let i:usize = i in
+          acc +! (arr.[ i ] <: usize) <: usize)
+  in
+  acc
+
+let repeat
+      (v_LEN: usize)
+      (#v_T: Type)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: Core.Marker.t_Sized v_T)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Core.Marker.t_Copy v_T)
+      (x: v_T)
+    : t_Array v_T v_LEN = Rust_primitives.Hax.repeat x v_LEN
+
+type t_Bar = | Bar : t_Bar
+'''

--- a/test-harness/src/snapshots/toolchain__traits into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__traits into-fstar.snap
@@ -17,6 +17,7 @@ info:
     snapshot:
       stderr: true
       stdout: true
+    include_flag: ~
 ---
 exit = 0
 stderr = '''
@@ -33,7 +34,7 @@ module Traits
 open Core
 open FStar.Mul
 
-let impl_2__method (x: v_T) : Prims.unit = f_bar x
+let impl_2__method (#v_T: Type) (x: v_T) : Prims.unit = f_bar x
 
 class t_Bar (v_Self: Type) = { f_bar:v_Self -> Prims.unit }
 

--- a/tests/generics/Cargo.toml
+++ b/tests/generics/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 [dependencies]
 
 [package.metadata.hax-tests]
-into."fstar" = { broken = false, snapshot = "none", issue_id = "21" }
+into."fstar" = { broken = false, issue_id = "21" }

--- a/tests/generics/src/lib.rs
+++ b/tests/generics/src/lib.rs
@@ -39,3 +39,9 @@ impl Foo for usize {
         self + N
     }
 }
+
+struct Bar;
+
+impl Bar {
+    fn inherent_impl_generics<T, const N: usize>(x: [T; N]) {}
+}


### PR DESCRIPTION
This PR fixes the F* extraction of the following kind of code:
```rust
struct Foo;
impl Foo {
  fn f<const N: usize>(...) {...} 
}
```

The translation used to drop the const generic `N`, this PR fixes that. 

✔️ I checked, this PR is not breaking Kyber extraction