### PR TITLE
fix(engine): translate associated types to `Self` (e.g. `Self::T`)

### DIFF
--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -280,6 +280,9 @@ struct
     | TArray { typ; length } ->
         F.mk_e_app (F.term_of_lid [ "t_Array" ]) [ pty span typ; pexpr length ]
     | TParam i -> F.term @@ F.AST.Var (F.lid_of_id @@ plocal_ident i)
+    | TAssociatedType { impl = Self; item } ->
+        F.term
+        @@ F.AST.Var (F.lid [ U.Concrete_ident_view.to_definition_name item ])
     | TAssociatedType { impl; item } -> (
         match pimpl_expr span impl with
         | Some impl ->

--- a/test-harness/src/snapshots/toolchain__traits into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__traits into-fstar.snap
@@ -18,6 +18,7 @@ info:
       stderr: true
       stdout: true
     include_flag: ~
+    backend_options: ~
 ---
 exit = 0
 stderr = '''
@@ -46,8 +47,8 @@ let impl_2__method
 class t_Lang (v_Self: Type) = {
   [@@@ FStar.Tactics.Typeclasses.no_method]_super_8328838127052049456:Core.Marker.t_Sized v_Self;
   f_Var:Type;
-  f_Var_6601305896307871948:Core.Marker.t_Sized _;
-  f_s:v_Self -> i32 -> (v_Self & _)
+  f_Var_6601305896307871948:Core.Marker.t_Sized f_Var;
+  f_s:v_Self -> i32 -> (v_Self & f_Var)
 }
 
 class t_SuperTrait (v_Self: Type) = {
@@ -63,13 +64,13 @@ let impl_SuperTrait_for_i32: t_SuperTrait i32 =
 
 class t_Foo (v_Self: Type) = {
   f_AssocType:Type;
-  f_AssocType_6857934811705287863:t_SuperTrait _;
-  f_AssocType_1499648403794240798:Core.Clone.t_Clone _;
-  f_AssocType_3786252681321530780:Core.Marker.t_Sized _;
+  f_AssocType_6857934811705287863:t_SuperTrait f_AssocType;
+  f_AssocType_1499648403794240798:Core.Clone.t_Clone f_AssocType;
+  f_AssocType_3786252681321530780:Core.Marker.t_Sized f_AssocType;
   f_N:usize;
   f_assoc_f:Prims.unit -> Prims.unit;
   f_method_f:v_Self -> Prims.unit;
-  f_assoc_type:{| i3: Core.Marker.t_Copy _ |} -> _ -> Prims.unit
+  f_assoc_type:{| i3: Core.Marker.t_Copy f_AssocType |} -> f_AssocType -> Prims.unit
 }
 
 let closure_impl_expr


### PR DESCRIPTION
This commit fixes #536.  The AST of hax has all the information for projected or associated things, but the F* backend doesn't use them much for now. This commit adds support for exactly `Self::WhateverAssociatedType`, but not for more (i.e. parent associated type).