### PR TITLE
feat(engine/phases): drop-references: accept `?`

### DIFF
--- a/engine/lib/phases/phase_drop_references.ml
+++ b/engine/lib/phases/phase_drop_references.ml
@@ -3,8 +3,7 @@ open! Prelude
 module%inlined_contents Make
     (F : Features.T
            with type raw_pointer = Features.Off.raw_pointer
-            and type mutable_reference = Features.Off.mutable_reference
-            and type question_mark = Features.Off.question_mark) =
+            and type mutable_reference = Features.Off.mutable_reference) =
 struct
   open Ast
   module FA = F
@@ -69,7 +68,7 @@ struct
 
     and dexpr' (span : span) (e : A.expr') : B.expr' =
       match (UA.unbox_underef_expr { e; span; typ = UA.never_typ }).e with
-      | [%inline_arms If + Literal + Array + Block] -> auto
+      | [%inline_arms If + Literal + Array + Block + QuestionMark] -> auto
       | Construct { constructor; is_record; is_struct; fields; base } ->
           Construct
             {

--- a/engine/lib/phases/phase_drop_references.mli
+++ b/engine/lib/phases/phase_drop_references.mli
@@ -3,7 +3,6 @@ open! Prelude
 module Make
     (F : Features.T
            with type raw_pointer = Features.Off.raw_pointer
-            and type question_mark = Features.Off.question_mark
             and type mutable_reference = Features.Off.mutable_reference) : sig
   include module type of struct
     module FA = F


### PR DESCRIPTION
The drop references phases constrained the input language to be question mark free, but it did not make any sense 