### PR TITLE
doc(frontend): document `copied.rs` file

### DIFF
--- a/frontend/exporter/src/constant_utils.rs
+++ b/frontend/exporter/src/constant_utils.rs
@@ -53,6 +53,10 @@ pub struct ConstantFieldExpr {
     pub value: ConstantExpr,
 }
 
+/// Rustc has different representation for constants: one for MIR
+/// ([`rustc_middle::mir::ConstantKind`]), one for the type system
+/// ([`rustc_middle::ty::ConstKind`]). For simplicity hax maps those
+/// two construct to one same `ConstantExpr` type.
 pub type ConstantExpr = Decorated<ConstantExprKind>;
 
 impl From<ConstantFieldExpr> for FieldExpr {

--- a/frontend/exporter/src/types/copied.rs
+++ b/frontend/exporter/src/types/copied.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 use crate::rustc_middle::query::Key;
 
+/// Reflects [`rustc_hir::definitions::DisambiguatedDefPathData`]
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -10,17 +11,31 @@ pub struct DisambiguatedDefPathItem {
     pub disambiguator: u32,
 }
 
+/// Reflects [`rustc_hir::def_id::DefId`]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord)]
 pub struct DefId {
     pub krate: String,
     pub path: Vec<DisambiguatedDefPathItem>,
+    /// Rustc's `CrateNum` and `DefIndex` raw indexes. This can be
+    /// useful if one needs to convert a [`DefId`] into a
+    /// [`rustc_hir::def_id::DefId`]; there is a `From` instance for
+    /// that purpose.
+    ///
+    /// **Warning: this `index` field might not be safe to use**. They are
+    /// valid only for one Rustc sesssion. Please do not rely on those
+    /// indexes unless you cannot do otherwise.
     pub index: (u32, u32),
 }
 
 impl std::hash::Hash for DefId {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.krate.hash(state);
-        self.path.hash(state);
+        let DefId {
+            krate,
+            path,
+            index: _, // intentionally discarding index
+        } = self;
+        krate.hash(state);
+        path.hash(state);
     }
 }
 
@@ -72,6 +87,7 @@ impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, GlobalIdent> for rustc_hir::def_id
     }
 }
 
+/// Reflects [`rustc_middle::thir::LogicalOp`]
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -81,6 +97,7 @@ pub enum LogicalOp {
     Or,
 }
 
+/// Reflects [`rustc_hir::definitions::DefPathData`]
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -102,6 +119,7 @@ pub enum DefPathItem {
     ImplTraitAssocTy,
 }
 
+/// Reflects [`rustc_middle::thir::LintLevel`]
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -111,6 +129,7 @@ pub enum LintLevel {
     Explicit(HirId),
 }
 
+/// Reflects [`rustc_ast::ast::AttrStyle`]
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -120,6 +139,7 @@ pub enum AttrStyle {
     Inner,
 }
 
+/// Reflects [`rustc_ast::ast::Attribute`]
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -132,6 +152,8 @@ pub struct Attribute {
     pub span: Span,
 }
 
+/// Generic container for decorating items with a type, a span,
+/// attributes and other meta-data.
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -143,6 +165,7 @@ pub struct Decorated<T> {
     pub attributes: Vec<Attribute>,
 }
 
+/// Reflects [`rustc_middle::mir::UnOp`]
 #[derive(AdtInto, Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[args(<'slt, S: UnderOwnerState<'slt>>, from: rustc_middle::mir::UnOp, state: S as _s)]
 pub enum UnOp {
@@ -150,6 +173,7 @@ pub enum UnOp {
     Neg,
 }
 
+/// Reflects [`rustc_middle::mir::BinOp`]
 #[derive(AdtInto, Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[args(<'slt, S: UnderOwnerState<'slt>>, from: rustc_middle::mir::BinOp, state: S as _s)]
 pub enum BinOp {
@@ -175,6 +199,7 @@ pub enum BinOp {
 pub type Pat = Decorated<PatKind>;
 pub type Expr = Decorated<ExprKind>;
 
+/// Reflects [`rustc_middle::mir::BinOp`]
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> + HasThir<'tcx>>, from: rustc_middle::middle::region::ScopeData, state: S as gstate)]
 pub enum ScopeData {
@@ -186,6 +211,7 @@ pub enum ScopeData {
     Remainder(FirstStatementIndex),
 }
 
+/// Reflects [`rustc_middle::mir::BinOp`]
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> + HasThir<'tcx>>, from: rustc_middle::middle::region::Scope, state: S as gstate)]
 pub struct Scope {
@@ -239,6 +265,7 @@ impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, Ty> for rustc_middle::ty::Ty<'tcx>
     }
 }
 
+/// Reflects [`rustc_hir::hir_id::HirId`]
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -256,6 +283,7 @@ impl<'tcx, S: BaseState<'tcx>> SInto<S, DefId> for rustc_hir::hir_id::OwnerId {
     }
 }
 
+/// Reflects [`rustc_ast::ast::LitFloatType`]
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -264,6 +292,7 @@ pub enum LitFloatType {
     Suffixed(FloatTy),
     Unsuffixed,
 }
+/// Reflects [`rustc_hir::Movability`]
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -273,6 +302,7 @@ pub enum Movability {
     Movable,
 }
 
+/// Reflects [`rustc_middle::infer::canonical::CanonicalTyVarKind`]
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::infer::canonical::CanonicalTyVarKind, state: S as gstate)]
 pub enum CanonicalTyVarKind {
@@ -281,6 +311,7 @@ pub enum CanonicalTyVarKind {
     Float,
 }
 
+/// Reflects [`rustc_middle::ty::ParamTy`]
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -290,6 +321,7 @@ pub struct ParamTy {
     pub name: Symbol,
 }
 
+/// Reflects [`rustc_middle::ty::ParamConst`]
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -299,6 +331,7 @@ pub struct ParamConst {
     pub name: Symbol,
 }
 
+/// Reflects [`rustc_middle::ty::DynKind`]
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -308,6 +341,7 @@ pub enum DynKind {
     DynStar,
 }
 
+/// Reflects [`rustc_middle::ty::BoundTyKind`]
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -317,6 +351,7 @@ pub enum BoundTyKind {
     Param(DefId, Symbol),
 }
 
+/// Reflects [`rustc_middle::ty::BoundTy`]
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -326,6 +361,7 @@ pub struct BoundTy {
     pub kind: BoundTyKind,
 }
 
+/// Reflects [`rustc_middle::ty::BoundRegionKind`]
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -336,6 +372,7 @@ pub enum BoundRegionKind {
     BrEnv,
 }
 
+/// Reflects [`rustc_middle::ty::BoundRegion`]
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -345,10 +382,14 @@ pub struct BoundRegion {
     pub kind: BoundRegionKind,
 }
 
+/// Reflects [`rustc_middle::ty::PlaceholderRegion`]
 pub type PlaceholderRegion = Placeholder<BoundRegion>;
+/// Reflects [`rustc_middle::ty::PlaceholderConst`]
 pub type PlaceholderConst = Placeholder<BoundVar>;
+/// Reflects [`rustc_middle::ty::PlaceholderType`]
 pub type PlaceholderType = Placeholder<BoundTy>;
 
+/// Reflects [`rustc_middle::ty::Placeholder`]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -368,12 +409,14 @@ impl<'tcx, S: UnderOwnerState<'tcx>, T: SInto<S, U>, U> SInto<S, Placeholder<U>>
     }
 }
 
