### PR TITLE
fix(engine/print-rust): `impl ...` local_idents

### DIFF
--- a/engine/lib/print_rust.ml
+++ b/engine/lib/print_rust.ml
@@ -101,7 +101,19 @@ module Raw = struct
   let pglobal_ident = pglobal_ident' ""
 
   let plocal_ident span (e : Local_ident.t) : AnnotatedString.t =
-    pure span e.name
+    let name =
+      match String.chop_prefix ~prefix:"impl " e.name with
+      | Some name ->
+          "impl_"
+          ^ String.map
+              ~f:(function
+                | 'a' .. 'z' as letter -> letter
+                | 'A' .. 'Z' as letter -> letter
+                | _ -> '_')
+              name
+      | _ -> e.name
+    in
+    pure span name
 
   let dmutability span : _ -> AnnotatedString.t =
     pure span << function Mutable _ -> "mut " | _ -> ""


### PR DESCRIPTION
The following Rust code:
```rust
fn f(x: impl Foo + Bar) {}
```

Is translated as:
```rust
fn f<NAME: Foo + Bar>(x: NAME) {}
```

where `NAME` is actually `impl Foo + Bar`.

This commit recognizes such `NAME` local idents and rename them in the Rust printer.