### PR TITLE
fix(engine/direct_and_mut): make sure `out` doesnt shadow

### DIFF
--- a/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
@@ -17,6 +17,7 @@ info:
     snapshot:
       stderr: false
       stdout: true
+    include_flag: ~
 ---
 exit = 0
 
@@ -213,9 +214,11 @@ let i (bar: t_Bar) : (t_Bar & u8) =
   bar, hax_temp_output <: (t_Bar & u8)
 
 let j (x: t_Bar) : (t_Bar & u8) =
-  let tmp0, out:(t_Bar & u8) = i x in
+  let out:u8 = 123uy in
+  let tmp0, out1:(t_Bar & u8) = i x in
   let x:t_Bar = tmp0 in
-  let hax_temp_output:u8 = out in
+  let hoist1:u8 = out1 in
+  let hax_temp_output:u8 = hoist1 +! out in
   x, hax_temp_output <: (t_Bar & u8)
 
 type t_Pair (v_T: Type) {| i0: Core.Marker.t_Sized v_T |} = {

--- a/tests/mut-ref-functionalization/src/lib.rs
+++ b/tests/mut-ref-functionalization/src/lib.rs
@@ -88,7 +88,8 @@ fn i(bar: &mut Bar) -> u8 {
 }
 
 fn j(x: &mut Bar) -> u8 {
-    i(x)
+    let out = 123;
+    i(x) + out
 }
 
 fn k(


### PR DESCRIPTION
Fixes #527