+/// Reflects [`rustc_middle::infer::canonical::Canonical`]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct Canonical<T> {
     pub max_universe: UniverseIndex,
     pub variables: Vec<CanonicalVarInfo>,
     pub value: T,
 }
+/// Reflects [`rustc_middle::ty::CanonicalUserType`]
 pub type CanonicalUserType = Canonical<UserType>;
 
 impl<'tcx, S: UnderOwnerState<'tcx>, T: SInto<S, U>, U> SInto<S, Canonical<U>>
@@ -388,6 +431,7 @@ impl<'tcx, S: UnderOwnerState<'tcx>, T: SInto<S, U>, U> SInto<S, Canonical<U>>
     }
 }
 
+/// Reflects [`rustc_middle::infer::canonical::CanonicalVarKind`]
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::infer::canonical::CanonicalVarKind<'tcx>, state: S as gstate)]
 pub enum CanonicalVarInfo {
@@ -399,6 +443,7 @@ pub enum CanonicalVarInfo {
     PlaceholderConst(PlaceholderConst, Ty),
 }
 
+/// Reflects [`rustc_middle::ty::subst::UserSelfTy`]
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::subst::UserSelfTy<'tcx>, state: S as gstate)]
 pub struct UserSelfTy {
@@ -406,6 +451,7 @@ pub struct UserSelfTy {
     pub self_ty: Ty,
 }
 
+/// Reflects [`rustc_middle::ty::subst::UserSubsts`]
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::subst::UserSubsts<'tcx>, state: S as gstate)]
 pub struct UserSubsts {
@@ -413,6 +459,9 @@ pub struct UserSubsts {
     pub user_self_ty: Option<UserSelfTy>,
 }
 
+/// Reflects [`rustc_middle::ty::UserType`]: this is currently
+/// disabled, and everything is printed as debug in the
+/// [`UserType::Todo`] variant.
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::UserType<'tcx>, state: S as _s)]
 pub enum UserType {
@@ -442,6 +491,7 @@ pub enum UserType {
     Todo(String),
 }
 
+/// Reflects [`rustc_hir::def::CtorKind`]
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[args(<S>, from: rustc_hir::def::CtorKind, state: S as _s)]
 pub enum CtorKind {
@@ -449,6 +499,7 @@ pub enum CtorKind {
     Const,
 }
 
+/// Reflects [`rustc_middle::ty::VariantDiscr`]
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::VariantDiscr, state: S as gstate)]
 pub enum VariantDiscr {
@@ -456,6 +507,7 @@ pub enum VariantDiscr {
     Relative(u32),
 }
 
+/// Reflects [`rustc_middle::ty::Visibility`]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub enum Visibility<Id = rustc_span::def_id::LocalDefId> {
     Public,
@@ -471,10 +523,13 @@ impl<S, T: SInto<S, U>, U> SInto<S, Visibility<U>> for rustc_middle::ty::Visibil
     }
 }
 
+/// Reflects [`rustc_middle::ty::FieldDef`]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct FieldDef {
     pub did: DefId,
-    /// The user may not have provided a name
+    /// Field definition of [tuple
+    /// structs](https://doc.rust-lang.org/book/ch05-01-defining-structs.html#using-tuple-structs-without-named-fields-to-create-different-types)
+    /// are anonymous, in that case `name` is [`None`].
     pub name: Option<Symbol>,
     pub vis: Visibility<DefId>,
     pub ty: Ty,
@@ -509,6 +564,7 @@ impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, FieldDef> for rustc_middle::ty::Fi
     }
 }
 
+/// Reflects [`rustc_middle::ty::VariantDef`]
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::VariantDef, state: S as s)]
 pub struct VariantDef {
@@ -516,12 +572,18 @@ pub struct VariantDef {
     pub ctor: Option<(CtorKind, DefId)>,
     pub name: Symbol,
     pub discr: VariantDiscr,
+    /// The definitions of the fields on this variant. In case of
+    /// [tuple
+    /// structs](https://doc.rust-lang.org/book/ch05-01-defining-structs.html#using-tuple-structs-without-named-fields-to-create-different-types),
+    /// the fields are anonymous, otherwise fields are named.
     #[value(self.fields.raw.sinto(s))]
     pub fields: Vec<FieldDef>,
+    /// Span of the definition of the variant
     #[value(s.base().tcx.def_span(self.def_id).sinto(s))]
     pub span: Span,
 }
 
+/// Reflects [`rustc_middle::ty::EarlyBoundRegion`]
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -532,6 +594,7 @@ pub struct EarlyBoundRegion {
     pub name: Symbol,
 }
 
+/// Reflects [`rustc_middle::ty::FreeRegion`]
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -541,21 +604,7 @@ pub struct FreeRegion {
     pub bound_region: BoundRegionKind,
 }
 
-#[derive(
-    Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
-)]
-pub struct RegionVid {
-    pub index: u32,
-}
-
-impl<S> SInto<S, RegionVid> for rustc_middle::ty::RegionVid {
-    fn sinto(&self, _: &S) -> RegionVid {
-        RegionVid {
-            index: self.as_u32(),
-        }
-    }
-}
-
+/// Reflects [`rustc_middle::ty::RegionKind`]
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -571,6 +620,7 @@ pub enum RegionKind {
     ReError(ErrorGuaranteed),
 }
 
+/// Reflects [`rustc_middle::ty::Region`]
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -580,6 +630,7 @@ pub struct Region {
     pub kind: RegionKind,
 }
 
+/// Reflects both [`rustc_middle::ty::subst::GenericArg`] and [`rustc_middle::ty::subst::GenericArgKind`]
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -604,6 +655,7 @@ impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, Vec<GenericArg>>
     }
 }
 
+/// Reflects both [`rustc_middle::ty::subst::GenericArg`] and [`rustc_middle::ty::subst::GenericArgKind`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> + HasThir<'tcx>>, from: rustc_ast::ast::LitIntType, state: S as gstate)]
 #[derive(
