### PR TITLE
feat(exporter/traits): parent bounds on impl and associated types

### DIFF
--- a/cli/default.nix
+++ b/cli/default.nix
@@ -56,7 +56,14 @@
       doInstallCargoArtifacts = true;
     }
   );
-  frontend-docs = craneLib.cargoDoc (commonArgs // {inherit cargoArtifacts pname;});
+  frontend-docs = craneLib.cargoDoc (commonArgs // {
+    preBuildPhases = ["addRustcDocs"];
+    addRustcDocs = ''
+      mkdir -p target/doc
+      cp --no-preserve=mode -rf ${rustc.passthru.availableComponents.rustc-docs}/share/doc/rust/html/rustc/* target/doc/
+    '';
+    inherit cargoArtifacts pname;
+  });
   docs = stdenv.mkDerivation {
     name = "hax-docs";
     unpackPhase = "true";

--- a/engine/backends/coq/ssprove/ssprove_backend.ml
+++ b/engine/backends/coq/ssprove/ssprove_backend.ml
@@ -1321,7 +1321,7 @@ struct
 
   let pgeneric_constraints_as_argument span :
       generic_constraint -> SSP.AST.argument list = function
-    | GCType { bound = { trait; args }; _ } ->
+    | GCType { goal = { trait; args }; _ } ->
         [
           SSP.AST.Typeclass
             ( None,
@@ -1738,11 +1738,11 @@ struct
                                     [],
                                     value ) );
                           ]
-                    | TIType trait_refs ->
+                    | TIType impl_idents ->
                         SSP.AST.Named
                           (pconcrete_ident x.ti_ident, SSP.AST.TypeTy)
                         :: List.map
-                             ~f:(fun (tr, _id) ->
+                             ~f:(fun { goal = tr; _ } ->
                                SSP.AST.Coercion
                                  ( pconcrete_ident x.ti_ident ^ "_"
                                    ^ pconcrete_ident tr.trait,
@@ -1752,7 +1752,7 @@ struct
                                          SSP.AST.NameTy
                                            (pconcrete_ident x.ti_ident);
                                        ] ) ))
-                             trait_refs)
+                             impl_idents)
                   items );
           ]
           @ List.concat_map

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -294,7 +294,7 @@ struct
     let some = Option.some in
     let hax_unstable_impl_exprs = false in
     match ie with
-    | Concrete tr -> c_trait_ref span tr |> some
+    | Concrete tr -> c_trait_goal span tr |> some
     | LocalBound { id } ->
         let local_ident =
           Local_ident.{ name = id; id = Local_ident.mk_id Expr 0 }
@@ -302,9 +302,9 @@ struct
         F.term @@ F.AST.Var (F.lid_of_id @@ plocal_ident local_ident) |> some
     | ImplApp { impl; _ } when not hax_unstable_impl_exprs ->
         pimpl_expr span impl
-    | Parent { impl; trait } when hax_unstable_impl_exprs ->
+    | Parent { impl; ident } when hax_unstable_impl_exprs ->
         let* impl = pimpl_expr span impl in
-        let trait = "_super_" ^ name_of_trait_ref span trait in
+        let trait = "_super_" ^ ident.name in
         F.term @@ F.AST.Project (impl, F.lid [ trait ]) |> some
     | ImplApp { impl; args = [] } when hax_unstable_impl_exprs ->
         pimpl_expr span impl
@@ -319,12 +319,9 @@ struct
         F.term_of_lid [ "_Builtin" ] |> some
     | _ -> None
 
-  and name_of_trait_ref _span : trait_ref -> string =
-    [%hash: trait_ref] >> Int.to_string
-
-  and c_trait_ref span trait_ref =
-    let trait = F.term @@ F.AST.Name (pconcrete_ident trait_ref.trait) in
-    List.map ~f:(pgeneric_value span) trait_ref.args |> F.mk_e_app trait
+  and c_trait_goal span trait_goal =
+    let trait = F.term @@ F.AST.Name (pconcrete_ident trait_goal.trait) in
+    List.map ~f:(pgeneric_value span) trait_goal.args |> F.mk_e_app trait
 
   and pgeneric_value span (g : generic_value) =
     match g with
@@ -570,9 +567,9 @@ struct
     let of_generic_constraint span (nth : int) (c : generic_constraint) =
       match c with
       | GCLifetime _ -> .
-      | GCType { bound; id; _ } ->
-          let typ = c_trait_ref span bound in
-          { kind = Tcresolve; ident = F.id id; typ }
+      | GCType { goal; name } ->
+          let typ = c_trait_goal span goal in
+          { kind = Tcresolve; ident = F.id name; typ }
 
     let of_generics ?(kind : kind = Implicit) span generics : t list =
       List.map ~f:(of_generic_param ~kind span) generics.params
@@ -618,7 +615,7 @@ struct
     match c with
     | GCLifetime _ ->
         Error.assertion_failure span "pgeneric_constraint_bd:LIFETIME"
-    | GCType { bound; _ } -> c_trait_ref span bound
+    | GCType { goal; name = _ } -> c_trait_goal span goal
 
   let get_attr (type a) (name : string) (map : string -> a) (attrs : attrs) :
       a option =
@@ -1033,14 +1030,18 @@ struct
                     (* in *)
                     (F.id name, None, [], t)
                     :: List.map
-                         ~f:(fun ({ trait; args }, id) ->
+                         ~f:
+                           (fun {
+                                  goal = { trait; args };
+                                  name = impl_ident_name;
+                                } ->
                            let base =
                              F.term @@ F.AST.Name (pconcrete_ident trait)
                            in
                            let args =
                              List.map ~f:(pgeneric_value e.span) args
                            in
-                           ( F.id (name ^ "_" ^ id),
+                           ( F.id (name ^ "_" ^ impl_ident_name),
                              None,
                              [],
                              F.mk_e_app base args ))
@@ -1062,10 +1063,10 @@ struct
         let constraints_fields : FStar_Parser_AST.tycon_record =
           generics.constraints
           |> List.map ~f:(fun c ->
-                 let bound =
-                   match c with GCType { bound; _ } -> bound | _ -> .
+                 let bound, id =
+                   match c with GCType { goal; name } -> (goal, name) | _ -> .
                  in
-                 let name = "_super_" ^ name_of_trait_ref e.span bound in
+                 let name = "_super_" ^ id in
                  let typ = pgeneric_constraint_type e.span c in
                  (F.id name, None, [ F.Attrs.no_method ], typ))
         in

--- a/engine/lib/ast.ml
+++ b/engine/lib/ast.ml
@@ -134,22 +134,35 @@ functor
 
     and impl_expr =
       | Self
-      | Concrete of trait_ref
+      | Concrete of trait_goal
       | LocalBound of { id : string }
-      | Parent of { impl : impl_expr; trait : trait_ref }
+      | Parent of { impl : impl_expr; ident : impl_ident }
       | Projection of {
           impl : impl_expr;
-          trait : trait_ref;
           item : concrete_ident;
+          ident : impl_ident;
         }
       | ImplApp of { impl : impl_expr; args : impl_expr list }
-      | Dyn of trait_ref
-      | Builtin of trait_ref
+      | Dyn of trait_goal
+      | Builtin of trait_goal
       | FnPointer of ty
       (* The `IE` suffix is there because visitors conflicts...... *)
       | ClosureIE of todo
 
-    and trait_ref = { trait : concrete_ident; args : generic_value list }
+    and trait_goal = { trait : concrete_ident; args : generic_value list }
+    (** A fully applied trait: [Foo<SomeTy, T0, ..., Tn>] (or
+      `SomeTy: Foo<T0, ..., Tn>`). An `impl_expr` "inhabits" a
+      `trait_goal`. *)
+
+    and impl_ident = { goal : trait_goal; name : string }
+    (** An impl identifier [{goal; name}] can be:
+          {ul
+              {- An in-scope variable [name] that inhabits [goal].}
+              {- A field of some other impl expression [i]: [i.name] inhabits [goal]. This corresponds to parent bounds or associated type bounds.}
+              {- An argument that introduces a variable [name] that inhabits [goal].}
+          }
+      *)
+    (* TODO: ADD SPAN! *)
 
     and pat' =
       | PWild
@@ -309,12 +322,7 @@ functor
 
     and generic_constraint =
       | GCLifetime of todo * F.lifetime
-      | GCType of {
-          bound : trait_ref;
-              (* trait_ref is always applied with the type the trait implements.
-                 For instance, `T: Clone` is actually `Clone<T> *)
-          id : string;
-        }
+      | GCType of impl_ident
     [@@deriving show, yojson, hash, eq]
 
     type param = { pat : pat; typ : ty; typ_span : span option; attrs : attrs }
@@ -388,7 +396,7 @@ functor
       ii_attrs : attrs;
     }
 
-    and trait_item' = TIType of (trait_ref * string) list | TIFn of ty
+    and trait_item' = TIType of impl_ident list | TIFn of ty
 
     and trait_item = {
       (* TODO: why do I need to prefix by `ti_` here? I guess visitors fail or something *)

--- a/engine/lib/ast.ml
+++ b/engine/lib/ast.ml
@@ -323,6 +323,8 @@ functor
     and generic_constraint =
       | GCLifetime of todo * F.lifetime
       | GCType of impl_ident
+          (** Trait or lifetime constraints. For instance, `A` and `B` in
+    `fn f<T: A + B>()`. *)
     [@@deriving show, yojson, hash, eq]
 
     type param = { pat : pat; typ : ty; typ_span : span option; attrs : attrs }

--- a/engine/lib/ast_utils.ml
+++ b/engine/lib/ast_utils.ml
@@ -180,6 +180,9 @@ module Make (F : Features.T) = struct
           expr e
       end
 
+    (** Rename impl expressions variables. By default, they are big
+      and unique identifiers, after this function, they are renamed
+      into `iN` where `N` is a short local unique identifier. *)
     let rename_generic_constraints =
       object
         inherit [_] Visitors.map as super
@@ -196,7 +199,12 @@ module Make (F : Features.T) = struct
         method! visit_trait_item (_, s) = super#visit_trait_item (true, s)
 
         method! visit_item' (_, s) item =
-          super#visit_item' ([%matches? Trait _] item |> not, s) item
+          let enabled =
+            (* generic constraints on traits correspond to super
+               traits, those are not local and should NOT be renamed *)
+            [%matches? Trait _] item |> not
+          in
+          super#visit_item' (enabled, s) item
 
         method! visit_impl_expr s ie =
           match ie with

--- a/engine/lib/concrete_ident/impl_infos.ml
+++ b/engine/lib/concrete_ident/impl_infos.ml
@@ -1,12 +1,12 @@
 open! Prelude
 
 type t = {
-  trait_ref : Ast.Rust.trait_ref option;
+  trait_goal : Ast.Rust.trait_goal option;
       (** The trait implemented by the [impl] block or [None] if the
          [impl] block is an {{: https://doc.rust-lang.org/reference/items/implementations.html#inherent-implementations } inherent [impl]}.
         *)
   typ : Ast.Rust.ty;  (** The type implemented by the [impl] block. *)
-  predicates : Ast.Rust.trait_ref list;
+  predicates : Ast.Rust.trait_goal list;
       (** The predicates that constraint this [impl] block. *)
 }
 (** metadata of an [impl] block *)
@@ -23,8 +23,8 @@ let lookup span (impl : Concrete_ident.t) : t option =
   let* Types.{ generics = _; predicates; typ; trait_ref } =
     Concrete_ident.lookup_raw_impl_info impl
   in
-  let trait_ref =
-    trait_ref |> Option.map ~f:(Import_thir.import_trait_ref span)
+  let trait_goal =
+    Option.map ~f:(Import_thir.import_trait_ref span) trait_ref
   in
   let typ = Import_thir.import_ty span typ in
   let predicates =
@@ -33,4 +33,4 @@ let lookup span (impl : Concrete_ident.t) : t option =
     in
     List.filter_map ~f predicates
   in
-  Some { trait_ref; typ; predicates }
+  Some { trait_goal; typ; predicates }

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -201,8 +201,8 @@ module type EXPR = sig
   val c_generics : Thir.generics -> generics
   val c_param : Thir.span -> Thir.param -> param
   val c_trait_item' : Thir.trait_item -> Thir.trait_item_kind -> trait_item'
-  val c_trait_ref : Thir.span -> Thir.trait_ref -> trait_ref
-  val c_predicate_kind : Thir.span -> Thir.predicate_kind -> trait_ref option
+  val c_trait_ref : Thir.span -> Thir.trait_ref -> trait_goal
+  val c_predicate_kind : Thir.span -> Thir.predicate_kind -> trait_goal option
 end
 
 (* BinOp to [core::ops::*] overloaded functions *)
@@ -910,7 +910,7 @@ end) : EXPR = struct
         let args = List.map ~f:(c_impl_expr span) args in
         ImplApp { impl; args }
 
-  and c_trait_ref span (tr : Thir.trait_ref) : trait_ref =
+  and c_trait_ref span (tr : Thir.trait_ref) : trait_goal =
     let trait = Concrete_ident.of_def_id Trait tr.def_id in
     let args = List.map ~f:(c_generic_value span) tr.generic_args in
     { trait; args }
@@ -919,16 +919,16 @@ end) : EXPR = struct
       =
     let browse_path (impl : impl_expr) (chunk : Thir.impl_expr_path_chunk) =
       match chunk with
-      | AssocItem { item; predicate = { trait_ref; _ }; _ } ->
-          let trait = c_trait_ref span trait_ref in
+      | AssocItem { item; predicate = { trait_ref; _ }; clause_id; _ } ->
+          let ident = { goal = c_trait_ref span trait_ref; name = clause_id } in
           let kind : Concrete_ident.Kind.t =
             match item.kind with Const | Fn -> Value | Type -> Type
           in
           let item = Concrete_ident.of_def_id kind item.def_id in
-          Projection { impl; trait; item }
-      | Parent { predicate = { trait_ref; _ }; _ } ->
-          let trait = c_trait_ref span trait_ref in
-          Parent { impl; trait }
+          Projection { impl; ident; item }
+      | Parent { predicate = { trait_ref; _ }; clause_id; _ } ->
+          let ident = { goal = c_trait_ref span trait_ref; name = clause_id } in
+          Parent { impl; ident }
     in
     match ie with
     | Concrete { id; generics } ->
@@ -996,18 +996,17 @@ end) : EXPR = struct
     let attrs = c_attrs param.attributes in
     { ident; span; attrs; kind }
 
-  let c_predicate_kind' span (p : Thir.predicate_kind) :
-      (trait_ref * string) option =
+  let c_predicate_kind' span (p : Thir.predicate_kind) : impl_ident option =
     match p with
     | Clause
         { kind = Trait { is_positive = true; is_const = _; trait_ref }; id } ->
         let args = List.map ~f:(c_generic_value span) trait_ref.generic_args in
         let trait = Concrete_ident.of_def_id Trait trait_ref.def_id in
-        Some ({ trait; args }, id)
+        Some { goal = { trait; args }; name = id }
     | _ -> None
 
-  let c_predicate_kind span (p : Thir.predicate_kind) : trait_ref option =
-    c_predicate_kind' span p |> Option.map ~f:fst
+  let c_predicate_kind span (p : Thir.predicate_kind) : trait_goal option =
+    c_predicate_kind' span p |> Option.map ~f:(fun (x : impl_ident) -> x.goal)
 
   let list_dedup (equal : 'a -> 'a -> bool) : 'a list -> 'a list =
     let rec aux (seen : 'a list) (todo : 'a list) : 'a list =
@@ -1022,8 +1021,7 @@ end) : EXPR = struct
   let c_generics (generics : Thir.generics) : generics =
     let bounds =
       List.filter_map ~f:(c_predicate_kind' generics.span) generics.bounds
-      |> List.map ~f:(fun (trait, id) : generic_constraint ->
-             GCType { bound = trait; id })
+      |> List.map ~f:(fun impl_ident -> GCType impl_ident)
     in
     {
       params = List.map ~f:c_generic_param generics.params;
@@ -1065,11 +1063,11 @@ include struct
 
   let import_ty : Types.span -> Types.ty -> Ast.Rust.ty = c_ty
 
-  let import_trait_ref : Types.span -> Types.trait_ref -> Ast.Rust.trait_ref =
+  let import_trait_ref : Types.span -> Types.trait_ref -> Ast.Rust.trait_goal =
     c_trait_ref
 
   let import_predicate_kind :
-      Types.span -> Types.predicate_kind -> Ast.Rust.trait_ref option =
+      Types.span -> Types.predicate_kind -> Ast.Rust.trait_goal option =
     c_predicate_kind
 end
 
@@ -1344,7 +1342,8 @@ and c_item_unwrapped ~ident (item : Thir.item) : item list =
                                }
                          | Const (_ty, e) ->
                              IIFn { body = c_expr e; params = [] }
-                         | Type ty -> IIType (c_ty item.span ty));
+                         | Type { ty; parent_bounds = _ } ->
+                             IIType (c_ty item.span ty));
                        ii_ident;
                        ii_attrs = c_item_attrs item.attributes;
                      })
@@ -1387,7 +1386,7 @@ let import_item (item : Thir.item) :
   let r, reports =
     let f =
       U.Mappers.rename_generic_constraints#visit_item
-        (Hashtbl.create (module String))
+        (true, Hashtbl.create (module String))
       >> U.Reducers.disambiguate_local_idents
     in
     Diagnostics.Core.capture (fun _ -> c_item item ~ident |> List.map ~f)

--- a/engine/lib/import_thir.mli
+++ b/engine/lib/import_thir.mli
@@ -1,8 +1,8 @@
 val import_ty : Types.span -> Types.ty -> Ast.Rust.ty
-val import_trait_ref : Types.span -> Types.trait_ref -> Ast.Rust.trait_ref
+val import_trait_ref : Types.span -> Types.trait_ref -> Ast.Rust.trait_goal
 
 val import_predicate_kind :
-  Types.span -> Types.predicate_kind -> Ast.Rust.trait_ref option
+  Types.span -> Types.predicate_kind -> Ast.Rust.trait_goal option
 
 val import_item :
   Types.item_for__decorated_for__expr_kind ->

--- a/engine/lib/phases/phase_drop_references.ml
+++ b/engine/lib/phases/phase_drop_references.ml
@@ -46,7 +46,7 @@ struct
       | [%inline_arms "dgeneric_value.*" - GLifetime] ->
           map (Option.some : B.generic_value -> _)
 
-    and dtrait_ref (span : span) (r : A.trait_ref) : B.trait_ref =
+    and dtrait_goal (span : span) (r : A.trait_goal) : B.trait_goal =
       {
         trait = r.trait;
         args = List.filter_map ~f:(dgeneric_value span) r.args;
@@ -138,8 +138,7 @@ struct
         B.generic_constraint option =
       match p with
       | GCLifetime _ -> None
-      | GCType { bound; id } ->
-          Some (B.GCType { bound = dtrait_ref span bound; id })
+      | GCType idents -> Some (B.GCType (dimpl_ident span idents))
 
     let dgenerics (span : span) (g : A.generics) : B.generics =
       {

--- a/engine/lib/print_rust.ml
+++ b/engine/lib/print_rust.ml
@@ -374,7 +374,7 @@ module Raw = struct
         !"<" & concat ~sep:!", " (List.map ~f:pgeneric_param pl) & !">"
     | _ -> empty
 
-  let ptrait_ref span { trait; args } =
+  let ptrait_goal span { trait; args } =
     let ( ! ) = pure span in
     let args = List.map ~f:(pgeneric_value span) args |> concat ~sep:!", " in
     !(Concrete_ident_view.show trait)
@@ -384,7 +384,7 @@ module Raw = struct
     let ( ! ) = pure span in
     match p with
     | GCLifetime _ -> !"'unk: 'unk"
-    | GCType { bound; _ } -> !"_:" & ptrait_ref span bound
+    | GCType { goal; _ } -> !"_:" & ptrait_goal span goal
 
   let pgeneric_constraints span (constraints : generic_constraint list) =
     if List.is_empty constraints then empty

--- a/engine/lib/subtype.ml
+++ b/engine/lib/subtype.ml
@@ -48,27 +48,30 @@ struct
     | TRawPointer { witness } ->
         TRawPointer { witness = S.raw_pointer span witness }
 
-  and dtrait_ref (span : span) (r : A.trait_ref) : B.trait_ref =
+  and dtrait_goal (span : span) (r : A.trait_goal) : B.trait_goal =
     { trait = r.trait; args = List.map ~f:(dgeneric_value span) r.args }
+
+  and dimpl_ident (span : span) (r : A.impl_ident) : B.impl_ident =
+    { goal = dtrait_goal span r.goal; name = r.name }
 
   and dimpl_expr (span : span) (i : A.impl_expr) : B.impl_expr =
     match i with
     | Self -> Self
-    | Concrete tr -> Concrete (dtrait_ref span tr)
+    | Concrete tr -> Concrete (dtrait_goal span tr)
     | LocalBound { id } -> LocalBound { id }
-    | Parent { impl; trait } ->
-        Parent { impl = dimpl_expr span impl; trait = dtrait_ref span trait }
-    | Projection { impl; item; trait } ->
+    | Parent { impl; ident } ->
+        Parent { impl = dimpl_expr span impl; ident = dimpl_ident span ident }
+    | Projection { impl; item; ident } ->
         Projection
-          { impl = dimpl_expr span impl; item; trait = dtrait_ref span trait }
+          { impl = dimpl_expr span impl; item; ident = dimpl_ident span ident }
     | ImplApp { impl; args } ->
         ImplApp
           {
             impl = dimpl_expr span impl;
             args = List.map ~f:(dimpl_expr span) args;
           }
-    | Dyn tr -> Dyn (dtrait_ref span tr)
-    | Builtin tr -> Builtin (dtrait_ref span tr)
+    | Dyn tr -> Dyn (dtrait_goal span tr)
+    | Builtin tr -> Builtin (dtrait_goal span tr)
     | ClosureIE todo -> ClosureIE todo
     | FnPointer ty -> FnPointer (dty span ty)
 
@@ -329,7 +332,7 @@ struct
         (generic_constraint : A.generic_constraint) : B.generic_constraint =
       match generic_constraint with
       | GCLifetime (lf, witness) -> B.GCLifetime (lf, S.lifetime span witness)
-      | GCType { bound; id } -> B.GCType { bound = dtrait_ref span bound; id }
+      | GCType impl_ident -> B.GCType (dimpl_ident span impl_ident)
 
     let dgenerics (span : span) (g : A.generics) : B.generics =
       {
@@ -355,7 +358,7 @@ struct
 
     let rec dtrait_item' (span : span) (ti : A.trait_item') : B.trait_item' =
       match ti with
-      | TIType g -> TIType (List.map ~f:(dtrait_ref span *** Fn.id) g)
+      | TIType idents -> TIType (List.map ~f:(dimpl_ident span) idents)
       | TIFn t -> TIFn (dty span t)
 
     and dtrait_item (ti : A.trait_item) : B.trait_item =

--- a/frontend/exporter/src/constant_utils.rs
+++ b/frontend/exporter/src/constant_utils.rs
@@ -189,18 +189,29 @@ pub(crate) fn scalar_to_constant_expr<'tcx, S: UnderOwnerState<'tcx>>(
                     provenance
                 )
             };
-            ConstantExprKind::Borrow((ConstantExprKind::GlobalName { id: did.sinto(s) }).decorate(ty.sinto(s), cspan.clone()))
+            ConstantExprKind::Borrow(
+                (ConstantExprKind::GlobalName { id: did.sinto(s) })
+                    .decorate(ty.sinto(s), cspan.clone()),
+            )
         }
         // A [Scalar] might also be any zero-sized [Adt] or [Tuple] (i.e., unit)
         ty::Tuple(ty) if ty.is_empty() => ConstantExprKind::Tuple { fields: vec![] },
         // It seems we can have ADTs when there is only one variant, and this variant doesn't have any fields.
-        ty::Adt(def, _) if let [variant_def] = &def.variants().raw && variant_def.fields.is_empty() => {
-            ConstantExprKind::Adt{
+        ty::Adt(def, _)
+            if let [variant_def] = &def.variants().raw
+                && variant_def.fields.is_empty() =>
+        {
+            ConstantExprKind::Adt {
                 info: get_variant_information(def, rustc_abi::FIRST_VARIANT, s),
                 fields: vec![],
             }
-        },
-        _ => fatal!(s[span], "Unexpected type {:#?} for scalar {:#?}", ty, scalar),
+        }
+        _ => fatal!(
+            s[span],
+            "Unexpected type {:#?} for scalar {:#?}",
+            ty,
+            scalar
+        ),
     };
     kind.decorate(ty.sinto(s), cspan)
 }

--- a/frontend/exporter/src/deterministic_hash.rs
+++ b/frontend/exporter/src/deterministic_hash.rs
@@ -1,4 +1,4 @@
-//! Stolen from https://github.com/Wassasin/deterministic-hash/blob/main/src/lib.rs
+//! Stolen from <https://github.com/Wassasin/deterministic-hash/blob/main/src/lib.rs>
 use core::hash::Hasher;
 
 /// Wrapper around any hasher to make it deterministic.

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -283,6 +283,25 @@ pub trait IntoImplExpr<'tcx> {
     ) -> ImplExpr;
 }
 
+impl<'tcx> IntoImplExpr<'tcx> for rustc_middle::ty::TraitRef<'tcx> {
+    fn impl_expr<S: UnderOwnerState<'tcx>>(
+        &self,
+        s: &S,
+        param_env: rustc_middle::ty::ParamEnv<'tcx>,
+    ) -> ImplExpr {
+        rustc_middle::ty::Binder::dummy(self.clone()).impl_expr(s, param_env)
+    }
+}
+impl<'tcx> IntoImplExpr<'tcx> for rustc_middle::ty::PolyTraitPredicate<'tcx> {
+    fn impl_expr<S: UnderOwnerState<'tcx>>(
+        &self,
+        s: &S,
+        param_env: rustc_middle::ty::ParamEnv<'tcx>,
+    ) -> ImplExpr {
+        use rustc_middle::ty::ToPolyTraitRef;
+        self.to_poly_trait_ref().impl_expr(s, param_env)
+    }
+}
 impl<'tcx> IntoImplExpr<'tcx> for rustc_middle::ty::PolyTraitRef<'tcx> {
     fn impl_expr<S: UnderOwnerState<'tcx>>(
         &self,

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -472,11 +472,7 @@ pub mod copy_paste_from_rustc {
         tcx: TyCtxt<'tcx>,
         (param_env, trait_ref): (ty::ParamEnv<'tcx>, ty::PolyTraitRef<'tcx>),
     ) -> Result<rustc_trait_selection::traits::Selection<'tcx>, CodegenObligationError> {
-        // We expect the input to be fully normalized.
-        debug_assert_eq!(
-            trait_ref,
-            tcx.normalize_erasing_regions(param_env, trait_ref)
-        );
+        let trait_ref = tcx.normalize_erasing_regions(param_env, trait_ref);
 
         // Do the initial selection for the obligation. This yields the
         // shallow result we are looking for -- that is, what specific impl.

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -13,6 +13,7 @@ pub enum ImplExprPathChunk {
     },
     Parent {
         predicate: TraitPredicate,
+        clause_id: u64,
         index: usize,
     },
 }
@@ -92,6 +93,7 @@ mod search_clause {
         },
         Parent {
             predicate: TraitPredicate<'tcx>,
+            clause_id: u64,
             index: usize,
         },
     }
@@ -212,6 +214,10 @@ mod search_clause {
                         cons(
                             PathChunk::Parent {
                                 predicate: p,
+                                clause_id: {
+                                    use rustc_middle::ty::ToPredicate;
+                                    crate::clause_id_of_predicate(s, p.to_predicate(s.base().tcx))
+                                },
                                 index,
                             },
                             path,

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -9,6 +9,7 @@ pub enum ImplExprPathChunk {
     AssocItem {
         item: AssocItem,
         predicate: TraitPredicate,
+        clause_id: u64,
         index: usize,
     },
     Parent {
@@ -89,6 +90,7 @@ mod search_clause {
         AssocItem {
             item: AssocItem,
             predicate: TraitPredicate<'tcx>,
+            clause_id: u64,
             index: usize,
         },
         Parent {
@@ -234,6 +236,13 @@ mod search_clause {
                                     cons(
                                         PathChunk::AssocItem {
                                             item,
+                                            clause_id: {
+                                                use rustc_middle::ty::ToPredicate;
+                                                crate::clause_id_of_predicate(
+                                                    s,
+                                                    p.to_predicate(s.base().tcx),
+                                                )
+                                            },
                                             predicate: p,
                                             index,
                                         },

--- a/frontend/exporter/src/types/copied.rs
+++ b/frontend/exporter/src/types/copied.rs
@@ -2322,7 +2322,8 @@ impl<'tcx, S: UnderOwnerState<'tcx>, Body: IsBody> SInto<S, ImplItem<Body>>
     fn sinto(&self, s: &S) -> ImplItem<Body> {
         let tcx: rustc_middle::ty::TyCtxt = s.base().tcx;
         let impl_item = tcx.hir().impl_item(self.id.clone());
-        impl_item.sinto(s)
+        let s = with_owner_id(s.base(), (), (), impl_item.owner_id.to_def_id());
+        impl_item.sinto(&s)
     }
 }
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]

--- a/frontend/exporter/src/types/copied.rs
+++ b/frontend/exporter/src/types/copied.rs
@@ -2407,6 +2407,7 @@ pub struct ImplItem<Body: IsBody> {
     pub attributes: ItemAttributes,
 }
 
+/// Reflects [`rustc_hir::ImplItemKind`], inlining the body of the items.
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::ImplItemKind<'tcx>, state: S as s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2420,18 +2421,19 @@ pub enum ImplItemKind<Body: IsBody> {
         let parent_bounds = {
             let (tcx, owner_id) = (s.base().tcx, s.owner_id());
             let assoc_item = tcx.opt_associated_item(owner_id).unwrap();
-            let impl_did = assoc_item.impl_container(tcx).unwrap(); // TODO: can be a trait_id!
+            let impl_did = assoc_item.impl_container(tcx).unwrap();
             tcx.explicit_item_bounds(assoc_item.trait_item_def_id.unwrap())
                 .skip_binder()
-                    .into_iter()
-                    .flat_map(|x| super_predicate_to_clauses_and_impl_expr(s, impl_did, x))
-                    .collect::<Vec<_>>()
+                .into_iter()
+                .flat_map(|x| super_predicate_to_clauses_and_impl_expr(s, impl_did, x))
+                .collect::<Vec<_>>()
         };
         ImplItemKind::Type {
             ty: t.sinto(s),
             parent_bounds
         }
         },)]
+    /// An associated type with its parent bounds inlined.
     Type {
         ty: Ty,
         parent_bounds: Vec<(Clause, ImplExpr, Span)>,
@@ -2459,6 +2461,7 @@ impl<
     }
 }
 
+/// Reflects [`rustc_hir::Impl`].
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::Impl<'tcx>, state: S as s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2488,6 +2491,8 @@ pub struct Impl<Body: IsBody> {
             vec![]
         }
     })]
+    /// The clauses and impl expressions corresponding to the impl's
+    /// trait (if not inherent) super bounds (if any).
     pub parent_bounds: Vec<(Clause, ImplExpr, Span)>,
 }
 

--- a/frontend/exporter/src/types/copied.rs
+++ b/frontend/exporter/src/types/copied.rs
@@ -902,7 +902,7 @@ impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, AliasTy> for rustc_middle::ty::Ali
         .then(|| {
             let trait_ref = self.trait_ref(tcx);
             let poly_trait_ref = rustc_middle::ty::Binder::dummy(trait_ref);
-            let param_env = tcx.param_env(s.owner_id());
+            let param_env = get_param_env(s);
             (
                 self.trait_def_id(tcx).sinto(s),
                 poly_trait_ref.impl_expr(s, param_env),
@@ -1914,7 +1914,7 @@ pub enum ExprKind {
                         let tcx = gstate.base().tcx;
                         let r#impl = tcx.opt_associated_item(*def_id).as_ref().and_then(|assoc| {
                             poly_trait_ref(gstate, assoc, substs)
-                        }).map(|poly_trait_ref| poly_trait_ref.impl_expr(gstate, tcx.param_env(gstate.owner_id())));
+                        }).map(|poly_trait_ref| poly_trait_ref.impl_expr(gstate, get_param_env(gstate)));
                         (Expr {
                             contents,
                             span: e.span.sinto(gstate),

--- a/test-harness/src/snapshots/toolchain__generics into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__generics into-fstar.snap
@@ -34,8 +34,12 @@ module Generics
 open Core
 open FStar.Mul
 
-let impl__Bar__inherent_impl_generics (#v_T: Type) (v_N: usize) (x: t_Array v_T v_N) : Prims.unit =
-  ()
+let impl__Bar__inherent_impl_generics
+      (#v_T: Type)
+      (v_N: usize)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: Core.Marker.t_Sized v_T)
+      (x: t_Array v_T v_N)
+    : Prims.unit = ()
 
 class t_Foo (v_Self: Type) = { f_const_add:v_N: usize -> v_Self -> usize }
 

--- a/test-harness/src/snapshots/toolchain__traits into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__traits into-fstar.snap
@@ -34,19 +34,24 @@ module Traits
 open Core
 open FStar.Mul
 
-let impl_2__method (#v_T: Type) (x: v_T) : Prims.unit = f_bar x
-
 class t_Bar (v_Self: Type) = { f_bar:v_Self -> Prims.unit }
 
+let impl_2__method
+      (#v_T: Type)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: Core.Marker.t_Sized v_T)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: t_Bar v_T)
+      (x: v_T)
+    : Prims.unit = f_bar x
+
 class t_Lang (v_Self: Type) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_529871881:Core.Marker.t_Sized v_Self;
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_8328838127052049456:Core.Marker.t_Sized v_Self;
   f_Var:Type;
   f_Var_6601305896307871948:Core.Marker.t_Sized _;
   f_s:v_Self -> i32 -> (v_Self & _)
 }
 
 class t_SuperTrait (v_Self: Type) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_590399929:Core.Clone.t_Clone v_Self;
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_2101570567305961368:Core.Clone.t_Clone v_Self;
   f_function_of_super_trait:v_Self -> u32
 }
 


### PR DESCRIPTION
This PR:
 - **exporter**:
   - decorate the paths to impl expressions with `clause_id`s;
   - refactor/clean/fixes some code;
   - resolve impl expressions and clauses for parent bounds and associated bounds on impl blocks;
 - **engine**:
   - renames the `trait_ref` AST type into `trait_goal`;
   - introduces `impl_ident` in the AST;
   - propagate/add the impl idents introduced in the exporter.

In a more high-level view, this PR adds the things missing in the exporter for fully supporting explicit implementation expressions.
I think now we have all the information in hax' AST to extract code with already resolved traits. For instance, we should be able to rework the F* backend so that we don't rely on TC inference on F* side any longer.