### PR TITLE
refactor(engine): enable OCaml warning `7`

### DIFF
--- a/engine/lib/ast_utils.ml
+++ b/engine/lib/ast_utils.ml
@@ -156,7 +156,7 @@ module Make (F : Features.T) = struct
     let regenerate_span_ids =
       object
         inherit [_] Visitors.map
-        method visit_span () = Span.refresh_id
+        method! visit_span () = Span.refresh_id
       end
 
     let normalize_borrow_mut =
@@ -344,10 +344,10 @@ module Make (F : Features.T) = struct
           inherit [_] Visitors.reduce as super
           inherit [_] Sets.Local_ident.monoid as _m
 
-          method visit_arm' env { arm_pat; body } =
+          method! visit_arm' env { arm_pat; body } =
             shadows ~env [ arm_pat ] body super#visit_expr
 
-          method visit_expr' env e =
+          method! visit_expr' env e =
             match e with
             | Let { monadic = _; lhs; rhs; body } ->
                 super#visit_expr env rhs
@@ -378,12 +378,12 @@ module Make (F : Features.T) = struct
                 shadows ~env params body super#visit_expr
             | _ -> super#visit_expr' env e
 
-          method visit_impl_item' env ii =
+          method! visit_impl_item' env ii =
             match ii with
             | IIFn { body; params } -> self#visit_function_like env body params
             | _ -> super#visit_impl_item' env ii
 
-          method visit_item' env i =
+          method! visit_item' env i =
             match i with
             | Fn { body; params; _ } -> self#visit_function_like env body params
             | _ -> super#visit_item' env i
@@ -392,7 +392,7 @@ module Make (F : Features.T) = struct
             let f p = p.pat in
             shadows ~env (List.map ~f params) body super#visit_expr
 
-          method visit_local_ident env id =
+          method! visit_local_ident env id =
             Set.(if id_shadows ~env id then Fn.flip singleton id else empty)
               (module Local_ident)
         end
@@ -490,7 +490,7 @@ module Make (F : Features.T) = struct
 
         (* TODO: loop state *)
 
-        method visit_expr' () e =
+        method! visit_expr' () e =
           match e with
           | Assign { lhs; e; _ } ->
               let rec visit_lhs lhs =
@@ -531,7 +531,7 @@ module Make (F : Features.T) = struct
                    (without_vars (self#visit_expr () body) vars))
           | _ -> super#visit_expr' () e
 
-        method visit_arm' () { arm_pat; body } =
+        method! visit_arm' () { arm_pat; body } =
           without_pat_vars (self#visit_expr () body) arm_pat
       end
 

--- a/engine/lib/dune
+++ b/engine/lib/dune
@@ -71,4 +71,4 @@
 (env
  (_
   (flags
-   (:standard -g -warn-error "+A" -w "-17-7-30-56-32"))))
+   (:standard -g -warn-error "+A" -w "-17-30-56-32"))))

--- a/engine/lib/generic_printer/generic_printer.ml
+++ b/engine/lib/generic_printer/generic_printer.ml
@@ -117,7 +117,7 @@ module Make (F : Features.T) (View : Concrete_ident.VIEW_API) = struct
             separate_map (comma ^^ break 1) (print#ty_at Ty_Tuple)
             >> iblock parens
 
-        method ty : par_state -> ty fn =
+        method! ty : par_state -> ty fn =
           fun ctx ty ->
             match ty with
             | TBool -> string "bool"
@@ -144,7 +144,7 @@ module Make (F : Features.T) (View : Concrete_ident.VIEW_API) = struct
             | TOpaque _ -> string "opaque_type!()"
             | TApp _ -> super#ty ctx ty
 
-        method expr' : par_state -> expr' fn =
+        method! expr' : par_state -> expr' fn =
           fun ctx e ->
             let wrap_parens =
               group
@@ -321,7 +321,7 @@ module Make (F : Features.T) (View : Concrete_ident.VIEW_API) = struct
 
         method attr : attr fn = fun _ -> empty
 
-        method pat' : par_state -> pat' fn =
+        method! pat' : par_state -> pat' fn =
           fun ctx ->
             let wrap_parens =
               group

--- a/engine/lib/phase_utils.ml
+++ b/engine/lib/phase_utils.ml
@@ -155,9 +155,7 @@ end = struct
              let regenerate_span_ids =
                (object
                   inherit [_] Visitors.map
-                  method visit_t () x = x
-                  method visit_mutability _ () m = m
-                  method visit_span = Fn.const Span.refresh_id
+                  method! visit_span = Fn.const Span.refresh_id
                end)
                  #visit_item
                  ()


### PR DESCRIPTION
This commit turns missing `!` on methods be an error: if a method is overridden, it should be marked explicitly with `!`.