@@ -617,22 +669,34 @@ pub enum LitIntType {
 
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[args(<'tcx, S: ExprState<'tcx>>, from: rustc_middle::thir::FruInfo<'tcx>, state: S as gstate)]
-/// This is [Constructor {⟨field_types⟩, ..base}]
+/// Field Record Update (FRU) informations, this reflects [`rustc_middle::thir::FruInfo`]
 pub struct FruInfo {
+    /// The base, e.g. `Foo {x: 1, .. base}`
     pub base: Expr,
     pub field_types: Vec<Ty>,
 }
 
+/// A field expression: a field name along with a value
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct FieldExpr {
     pub field: DefId,
     pub value: Expr,
 }
 
+/// A field pattern: a field name along with a pattern
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct FieldPat {
     pub field: DefId,
     pub pattern: Pat,
+}
+
+/// Reflects [`rustc_middle::thir::AdtExpr`]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct AdtExpr {
+    pub info: VariantInformations,
+    pub user_ty: Option<CanonicalUserType>,
+    pub fields: Vec<FieldExpr>,
+    pub base: Option<FruInfo>,
 }
 
 impl<'tcx, S: ExprState<'tcx>> SInto<S, AdtExpr> for rustc_middle::thir::AdtExpr<'tcx> {
@@ -655,6 +719,7 @@ impl<'tcx, S: ExprState<'tcx>> SInto<S, AdtExpr> for rustc_middle::thir::AdtExpr
     }
 }
 
+/// Reflects [`rustc_span::Loc`]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash, PartialOrd, Ord,
 )]
@@ -663,6 +728,7 @@ pub struct Loc {
     pub col: usize,
 }
 
+/// Reflects [`rustc_span::hygiene::DesugaringKind`]
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[args(<S>, from: rustc_span::hygiene::DesugaringKind, state: S as _s)]
 pub enum DesugaringKind {
@@ -677,6 +743,7 @@ pub enum DesugaringKind {
     WhileLoop,
 }
 
+/// Reflects [`rustc_span::hygiene::AstPass`]
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[args(<S>, from: rustc_span::hygiene::AstPass, state: S as _s)]
 pub enum AstPass {
@@ -685,6 +752,7 @@ pub enum AstPass {
     ProcMacroHarness,
 }
 
+/// Reflects [`rustc_span::hygiene::MacroKind`]
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[args(<S>, from: rustc_span::hygiene::MacroKind, state: S as _s)]
 pub enum MacroKind {
@@ -693,6 +761,7 @@ pub enum MacroKind {
     Derive,
 }
 
+/// Reflects [`rustc_span::hygiene::ExpnKind`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: BaseState<'tcx>>, from: rustc_span::hygiene::ExpnKind, state: S as gstate)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -703,6 +772,7 @@ pub enum ExpnKind {
     Desugaring(DesugaringKind),
 }
 
+/// Reflects [`rustc_span::edition::Edition`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_span::edition::Edition, state: S as _s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -713,6 +783,7 @@ pub enum Edition {
     Edition2024,
 }
 
+/// Reflects [`rustc_span::hygiene::ExpnData`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: BaseState<'tcx>>, from: rustc_span::hygiene::ExpnData, state: S as state)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -731,6 +802,7 @@ pub struct ExpnData {
     pub collapse_debuginfo: bool,
 }
 
+/// Reflects [`rustc_span::Span`]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash, PartialOrd, Ord,
 )]
@@ -758,6 +830,7 @@ impl<'tcx, S: BaseState<'tcx>> SInto<S, Span> for rustc_span::Span {
     }
 }
 
+/// Reflects [`rustc_middle::thir::LocalVarId`]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct LocalIdent {
     pub name: String,
@@ -781,6 +854,7 @@ impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, LocalIdent> for rustc_middle::thir
     }
 }
 
+/// Reflects [`rustc_span::source_map::Spanned`]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct Spanned<T> {
     pub node: T,
@@ -803,6 +877,7 @@ impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, String> for PathBuf {
     }
 }
 
+/// Reflects [`rustc_span::RealFileName`]
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Hash, PartialOrd, Ord,
 )]
@@ -825,6 +900,7 @@ impl<S> SInto<S, u64> for rustc_data_structures::stable_hasher::Hash64 {
     }
 }
 
+/// Reflects [`rustc_span::FileName`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_span::FileName, state: S as gstate)]
 #[derive(
@@ -845,6 +921,7 @@ pub enum FileName {
     InlineAsm(u64),
 }
 
+/// Reflects partially [`rustc_middle::ty::InferTy`]
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -861,6 +938,7 @@ pub enum InferTy {
     FreshFloatTy(u32),
 }
 
+/// Reflects [`rustc_middle::thir::BlockSafety`]
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[args(<'tcx, S>, from: rustc_middle::thir::BlockSafety, state: S as _s)]
 pub enum BlockSafety {
@@ -870,6 +948,7 @@ pub enum BlockSafety {
     ExplicitUnsafe,
 }
 
+/// Reflects [`rustc_middle::thir::Block`]
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[args(<'tcx, S: ExprState<'tcx>>, from: rustc_middle::thir::Block, state: S as gstate)]
 pub struct Block {
@@ -882,12 +961,16 @@ pub struct Block {
     pub safety_mode: BlockSafety,
 }
 
+/// Reflects [`rustc_middle::ty::AliasTy`]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
 pub struct AliasTy {
     pub substs: Vec<GenericArg>,
     pub trait_def_id: Option<(DefId, ImplExpr)>,
+    /// If the alias is a projection (e.g. `<Ty as Trait<...>>::N<...>`),
+    /// `trait_def_id` contains the identifier for `Trait` and the
+    /// impl expressions that satisfies `Ty: Trait<...>`.
     pub def_id: DefId,
 }
 
@@ -900,12 +983,9 @@ impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, AliasTy> for rustc_middle::ty::Ali
             AssocTy | AssocConst | ImplTraitPlaceholder
         )
         .then(|| {
-            let trait_ref = self.trait_ref(tcx);
-            let poly_trait_ref = rustc_middle::ty::Binder::dummy(trait_ref);
-            let param_env = get_param_env(s);
             (
                 self.trait_def_id(tcx).sinto(s),
-                poly_trait_ref.impl_expr(s, param_env),
+                self.trait_ref(tcx).impl_expr(s, get_param_env(s)),
             )
         });
         AliasTy {
@@ -916,6 +996,7 @@ impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, AliasTy> for rustc_middle::ty::Ali
     }
 }
 
+/// Reflects [`rustc_middle::thir::BindingMode`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_middle::thir::BindingMode, state: S as s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -924,6 +1005,7 @@ pub enum BindingMode {
     ByRef(BorrowKind),
 }
 
+/// Reflects [`rustc_middle::thir::Stmt`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: ExprState<'tcx>>, from: rustc_middle::thir::Stmt<'tcx>, state: S as s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -932,6 +1014,7 @@ pub struct Stmt {
     pub opt_destruction_scope: Option<Scope>,
 }
 
