### PR TITLE
feat(nix): add a `hax-env` that injects env vars

### DIFF
--- a/.github/workflows/install_and_test.yml
+++ b/.github/workflows/install_and_test.yml
@@ -75,7 +75,7 @@ jobs:
         CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
       run: |
         nix profile install nixpkgs#cachix nixpkgs#jq
-        nix build --json \
+        nix build .# .#fstar --json \
           | jq -r '.[].outputs | to_entries[].value' \
           | cachix push hax
 

--- a/examples/default.nix
+++ b/examples/default.nix
@@ -5,6 +5,7 @@
   hax,
   fstar,
   hacl-star,
+  hax-env,
 }: let
   commonArgs = {
     version = "0.0.1";
@@ -33,6 +34,7 @@ in
       doCheck = false;
       buildPhaseCargoCommand = ''
         cd examples
+        eval $(hax-env)
         export CACHE_DIR=$(mktemp -d)
         export HINT_DIR=$(mktemp -d)
         export SHELL=${stdenv.shell}
@@ -41,8 +43,5 @@ in
         sed -i "s/make -C limited-order-book/HAX_VANILLA_RUSTC=never make -C limited-order-book/g" Makefile
         make
       '';
-      buildInputs = [hax fstar];
-      HAX_PROOF_LIBS = "${../proof-libs/fstar}";
-      HAX_LIB = "${../hax-lib}";
-      HACL_HOME = "${hacl-star}";
+      buildInputs = [hax hax-env fstar];
     })

--- a/flake.nix
+++ b/flake.nix
@@ -41,10 +41,17 @@
         ocamlformat = pkgs.ocamlformat_0_24_1;
         rustfmt = pkgs.rustfmt;
         fstar = inputs.fstar.packages.${system}.default;
+        hax-env-file = pkgs.writeText "hax-env-file" ''
+          HAX_PROOF_LIBS="${./proof-libs/fstar}"
+          HAX_LIB="${./hax-lib}"
+          HACL_HOME="${hacl-star}"
+        '';
         hax-env = pkgs.writeScriptBin "hax-env" ''
-          echo 'export HAX_PROOF_LIBS="${./proof-libs/fstar}"'
-          echo 'export HAX_LIB="${./hax-lib}"'
-          echo 'export HACL_HOME="${hacl-star}"'
+          if [[ "$1" == "no-export" ]]; then
+            cat "${hax-env-file}"
+          else
+            cat "${hax-env-file}" | xargs -I{} echo "export {}"
+          fi
         '';
       in rec {
         packages = {

--- a/flake.nix
+++ b/flake.nix
@@ -41,9 +41,14 @@
         ocamlformat = pkgs.ocamlformat_0_24_1;
         rustfmt = pkgs.rustfmt;
         fstar = inputs.fstar.packages.${system}.default;
+        hax-env = pkgs.writeScriptBin "hax-env" ''
+          echo 'export HAX_PROOF_LIBS="${./proof-libs/fstar}"'
+          echo 'export HAX_LIB="${./hax-lib}"'
+          echo 'export HACL_HOME="${hacl-star}"'
+        '';
       in rec {
         packages = {
-          inherit rustc ocamlformat rustfmt fstar;
+          inherit rustc ocamlformat rustfmt fstar hax-env;
           hax-engine = pkgs.callPackage ./engine {
             hax-rust-frontend = packages.hax-rust-frontend.unwrapped;
             hax-engine-names-extract = packages.hax-rust-frontend.hax-engine-names-extract;
@@ -64,7 +69,7 @@
           toolchain = packages.hax.tests;
           examples = pkgs.callPackage ./examples {
             inherit (packages) hax;
-            inherit craneLib fstar hacl-star;
+            inherit craneLib fstar hacl-star hax-env;
           };
           readme-coherency = let
             src = pkgs.lib.sourceFilesBySuffices ./. [".md"];
@@ -139,8 +144,8 @@
         in {
           fstar = pkgs.mkShell {
             inherit inputsFrom LIBCLANG_PATH;
-            HACL_HOME = "${hacl-star}";
-            packages = packages ++ [fstar];
+            shellHook = "eval $(hax-env)";
+            packages = packages ++ [fstar hax-env];
           };
           default = pkgs.mkShell {
             inherit packages inputsFrom LIBCLANG_PATH;


### PR DESCRIPTION
This PR adds a `hax-env` binary to Nix that sets the HAX_PROOF_LIBS, HAX_LIB and HACL_HOME.
So that one can run `eval $(nix run github:hacspec/hax#hax-env)`, this will set environment variable directly.

The nice thing is that every dependency (Hacl, F*, Hax's lib) is frozen and given by hax' Nix flake, so dev environments are very very reproductible.