### PR TITLE
Introduce `opaque_type` attribute

### DIFF
--- a/frontend/diagnostics/src/lib.rs
+++ b/frontend/diagnostics/src/lib.rs
@@ -121,6 +121,8 @@ impl<S> std::fmt::Display for Diagnostics<S> {
                 bindings
             ),
             Kind::ArbitraryLHS => write!(f, "Assignation of an arbitrary left-hand side is not supported. `lhs = e` is fine only when `lhs` is a combination of local identifiers, field accessors and index accessors."),
+
+            Kind::AttributeRejected {reason} => write!(f, "Here, this attribute cannot be used: {reason}."),
             _ => write!(f, "{:?}", self.kind),
         }
     }
@@ -180,6 +182,11 @@ pub enum Kind {
     } = 9,
 
     ExpectedMutRef = 10,
+
+    /// An hax attribute (from `hax-lib-macros`) was rejected
+    AttributeRejected {
+        reason: String,
+    },
 }
 
 impl Kind {

--- a/hax-lib-macros/src/lib.rs
+++ b/hax-lib-macros/src/lib.rs
@@ -475,6 +475,16 @@ pub fn attributes(_attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStr
     quote! { #item }.into()
 }
 
+/// Mark a struct or an enum opaque: the extraction will assume the
+/// type without revealing its definition.
+#[proc_macro_error]
+#[proc_macro_attribute]
+pub fn opaque_type(_attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
+    let item: Item = parse_macro_input!(item);
+    let attr = AttrPayload::OpaqueType;
+    quote! {#attr #item}.into()
+}
+
 /// A marker indicating a `fn` as a ProVerif process read.
 #[proc_macro_error]
 #[proc_macro_attribute]

--- a/hax-lib-macros/types/src/lib.rs
+++ b/hax-lib-macros/types/src/lib.rs
@@ -75,6 +75,8 @@ pub enum AttrPayload {
     ProcessWrite,
     ProcessInit,
     ProtocolMessages,
+    /// Make a type opaque
+    OpaqueType,
 }
 
 pub const HAX_TOOL: &str = "_hax";

--- a/test-harness/src/harness.rs
+++ b/test-harness/src/harness.rs
@@ -45,6 +45,7 @@ pub struct TestSpec {
     pub positive: bool,
     pub snapshot: TestSnapshot,
     pub include_flag: Option<String>,
+    pub backend_options: Option<Vec<String>>,
 }
 
 impl From<Value> for TestSpec {
@@ -68,6 +69,7 @@ impl From<Value> for TestSpec {
             positive: as_bool(&o, "positive", true),
             issue_id: o["positive"].as_u64(),
             include_flag: o["include-flag"].as_str().map(|s| s.into()),
+            backend_options: serde_json::from_value(o["backend-options"].clone()).unwrap(),
             snapshot: as_opt_bool(snapshot, true)
                 .map(|b| TestSnapshot {
                     stderr: b,
@@ -119,6 +121,9 @@ impl Test {
                 }
                 args.push("--dry-run".to_string());
                 args.push(backend.clone());
+                if let Some(backend_options) = &self.spec.backend_options {
+                    args.extend_from_slice(backend_options.clone().as_slice());
+                }
                 args
             }
         }

--- a/test-harness/src/snapshots/toolchain__attribute-opaque into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__attribute-opaque into-fstar.snap
@@ -1,0 +1,53 @@
+---
+source: test-harness/src/harness.rs
+expression: snapshot
+info:
+  kind:
+    Translate:
+      backend: fstar
+  info:
+    name: attribute-opaque
+    manifest: attribute-opaque/Cargo.toml
+    description: ~
+  spec:
+    optional: false
+    broken: false
+    issue_id: ~
+    positive: true
+    snapshot:
+      stderr: true
+      stdout: true
+    include_flag: ~
+    backend_options:
+      - "--interfaces"
+      - +**
+---
+exit = 0
+stderr = '''
+Compiling attribute-opaque v0.1.0 (WORKSPACE_ROOT/attribute-opaque)
+    Finished dev [unoptimized + debuginfo] target(s) in XXs'''
+
+[stdout]
+diagnostics = []
+
+[stdout.files]
+"Attribute_opaque.fsti" = '''
+module Attribute_opaque
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+val t_OpaqueEnum
+      (v_X: usize)
+      (#v_T #v_U: Type)
+      {| i0: Core.Marker.t_Sized v_T |}
+      {| i1: Core.Marker.t_Sized v_U |}
+    : Type
+
+val t_OpaqueStruct
+      (v_X: usize)
+      (#v_T #v_U: Type)
+      {| i0: Core.Marker.t_Sized v_T |}
+      {| i1: Core.Marker.t_Sized v_U |}
+    : Type
+'''

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -27,6 +27,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "attribute-opaque"
+version = "0.1.0"
+dependencies = [
+ "hax-lib",
+ "hax-lib-macros",
+ "serde",
+]
+
+[[package]]
 name = "attributes"
 version = "0.1.0"
 dependencies = [

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -18,6 +18,7 @@ members = [
         "odd",
         "never-type",
         "attributes",
+        "attribute-opaque",
         "raw-attributes",
         "traits",
         "reordering",

--- a/tests/attribute-opaque/Cargo.toml
+++ b/tests/attribute-opaque/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "attribute-opaque"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+hax-lib-macros = { path = "../../hax-lib-macros" }
+hax-lib = { path = "../../hax-lib" }
+serde = { version = "1.0", features = ["derive"] }
+
+[package.metadata.hax-tests]
+into."fstar" = { backend-options = ["--interfaces", "+**"] }

--- a/tests/attribute-opaque/src/lib.rs
+++ b/tests/attribute-opaque/src/lib.rs
@@ -1,0 +1,13 @@
+use hax_lib_macros as hax;
+
+#[hax::opaque_type]
+struct OpaqueStruct<const X: usize, T, U> {
+    field: [T; X],
+    other_field: U,
+}
+
+#[hax::opaque_type]
+enum OpaqueEnum<const X: usize, T, U> {
+    A([T; X]),
+    B(U),
+}


### PR DESCRIPTION
This PR:
 - introduces `opaque_type` attribute that can mark enums and structs so that their (F* for now) extraction doesn't reveal their definition.
 - introduce an option in the test harness so that we can write tests that specify backend options;
 - add a test.

Fixes #525