+/// Reflects [`rustc_ast::ast::MacDelimiter`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_ast::ast::MacDelimiter, state: S as _s)]
 #[derive(
@@ -943,6 +1026,7 @@ pub enum MacDelimiter {
     Brace,
 }
 
+/// Reflects [`rustc_ast::token::Delimiter`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_ast::token::Delimiter, state: S as _s)]
 #[derive(
@@ -955,6 +1039,7 @@ pub enum Delimiter {
     Invisible,
 }
 
+/// Reflects [`rustc_ast::tokenstream::TokenTree`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_ast::tokenstream::TokenTree, state: S as s)]
 #[derive(
@@ -965,6 +1050,7 @@ pub enum TokenTree {
     Delimited(DelimSpan, Delimiter, TokenStream),
 }
 
+/// Reflects [`rustc_ast::tokenstream::Spacing`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_ast::tokenstream::Spacing, state: S as _s)]
 #[derive(
@@ -975,6 +1061,7 @@ pub enum Spacing {
     Joint,
 }
 
+/// Reflects [`rustc_ast::token::BinOpToken`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_ast::token::BinOpToken, state: S as _s)]
 #[derive(
@@ -993,6 +1080,7 @@ pub enum BinOpToken {
     Shr,
 }
 
+/// Reflects [`rustc_ast::token::TokenKind`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_ast::token::TokenKind, state: S as gstate)]
 #[derive(
@@ -1040,6 +1128,7 @@ pub enum TokenKind {
     Todo(String),
 }
 
+/// Reflects [`rustc_ast::token::Token`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_ast::token::Token, state: S as gstate)]
 #[derive(
@@ -1050,6 +1139,7 @@ pub struct Token {
     pub span: Span,
 }
 
+/// Reflects [`rustc_ast::ast::DelimArgs`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_ast::ast::DelimArgs, state: S as gstate)]
 #[derive(
@@ -1061,6 +1151,7 @@ pub struct DelimArgs {
     pub tokens: TokenStream,
 }
 
+/// Reflects [`rustc_ast::ast::MacCall`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_ast::ast::MacCall, state: S as gstate)]
 #[derive(
@@ -1072,6 +1163,9 @@ pub struct MacCall {
     pub args: DelimArgs,
 }
 
+/// Reflects [`rustc_ast::tokenstream::TokenStream`] as a plain
+/// string. If you need to reshape that into Rust tokens or construct,
+/// please use, e.g., `syn`.
 pub type TokenStream = String;
 impl<'t, S> SInto<S, TokenStream> for rustc_ast::tokenstream::TokenStream {
     fn sinto(&self, _: &S) -> String {
@@ -1091,6 +1185,8 @@ impl<'tcx, S: ExprState<'tcx>> SInto<S, Stmt> for rustc_middle::thir::StmtId {
     }
 }
 
+/// While translating expressions, we expect to always have a THIR
+/// body and an `owner_id` in the state
 pub trait ExprState<'tcx> = UnderOwnerState<'tcx> + HasThir<'tcx>;
 
 impl<'tcx, S: ExprState<'tcx>> SInto<S, Expr> for rustc_middle::thir::Expr<'tcx> {
@@ -1261,6 +1357,7 @@ impl<'tcx, S: ExprState<'tcx>> SInto<S, Arm> for rustc_middle::thir::ArmId {
     }
 }
 
+/// Reflects [`rustc_type_ir::IntTy`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_type_ir::IntTy, state: S as _s)]
 #[derive(
@@ -1275,6 +1372,7 @@ pub enum IntTy {
     I128,
 }
 
+/// Reflects [`rustc_type_ir::FloatTy`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_type_ir::FloatTy, state: S as _s)]
 #[derive(
@@ -1322,6 +1420,7 @@ impl<'tcx, S> SInto<S, UintTy> for rustc_ast::ast::UintTy {
     }
 }
 
+/// Reflects [`rustc_type_ir::UintTy`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_type_ir::UintTy, state: S as _s)]
 #[derive(
@@ -1364,6 +1463,7 @@ impl ToString for UintTy {
     }
 }
 
+/// Reflects [`rustc_middle::ty::TypeAndMut`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::TypeAndMut<'tcx>, state: S as gstate)]
 #[derive(
@@ -1380,12 +1480,7 @@ impl<S, U, T: SInto<S, U>> SInto<S, Vec<U>> for rustc_middle::ty::List<T> {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
-pub enum ArrowKind {
-    Constructor { payload: Ty },
-    Function { params: Vec<Ty> },
-}
-
+/// Reflects [`rustc_middle::ty::GenericParamDef`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::GenericParamDef, state: S as state)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -1397,6 +1492,7 @@ pub struct GenericParamDef {
     pub kind: GenericParamDefKind,
 }
 
+/// Reflects [`rustc_middle::ty::GenericParamDefKind`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::GenericParamDefKind, state: S as state)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -1406,6 +1502,7 @@ pub enum GenericParamDefKind {
     Const { has_default: bool },
 }
 
+/// Reflects [`rustc_middle::ty::Generics`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::Generics, state: S as state)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -1418,6 +1515,7 @@ pub struct TyGenerics {
     pub has_late_bound_regions: Option<Span>,
 }
 
+/// Reflects [`rustc_type_ir::sty::AliasKind`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_type_ir::sty::AliasKind, state: S as _s)]
 #[derive(
@@ -1429,6 +1527,7 @@ pub enum AliasKind {
     Opaque,
 }
 
+/// Reflects [`rustc_middle::ty::TyKind`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::TyKind<'tcx>, state: S as state)]
 #[derive(
@@ -1453,6 +1552,7 @@ pub enum Ty {
             arrow_of_sig(&sig, state)
         },
     )]
+    /// Reflects [`rustc_middle::ty::TyKind::FnPtr`], [`rustc_middle::ty::TyKind::FnDef`] and [`rustc_middle::ty::TyKind::Closure`]
     Arrow(Box<PolyFnSig>),
 
     #[custom_arm(
@@ -1463,6 +1563,7 @@ pub enum Ty {
         },
     )]
     Adt {
+        /// Reflects [`rustc_middle::ty::TyKind::Adt`]'s substitutions
         generic_args: Vec<GenericArg>,
         def_id: DefId,
     },
@@ -1487,6 +1588,7 @@ pub enum Ty {
     Todo(String),
 }
 
+/// Reflects [`rustc_middle::thir::StmtKind`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: ExprState<'tcx>>, from: rustc_middle::thir::StmtKind<'tcx>, state: S as gstate)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -1503,10 +1605,12 @@ pub enum StmtKind {
         else_block: Option<Block>,
         lint_level: LintLevel,
         #[value(attribute_from_scope(gstate, init_scope).1)]
+        /// The attribute on this `let` binding
         attributes: Vec<Attribute>,
     },
 }
 
+/// Reflects [`rustc_middle::ty::Variance`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_middle::ty::Variance, state: S as _s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -1517,6 +1621,7 @@ pub enum Variance {
     Bivariant,
 }
 
+/// Reflects [`rustc_middle::ty::CanonicalUserTypeAnnotation`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::CanonicalUserTypeAnnotation<'tcx>, state: S as gstate)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -1526,6 +1631,7 @@ pub struct CanonicalUserTypeAnnotation {
     pub inferred_ty: Ty,
 }
 
+/// Reflects [`rustc_middle::thir::Ascription`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> + HasThir<'tcx>>, from: rustc_middle::thir::Ascription<'tcx>, state: S as gstate)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -1534,6 +1640,7 @@ pub struct Ascription {
     pub variance: Variance,
 }
 
+/// Reflects [`rustc_hir::RangeEnd`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_hir::RangeEnd, state: S as _s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -1542,6 +1649,7 @@ pub enum RangeEnd {
     Excluded,
 }
 
+/// Reflects [`rustc_middle::thir::PatRange`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> + HasThir<'tcx>>, from: rustc_middle::thir::PatRange<'tcx>, state: S as state)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -1551,6 +1659,7 @@ pub struct PatRange {
     pub end: RangeEnd,
 }
 
+/// Reflects [`rustc_middle::ty::AdtKind`]
 #[derive(AdtInto, Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::AdtKind, state: S as _s)]
 pub enum AdtKind {
@@ -1561,6 +1670,7 @@ pub enum AdtKind {
 
 // This comes from MIR
 // TODO: add the generics and the predicates
+/// Reflects [`rustc_middle::ty::AdtDef`]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AdtDef {
     pub did: DefId,
@@ -1582,6 +1692,7 @@ impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, AdtDef> for rustc_middle::ty::AdtD
     }
 }
 
+/// Describe a variant
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -1592,24 +1703,18 @@ pub struct VariantInformations {
     pub variant: DefId,
     pub variant_index: VariantIdx,
 
-    // A record type is a type with only one variant which is a record variant.
+    /// A record type is a type with only one variant which is a
+    /// record variant.
     pub typ_is_record: bool,
-    // A record variant is a variant whose fields are named, a record
-    // variant always has at least one field.
+    /// A record variant is a variant whose fields are named, a record
+    /// variant always has at least one field.
     pub variant_is_record: bool,
-    // A struct is a type with exactly one variant. Note that one
-    // variant is named exactly as the type.
+    /// A struct is a type with exactly one variant. Note that one
+    /// variant is named exactly as the type.
     pub typ_is_struct: bool,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
-pub struct AdtExpr {
-    pub info: VariantInformations,
-    pub user_ty: Option<CanonicalUserType>,
-    pub fields: Vec<FieldExpr>,
-    pub base: Option<FruInfo>,
-}
-
+/// Reflects [`rustc_middle::thir::PatKind`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: ExprState<'tcx>>, from: rustc_middle::thir::PatKind<'tcx>, state: S as gstate)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -1661,10 +1766,6 @@ pub enum PatKind {
     )]
     Variant {
         info: VariantInformations,
-        // constructs_record: bool,
-        // constructs_type: DefId,
-        // type_namespace: DefId,
-        // variant: DefId,
         substs: Vec<GenericArg>,
         subpatterns: Vec<FieldPat>,
     },
@@ -1694,6 +1795,7 @@ pub enum PatKind {
     },
 }
 
+/// Reflects [`rustc_middle::thir::Guard`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: ExprState<'tcx>>, from: rustc_middle::thir::Guard<'tcx>, state: S as gstate)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -1702,6 +1804,7 @@ pub enum Guard {
     IfLet(Pat, Expr),
 }
 
+/// Reflects [`rustc_middle::thir::Arm`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: ExprState<'tcx>>, from: rustc_middle::thir::Arm<'tcx>, state: S as gstate)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -1716,6 +1819,7 @@ pub struct Arm {
     attributes: Vec<Attribute>,
 }
 
+/// Reflects [`rustc_hir::Unsafety`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_hir::Unsafety, state: S as _s)]
 #[derive(
@@ -1726,6 +1830,7 @@ pub enum Unsafety {
     Normal,
 }
 
+/// Reflects [`rustc_middle::ty::adjustment::PointerCast`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_middle::ty::adjustment::PointerCast, state: S as gstate)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -1738,6 +1843,7 @@ pub enum PointerCast {
     Unsize,
 }
 
+/// Reflects [`rustc_middle::mir::BorrowKind`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_middle::mir::BorrowKind, state: S as gstate)]
 #[derive(
@@ -1750,6 +1856,7 @@ pub enum BorrowKind {
     Mut { allow_two_phase_borrow: bool },
 }
 
+/// Reflects [`rustc_ast::ast::StrStyle`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_ast::ast::StrStyle, state: S as gstate)]
 #[derive(
@@ -1760,6 +1867,7 @@ pub enum StrStyle {
     Raw(u8),
 }
 
+/// Reflects [`rustc_ast::ast::LitKind`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> + HasThir<'tcx>>, from: rustc_ast::ast::LitKind, state: S as gstate)]
 #[derive(
@@ -1777,6 +1885,10 @@ pub enum LitKind {
     Err,
 }
 
+// FIXME: typo: invo**C**ation
+#[allow(rustdoc::private_intra_doc_links)]
+/// Describe a macro invocation, using
+/// [`macro_invocation_of_raw_mac_invocation`]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct MacroInvokation {
     pub macro_ident: DefId,
@@ -1784,6 +1896,7 @@ pub struct MacroInvokation {
     pub span: Span,
 }
 
+/// Reflects [`rustc_hir::ImplicitSelfKind`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_hir::ImplicitSelfKind, state: S as _s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -1795,6 +1908,7 @@ pub enum ImplicitSelfKind {
     None,
 }
 
+/// Reflects [`rustc_ast::token::CommentKind`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_ast::token::CommentKind, state: S as _s)]
 #[derive(
@@ -1805,6 +1919,7 @@ pub enum CommentKind {
     Block,
 }
 
+/// Reflects [`rustc_ast::ast::AttrArgs`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_ast::ast::AttrArgs, state: S as tcx)]
 #[derive(
@@ -1819,6 +1934,7 @@ pub enum AttrArgs {
     // Eq(Span, AttrArgsEq),
 }
 
+/// Reflects [`rustc_ast::ast::AttrItem`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_ast::ast::AttrItem, state: S as tcx)]
 #[derive(
@@ -1837,6 +1953,7 @@ impl<S> SInto<S, String> for rustc_ast::tokenstream::LazyAttrTokenStream {
     }
 }
 
+/// Reflects [`rustc_ast::ast::NormalAttr`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_ast::ast::NormalAttr, state: S as tcx)]
 #[derive(
@@ -1847,6 +1964,7 @@ pub struct NormalAttr {
     pub tokens: Option<TokenStream>,
 }
 
+/// Reflects [`rustc_ast::AttrKind`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_ast::AttrKind, state: S as tcx)]
 #[derive(
@@ -1857,6 +1975,7 @@ pub enum AttrKind {
     DocComment(CommentKind, Symbol),
 }
 
+/// Reflects [`rustc_middle::thir::Param`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: ExprState<'tcx>>, from: rustc_middle::thir::Param<'tcx>, state: S as s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -1869,9 +1988,11 @@ pub struct Param {
     #[value(hir_id.map(|id| {
         s.base().tcx.hir().attrs(id).sinto(s)
     }).unwrap_or(vec![]))]
+    /// attributes on this parameter
     pub attributes: Vec<Attribute>,
 }
 
+/// Reflects [`rustc_middle::thir::ExprKind`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: ExprState<'tcx>>, from: rustc_middle::thir::ExprKind<'tcx>, state: S as gstate)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -1892,6 +2013,8 @@ pub enum ExprKind {
     },
     #[disable_mapping]
     MacroInvokation(MacroInvokation),
+    /// Resugared macros calls. This is deprecated: see
+    /// <https://github.com/hacspec/hax/issues/145>.
     If {
         if_then_scope: Scope,
         cond: Expr,
@@ -2191,6 +2314,7 @@ impl<'tcx> ExprKindExt<'tcx> for rustc_middle::thir::Expr<'tcx> {
     }
 }
 
+/// Reflects [`rustc_middle::ty::FnSig`]
 #[derive(
     AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -2205,8 +2329,10 @@ pub struct TyFnSig {
     pub abi: Abi,
 }
 
+/// Reflects [`rustc_middle::ty::PolyFnSig`]
 pub type PolyFnSig = Binder<TyFnSig>;
 
+/// Function definition
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct FnDef<Body: IsBody> {
     pub header: FnHeader,
@@ -2216,6 +2342,7 @@ pub struct FnDef<Body: IsBody> {
     pub sig_span: Span,
 }
 
+/// Reflects [`rustc_hir::FnDecl`]
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::FnDecl<'tcx>, state: S as tcx)]
 pub struct FnDecl {
@@ -2226,6 +2353,7 @@ pub struct FnDecl {
     pub lifetime_elision_allowed: bool,
 }
 
+/// Reflects [`rustc_hir::FnSig`]
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::FnSig<'tcx>, state: S as tcx)]
 pub struct FnSig {
@@ -2234,6 +2362,7 @@ pub struct FnSig {
     pub span: Span,
 }
 
+/// Reflects [`rustc_hir::FnHeader`]
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[args(<S>, from: rustc_hir::FnHeader, state: S as tcx)]
 pub struct FnHeader {
@@ -2253,6 +2382,7 @@ impl<'x, 'tcx, S: UnderOwnerState<'tcx>> SInto<S, Ty> for rustc_hir::Ty<'x> {
     }
 }
 
+/// Reflects [`rustc_hir::UseKind`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_hir::UseKind, state: S as _s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2262,6 +2392,7 @@ pub enum UseKind {
     ListStem,
 }
 
+/// Reflects [`rustc_hir::IsAuto`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_hir::IsAuto, state: S as _s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2270,6 +2401,7 @@ pub enum IsAuto {
     No,
 }
 
+/// Reflects [`rustc_hir::Defaultness`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_hir::Defaultness, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2278,6 +2410,7 @@ pub enum Defaultness {
     Final,
 }
 
+/// Reflects [`rustc_hir::ImplPolarity`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_hir::ImplPolarity, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2286,6 +2419,7 @@ pub enum ImplPolarity {
     Negative(Span),
 }
 
+/// Reflects [`rustc_hir::Constness`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_hir::Constness, state: S as _s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2294,6 +2428,7 @@ pub enum Constness {
     NotConst,
 }
 
+/// Reflects [`rustc_hir::Generics`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::Generics<'tcx>, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2307,6 +2442,7 @@ pub struct Generics<Body: IsBody> {
     pub span: Span,
 }
 
+/// Reflects [`rustc_hir::WherePredicate`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::WherePredicate<'tcx>, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2326,12 +2462,16 @@ impl<'tcx, S: UnderOwnerState<'tcx>, Body: IsBody> SInto<S, ImplItem<Body>>
         impl_item.sinto(&s)
     }
 }
+
+/// Reflects [`rustc_hir::ParamName`]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub enum ParamName {
     Plain(LocalIdent),
     Fresh,
     Error,
 }
+
+/// Reflects [`rustc_hir::LifetimeParamKind`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_hir::LifetimeParamKind, state: S as _s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2340,6 +2480,8 @@ pub enum LifetimeParamKind {
     Elided,
     Error,
 }
+
+/// Reflects [`rustc_hir::AnonConst`]
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_hir::AnonConst, state: S as s)]
 pub struct AnonConst<Body: IsBody> {
@@ -2351,6 +2493,7 @@ pub struct AnonConst<Body: IsBody> {
     pub body: Body,
 }
 
+/// Reflects [`rustc_hir::GenericParamKind`]
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::GenericParamKind<'tcx>, state: S as tcx)]
 pub enum GenericParamKind<Body: IsBody> {
@@ -2368,6 +2511,7 @@ pub enum GenericParamKind<Body: IsBody> {
     },
 }
 
+/// Reflects [`rustc_hir::GenericParam`]
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::GenericParam<'tcx>, state: S as s)]
 pub struct GenericParam<Body: IsBody> {
@@ -2393,6 +2537,7 @@ pub struct GenericParam<Body: IsBody> {
     attributes: Vec<Attribute>,
 }
 
+/// Reflects [`rustc_hir::ImplItem`]
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::ImplItem<'tcx>, state: S as s)]
 pub struct ImplItem<Body: IsBody> {
@@ -2404,6 +2549,7 @@ pub struct ImplItem<Body: IsBody> {
     pub span: Span,
     pub vis_span: Span,
     #[value(ItemAttributes::from_owner_id(s, *owner_id))]
+    /// the attributes on this impl item
     pub attributes: ItemAttributes,
 }
 
@@ -2440,6 +2586,7 @@ pub enum ImplItemKind<Body: IsBody> {
     },
 }
 
+/// Reflects [`rustc_hir::AssocItemKind`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_hir::AssocItemKind, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2496,6 +2643,7 @@ pub struct Impl<Body: IsBody> {
     pub parent_bounds: Vec<(Clause, ImplExpr, Span)>,
 }
 
+/// Reflects [`rustc_hir::IsAsync`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_hir::IsAsync, state: S as _s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2504,6 +2652,7 @@ pub enum IsAsync {
     NotAsync,
 }
 
+/// Reflects [`rustc_hir::FnRetTy`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::FnRetTy<'tcx>, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2512,6 +2661,7 @@ pub enum FnRetTy {
     Return(Ty),
 }
 
+/// Reflects [`rustc_hir::VariantData`]
 #[derive(AdtInto, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::VariantData<'tcx>, state: S as tcx)]
 pub enum VariantData {
@@ -2520,6 +2670,7 @@ pub enum VariantData {
     Unit(HirId, GlobalIdent),
 }
 
+/// Reflects [`rustc_hir::FieldDef`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::FieldDef<'tcx>, state: S as s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2534,6 +2685,7 @@ pub struct HirFieldDef {
     attributes: Vec<Attribute>,
 }
 
+/// Reflects [`rustc_hir::Variant`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::Variant<'tcx>, state: S as s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2548,6 +2700,7 @@ pub struct Variant<Body: IsBody> {
     pub attributes: Vec<Attribute>,
 }
 
+/// Reflects [`rustc_hir::UsePath`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_hir::UsePath<'tcx>, state: S as s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2569,6 +2722,7 @@ pub struct UsePath {
     pub rename: Option<String>,
 }
 
+/// Reflects [`rustc_hir::def::Res`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_hir::def::Res, state: S as s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2590,6 +2744,7 @@ pub enum Res {
     Err,
 }
 
+/// Reflects [`rustc_hir::PrimTy`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_hir::PrimTy, state: S as s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2602,6 +2757,7 @@ pub enum PrimTy {
     Char,
 }
 
+/// Reflects [`rustc_hir::def::NonMacroAttrKind`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_hir::def::NonMacroAttrKind, state: S as s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2612,6 +2768,7 @@ pub enum NonMacroAttrKind {
     DeriveHelperCompat,
 }
 
+/// Reflects [`rustc_hir::PathSegment`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_hir::PathSegment<'tcx>, state: S as s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2624,6 +2781,7 @@ pub struct PathSegment {
     pub infer_args: bool,
 }
 
+/// Reflects [`rustc_hir::ItemKind`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::ItemKind<'tcx>, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2665,6 +2823,7 @@ pub enum ItemKind<Body: IsBody> {
 
 pub type EnumDef<Body> = Vec<Variant<Body>>;
 
+/// Reflects [`rustc_hir::TraitItemKind`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::TraitItemKind<'tcx>, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2675,12 +2834,14 @@ pub enum TraitItemKind<Body: IsBody> {
             TraitItemKind::RequiredFn(sig.sinto(tcx), id.sinto(tcx))
         }
     )]
+    /// Reflects a required [`rustc_hir::TraitItemKind::Fn`]
     RequiredFn(FnSig, Vec<Ident>),
     #[custom_arm(
         rustc_hir::TraitItemKind::Fn(sig, rustc_hir::TraitFn::Provided(body)) => {
             TraitItemKind::ProvidedFn(sig.sinto(tcx), make_fn_def::<Body, _>(sig, body, tcx))
         }
     )]
+    /// Reflects a provided [`rustc_hir::TraitItemKind::Fn`]
     ProvidedFn(FnSig, FnDef<Body>),
     #[custom_arm(
         rustc_hir::TraitItemKind::Type(b, ty) => {
@@ -2690,6 +2851,7 @@ pub enum TraitItemKind<Body: IsBody> {
     Type(GenericBounds, Option<Ty>),
 }
 
+/// Reflects [`rustc_hir::TraitItem`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::TraitItem<'tcx>, state: S as s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2701,6 +2863,7 @@ pub struct TraitItem<Body: IsBody> {
     pub span: Span,
     pub defaultness: Defaultness,
     #[value(ItemAttributes::from_owner_id(s, *owner_id))]
+    /// The attributes on this trait item
     pub attributes: ItemAttributes,
 }
 
@@ -2733,6 +2896,7 @@ impl<'a, 'tcx, S: UnderOwnerState<'tcx>, Body: IsBody> SInto<S, Vec<Item<Body>>>
     }
 }
 
+/// Reflects [`rustc_hir::ForeignItemKind`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::ForeignItemKind<'tcx>, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2742,6 +2906,7 @@ pub enum ForeignItemKind<Body: IsBody> {
     Type,
 }
 
+/// Reflects [`rustc_hir::ForeignItem`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::ForeignItem<'tcx>, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2762,6 +2927,7 @@ impl<'a, S: UnderOwnerState<'a>, Body: IsBody> SInto<S, ForeignItem<Body>>
     }
 }
 
+/// Reflects [`rustc_hir::OpaqueTy`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::OpaqueTy<'tcx>, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2772,6 +2938,7 @@ pub struct OpaqueTy<Body: IsBody> {
     pub in_trait: bool,
 }
 
+/// Reflects [`rustc_hir::LifetimeName`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_hir::LifetimeName, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2783,6 +2950,7 @@ pub enum LifetimeName {
     Static,
 }
 
+/// Reflects [`rustc_hir::Lifetime`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_hir::Lifetime, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -2792,6 +2960,7 @@ pub struct Lifetime {
     pub res: LifetimeName,
 }
 
+/// Reflects [`rustc_middle::ty::TraitRef`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::TraitRef<'tcx>, state: S as tcx)]
 #[derive(
@@ -2800,9 +2969,11 @@ pub struct Lifetime {
 pub struct TraitRef {
     pub def_id: DefId,
     #[from(substs)]
+    /// reflects the `substs` field
     pub generic_args: Vec<GenericArg>,
 }
 
+/// Reflects [`rustc_middle::ty::TraitPredicate`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::TraitPredicate<'tcx>, state: S as tcx)]
 #[derive(
@@ -2818,6 +2989,10 @@ pub struct TraitPredicate {
     pub is_positive: bool,
 }
 
+/// Reflects [`rustc_middle::ty::OutlivesPredicate`] as a named struct
+/// instead of a tuple struct. This is because the script converting
+/// JSONSchema types to OCaml doesn't support tuple structs, and this
+/// is the only tuple struct in the whole AST.
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -2840,9 +3015,12 @@ where
     }
 }
 
+/// Reflects [`rustc_middle::ty::RegionOutlivesPredicate`]
 pub type RegionOutlivesPredicate = OutlivesPredicate<Region, Region>;
+/// Reflects [`rustc_middle::ty::TypeOutlivesPredicate`]
 pub type TypeOutlivesPredicate = OutlivesPredicate<Ty, Region>;
 
+/// Reflects [`rustc_middle::ty::Term`]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -2861,6 +3039,7 @@ impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, Term> for rustc_middle::ty::Term<'
     }
 }
 
+/// Reflects [`rustc_middle::ty::ProjectionPredicate`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::ProjectionPredicate<'tcx>, state: S as tcx)]
 #[derive(
@@ -2871,6 +3050,7 @@ pub struct ProjectionPredicate {
     pub term: Term,
 }
 
+/// Reflects [`rustc_middle::ty::Clause`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::Clause<'tcx>, state: S as tcx)]
 #[derive(
@@ -2884,6 +3064,7 @@ pub enum ClauseKind {
     ConstArgHasType(ConstantExpr, Ty),
 }
 
+/// Reflects [`rustc_middle::ty::Clause`]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -2902,6 +3083,7 @@ impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, Clause> for rustc_middle::ty::Clau
     }
 }
 
+/// Reflects [`rustc_middle::ty::BoundVariableKind`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::BoundVariableKind, state: S as tcx)]
 #[derive(
@@ -2913,6 +3095,7 @@ pub enum BoundVariableKind {
     Const,
 }
 
+/// Reflects [`rustc_middle::ty::Binder`]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -2921,6 +3104,7 @@ pub struct Binder<T> {
     pub bound_vars: Vec<BoundVariableKind>,
 }
 
+/// Reflects [`rustc_middle::ty::GenericPredicates`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::GenericPredicates<'tcx>, state: S as tcx)]
 #[derive(
@@ -2931,6 +3115,7 @@ pub struct GenericPredicates {
     pub predicates: Vec<(Predicate, Span)>,
 }
 
+/// Reflects [`rustc_middle::ty::Predicate`]
 pub type Predicate = Binder<PredicateKind>;
 
 impl<'tcx, S: UnderOwnerState<'tcx>, T1, T2> SInto<S, Binder<T2>>
@@ -2951,6 +3136,7 @@ impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, Predicate> for rustc_middle::ty::P
     }
 }
 
+/// Reflects [`rustc_middle::ty::SubtypePredicate`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::SubtypePredicate<'tcx>, state: S as tcx)]
 #[derive(
@@ -2962,6 +3148,7 @@ pub struct SubtypePredicate {
     pub b: Ty,
 }
 
+/// Reflects [`rustc_middle::ty::CoercePredicate`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::CoercePredicate<'tcx>, state: S as tcx)]
 #[derive(
@@ -2972,6 +3159,7 @@ pub struct CoercePredicate {
     pub b: Ty,
 }
 
+/// Reflects [`rustc_middle::ty::AliasRelationDirection`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::AliasRelationDirection, state: S as _tcx)]
 #[derive(
@@ -2982,6 +3170,7 @@ pub enum AliasRelationDirection {
     Subtype,
 }
 
+/// Reflects [`rustc_middle::ty::ClosureKind`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::ClosureKind, state: S as _tcx)]
 #[derive(
@@ -2993,6 +3182,7 @@ pub enum ClosureKind {
     FnOnce,
 }
 
+/// Reflects [`rustc_middle::ty::PredicateKind`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::PredicateKind<'tcx>, state: S as tcx)]
 #[derive(
@@ -3012,8 +3202,10 @@ pub enum PredicateKind {
     AliasRelate(Term, Term, AliasRelationDirection),
 }
 
+/// Reflects [`rustc_hir::GenericBounds`]
 type GenericBounds = Vec<PredicateKind>;
 
+/// Compute the bounds for the owner registed in the state `s`
 fn region_bounds_at_current_owner<'tcx, S: UnderOwnerState<'tcx>>(s: &S) -> GenericBounds {
     let tcx = s.base().tcx;
 
@@ -3062,6 +3254,7 @@ impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, GenericBounds> for rustc_hir::Gene
     }
 }
 
+/// Reflects [`rustc_hir::OpaqueTyOrigin`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_hir::OpaqueTyOrigin, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -3071,6 +3264,7 @@ pub enum OpaqueTyOrigin {
     TyAlias { in_assoc_ty: bool },
 }
 
+/// Reflects [`rustc_ast::ast::MacroDef`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: BaseState<'tcx>>, from: rustc_ast::ast::MacroDef, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -3079,6 +3273,7 @@ pub struct MacroDef {
     pub macro_rules: bool,
 }
 
+/// Reflects [`rustc_hir::Item`] (and [`rustc_hir::ItemId`])
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct Item<Body: IsBody> {
     pub def_id: Option<GlobalIdent>,
@@ -3117,6 +3312,7 @@ impl<'tcx, S: BaseState<'tcx>, Body: IsBody> SInto<S, Item<Body>> for rustc_hir:
     }
 }
 
+/// Reflects [`rustc_span::symbol::Ident`]
 pub type Ident = (Symbol, Span);
 
 impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, Ident> for rustc_span::symbol::Ident {
@@ -3125,6 +3321,7 @@ impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, Ident> for rustc_span::symbol::Ide
     }
 }
 
+/// Reflects [`rustc_hir::WhereBoundPredicate`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc_hir::WhereBoundPredicate<'tcx>, state: S as tcx)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -3138,6 +3335,7 @@ pub struct WhereBoundPredicate<Body: IsBody> {
     // pub bounds: GenericBounds,
 }
 
+/// Reflects [`rustc_hir::PredicateOrigin`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_hir::PredicateOrigin, state: S as _s)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -3147,6 +3345,7 @@ pub enum PredicateOrigin {
     ImplTrait,
 }
 
+/// Reflects [`rustc_middle::ty::AssocItem`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::AssocItem, state: S as tcx)]
 #[derive(
@@ -3162,6 +3361,7 @@ pub struct AssocItem {
     pub opt_rpitit_info: Option<ImplTraitInTraitData>,
 }
 
+/// Reflects [`rustc_middle::ty::ImplTraitInTraitData`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::ImplTraitInTraitData, state: S as _tcx)]
 #[derive(
@@ -3177,6 +3377,7 @@ pub enum ImplTraitInTraitData {
     },
 }
 
+/// Reflects [`rustc_middle::ty::AssocItemContainer`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_middle::ty::AssocItemContainer, state: S as _tcx)]
 #[derive(
@@ -3187,6 +3388,7 @@ pub enum AssocItemContainer {
     ImplContainer,
 }
 
+/// Reflects [`rustc_middle::ty::AssocKind`]
 #[derive(AdtInto)]
 #[args(<S>, from: rustc_middle::ty::AssocKind, state: S as _tcx)]
 #[derive(

--- a/frontend/exporter/src/types/index.rs
+++ b/frontend/exporter/src/types/index.rs
@@ -7,3 +7,4 @@ sinto_as_usize!(rustc_middle::ty, BoundVar);
 sinto_as_usize!(rustc_middle::middle::region, FirstStatementIndex);
 sinto_as_usize!(rustc_hir::hir_id, ItemLocalId);
 sinto_as_usize!(rustc_target::abi, VariantIdx);
+sinto_as_usize!(rustc_middle::ty, RegionVid);


### PR DESCRIPTION
This commit adds general documentation to the structs and enums defined in `copied.rs`. When a struct or enum is a direct copy from rustc, the documentation just links the original defintion, otherwise I try to add brief documentation on why there is a difference.