### PR TITLE
F*: insert `solve ()` in impls parent bound fields

### DIFF
--- a/engine/backends/coq/ssprove/ssprove_backend.ml
+++ b/engine/backends/coq/ssprove/ssprove_backend.ml
@@ -1834,12 +1834,12 @@ struct
                                       body,
                                     ret_typ ));
                              ]
-                         | IIType ty ->
+                         | IIType {typ; _} ->
                              [
                                SSP.AST.LetDef
                                  ( pconcrete_ident x.ii_ident,
                                    [],
-                                   SSP.AST.Type (pty span ty),
+                                   SSP.AST.Type (pty span typ),
                                    SSP.AST.TypeTy );
                              ])
                        items) );

--- a/engine/backends/coq/ssprove/ssprove_backend.ml
+++ b/engine/backends/coq/ssprove/ssprove_backend.ml
@@ -1834,7 +1834,7 @@ struct
                                       body,
                                     ret_typ ));
                              ]
-                         | IIType {typ; _} ->
+                         | IIType { typ; _ } ->
                              [
                                SSP.AST.LetDef
                                  ( pconcrete_ident x.ii_ident,

--- a/engine/backends/fstar/fstar_ast.ml
+++ b/engine/backends/fstar/fstar_ast.ml
@@ -34,10 +34,10 @@ module Attrs = struct
   let no_method = term @@ AST.Var FStar_Parser_Const.no_method_lid
 end
 
+let tcresolve = term @@ AST.Var FStar_Parser_Const.tcresolve_lid
+
 let pat_var_tcresolve (var : string option) =
-  let tcresolve =
-    Some (AST.Meta (term @@ AST.Var FStar_Parser_Const.tcresolve_lid))
-  in
+  let tcresolve = Some (AST.Meta tcresolve) in
   pat
   @@
   match var with
@@ -53,6 +53,16 @@ let mk_e_abs args body =
 let mk_e_app base args =
   AST.mkApp base (List.map ~f:(fun arg -> (arg, AST.Nothing)) args) dummyRange
 
+let unit = term AST.(Const Const_unit)
+
+let tc_solve =
+  let solve =
+    term
+    @@ AST.Var
+         (FStar_Parser_Const.fstar_tactics_lid' [ "Typeclasses"; "solve" ])
+  in
+  mk_e_app solve [ unit ]
+
 let mk_binder ?(aqual : FStar_Parser_AST.arg_qualifier option = Some Implicit) b
     =
   AST.{ b; brange = dummyRange; blevel = Un; aqual; battributes = [] }
@@ -65,8 +75,6 @@ let binder_of_term ?name (t : AST.term) : AST.binder =
     match name with None -> AST.NoName t | Some n -> AST.Annotated (n, t)
   in
   mk_e_binder b
-
-let unit = term AST.(Const Const_unit)
 
 let mk_e_arrow inputs output =
   term @@ AST.Product (List.map ~f:binder_of_term inputs, output)

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -1337,6 +1337,7 @@ module DepGraphR = Dependencies.Make (Features.Rust)
 module TransformToInputLanguage =
   [%functor_application
   Phases.Reject.RawOrMutPointer(Features.Rust)
+  |> Phases.Drop_sized_trait
   |> Phases.And_mut_defsite
   |> Phases.Reconstruct_for_loops
   |> Phases.Reconstruct_while_loops

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -1150,7 +1150,14 @@ struct
         let tcdef = F.AST.TyconRecord (name, bds, None, [], fields) in
         let d = F.AST.Tycon (false, true, [ tcdef ]) in
         [ `Intf { d; drange = F.dummyRange; quals = []; attrs = [] } ]
-    | Impl { generics; self_ty = _; of_trait = trait, generic_args; items } ->
+    | Impl
+        {
+          generics;
+          self_ty = _;
+          of_trait = trait, generic_args;
+          items;
+          parent_bounds;
+        } ->
         let name = U.Concrete_ident_view.to_definition_name e.ident |> F.id in
         let pat = F.pat @@ F.AST.PatVar (name, None, []) in
         let generics = FStarBinder.of_generics e.span generics in
@@ -1165,25 +1172,29 @@ struct
         in
         let pat = F.pat @@ F.AST.PatAscribed (pat, (typ, None)) in
         let fields =
-          List.map
+          List.concat_map
             ~f:(fun { ii_span; ii_generics; ii_v; ii_ident } ->
               let name = U.Concrete_ident_view.to_definition_name ii_ident in
-              ( F.lid [ name ],
-                match ii_v with
-                | IIFn { body; params } ->
-                    let pats =
-                      FStarBinder.(
-                        of_generics ii_span ii_generics
-                        |> List.map ~f:to_pattern)
-                      @ List.map
-                          ~f:(fun { pat; typ_span; typ } ->
-                            let span = Option.value ~default:ii_span typ_span in
-                            F.pat
-                            @@ F.AST.PatAscribed (ppat pat, (pty span typ, None)))
-                          params
-                    in
-                    F.mk_e_abs pats (pexpr body)
-                | IIType {typ; _} -> pty ii_span typ ))
+
+              match ii_v with
+              | IIFn { body; params } ->
+                  let pats =
+                    FStarBinder.(
+                      of_generics ii_span ii_generics |> List.map ~f:to_pattern)
+                    @ List.map
+                        ~f:(fun { pat; typ_span; typ } ->
+                          let span = Option.value ~default:ii_span typ_span in
+                          F.pat
+                          @@ F.AST.PatAscribed (ppat pat, (pty span typ, None)))
+                        params
+                  in
+                  [ (F.lid [ name ], F.mk_e_abs pats (pexpr body)) ]
+              | IIType { typ; parent_bounds } ->
+                  (F.lid [ name ], pty ii_span typ)
+                  :: List.map
+                       ~f:(fun (_impl_expr, impl_ident) ->
+                         (F.lid [ name ^ "_" ^ impl_ident.name ], F.tc_solve))
+                       parent_bounds)
             items
         in
         let fields =
@@ -1191,6 +1202,13 @@ struct
             [ (F.lid [ "__marker_trait" ], pexpr (U.unit_expr e.span)) ]
           else fields
         in
+        let parent_bounds_fields =
+          List.map
+            ~f:(fun (_impl_expr, impl_ident) ->
+              (F.lid [ "_super_" ^ impl_ident.name ], F.tc_solve))
+            parent_bounds
+        in
+        let fields = parent_bounds_fields @ fields in
         let body = F.term @@ F.AST.Record (None, fields) in
         let tcinst = F.term @@ F.AST.Var FStar_Parser_Const.tcinstance_lid in
         F.decls ~fsti:ctx.interface_mode ~attrs:[ tcinst ]

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -1183,7 +1183,7 @@ struct
                           params
                     in
                     F.mk_e_abs pats (pexpr body)
-                | IIType ty -> pty ii_span ty ))
+                | IIType {typ; _} -> pty ii_span typ ))
             items
         in
         let fields =

--- a/engine/lib/ast.ml
+++ b/engine/lib/ast.ml
@@ -372,6 +372,7 @@ functor
           self_ty : ty;
           of_trait : global_ident * generic_value list;
           items : impl_item list;
+          parent_bounds : (impl_expr * impl_ident) list;
         }
       | Alias of { name : concrete_ident; item : concrete_ident }
           (** `Alias {name; item}` is basically a `use

--- a/engine/lib/ast.ml
+++ b/engine/lib/ast.ml
@@ -388,7 +388,7 @@ functor
     and item = { v : item'; span : span; ident : concrete_ident; attrs : attrs }
 
     and impl_item' =
-      | IIType of ty
+      | IIType of { typ : ty; parent_bounds : (impl_expr * impl_ident) list }
       | IIFn of { body : expr; params : param list }
 
     and impl_item = {

--- a/engine/lib/ast_visitors.ml
+++ b/engine/lib/ast_visitors.ml
@@ -644,7 +644,12 @@ functor
               let items =
                 self#visit_list self#visit_impl_item env record_payload.items
               in
-              Impl { generics; self_ty; of_trait; items }
+              let parent_bounds =
+                self#visit_list
+                  (self#visit_tuple2 self#visit_impl_expr self#visit_impl_ident)
+                  env record_payload.parent_bounds
+              in
+              Impl { generics; self_ty; of_trait; items; parent_bounds }
           | Alias record_payload ->
               let name = self#visit_concrete_ident env record_payload.name in
               let item = self#visit_concrete_ident env record_payload.item in
@@ -1746,7 +1751,14 @@ functor
                 self#visit_list self#visit_impl_item env record_payload.items
               in
               let reduce_acc = self#plus reduce_acc reduce_acc' in
-              (Impl { generics; self_ty; of_trait; items }, reduce_acc)
+              let parent_bounds, reduce_acc' =
+                self#visit_list
+                  (self#visit_tuple2 self#visit_impl_expr self#visit_impl_ident)
+                  env record_payload.parent_bounds
+              in
+              let reduce_acc = self#plus reduce_acc reduce_acc' in
+              ( Impl { generics; self_ty; of_trait; items; parent_bounds },
+                reduce_acc )
           | Alias record_payload ->
               let name, reduce_acc =
                 self#visit_concrete_ident env record_payload.name
@@ -2822,6 +2834,12 @@ functor
               let reduce_acc = self#plus reduce_acc reduce_acc' in
               let reduce_acc' =
                 self#visit_list self#visit_impl_item env record_payload.items
+              in
+              let reduce_acc = self#plus reduce_acc reduce_acc' in
+              let reduce_acc' =
+                self#visit_list
+                  (self#visit_tuple2 self#visit_impl_expr self#visit_impl_ident)
+                  env record_payload.parent_bounds
               in
               let reduce_acc = self#plus reduce_acc reduce_acc' in
               reduce_acc

--- a/engine/lib/dependencies.ml
+++ b/engine/lib/dependencies.ml
@@ -54,12 +54,16 @@ module Make (F : Features.T) = struct
         | Trait { name = _; generics; items } ->
             v#visit_generics () generics
             @ concat_map (v#visit_trait_item ()) items
-        | Impl { generics; self_ty; of_trait; items } ->
+        | Impl { generics; self_ty; of_trait; items; parent_bounds } ->
             v#visit_generics () generics
             @ v#visit_ty () self_ty
             @ v#visit_global_ident () (fst of_trait)
             @ concat_map (v#visit_generic_value ()) (snd of_trait)
             @ concat_map (v#visit_impl_item ()) items
+            @ concat_map
+                (fun (ie, ii) ->
+                  v#visit_impl_expr () ie @ v#visit_impl_ident () ii)
+                parent_bounds
         | Alias { name = _; item } -> v#visit_concrete_ident () item
         | Use _ | HaxError _ | NotImplementedYet ->
             Set.empty (module Concrete_ident)

--- a/engine/lib/diagnostics.ml
+++ b/engine/lib/diagnostics.ml
@@ -38,6 +38,7 @@ module Phase = struct
     | TrivializeAssignLhs
     | CfIntoMonads
     | FunctionalizeLoops
+    | TraitsSpecs
     | DummyA
     | DummyB
     | DummyC

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -203,6 +203,8 @@ module type EXPR = sig
   val c_trait_item' : Thir.trait_item -> Thir.trait_item_kind -> trait_item'
   val c_trait_ref : Thir.span -> Thir.trait_ref -> trait_goal
   val c_predicate_kind : Thir.span -> Thir.predicate_kind -> trait_goal option
+  val c_impl_expr : Thir.span -> Thir.impl_expr -> impl_expr
+  val c_clause : Thir.span -> Thir.clause -> impl_ident option
 end
 
 (* BinOp to [core::ops::*] overloaded functions *)
@@ -997,14 +999,17 @@ end) : EXPR = struct
     let attrs = c_attrs param.attributes in
     { ident; span; attrs; kind }
 
-  let c_predicate_kind' span (p : Thir.predicate_kind) : impl_ident option =
-    match p with
-    | Clause
-        { kind = Trait { is_positive = true; is_const = _; trait_ref }; id } ->
+  let c_clause span (p : Thir.clause) : impl_ident option =
+    let ({ kind; id } : Thir.clause) = p in
+    match kind with
+    | Trait { is_positive = true; is_const = _; trait_ref } ->
         let args = List.map ~f:(c_generic_value span) trait_ref.generic_args in
         let trait = Concrete_ident.of_def_id Trait trait_ref.def_id in
         Some { goal = { trait; args }; name = id }
     | _ -> None
+
+  let c_predicate_kind' span (p : Thir.predicate_kind) : impl_ident option =
+    match p with Clause clause -> c_clause span clause | _ -> None
 
   let c_predicate_kind span (p : Thir.predicate_kind) : trait_goal option =
     c_predicate_kind' span p |> Option.map ~f:(fun (x : impl_ident) -> x.goal)
@@ -1304,6 +1309,7 @@ and c_item_unwrapped ~ident (item : Thir.item) : item list =
           self_ty;
           items;
           unsafety = Normal;
+          parent_bounds;
           _;
         } ->
         let items =
@@ -1349,6 +1355,12 @@ and c_item_unwrapped ~ident (item : Thir.item) : item list =
                        ii_attrs = c_item_attrs item.attributes;
                      })
                    items;
+               parent_bounds =
+                 List.filter_map
+                   ~f:(fun (clause, impl_expr, span) ->
+                     let* trait_goal = c_clause span clause in
+                     Some (c_impl_expr span impl_expr, trait_goal))
+                   parent_bounds;
              }
     | Use ({ span = _; res; segments; rename }, _) ->
         let v =

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -1349,8 +1349,18 @@ and c_item_unwrapped ~ident (item : Thir.item) : item list =
                                }
                          | Const (_ty, e) ->
                              IIFn { body = c_expr e; params = [] }
-                         | Type { ty; parent_bounds = _ } ->
-                             IIType (c_ty item.span ty));
+                         | Type { ty; parent_bounds } ->
+                             IIType
+                               {
+                                 typ = c_ty item.span ty;
+                                 parent_bounds =
+                                   List.filter_map
+                                     ~f:(fun (clause, impl_expr, span) ->
+                                       let* trait_goal = c_clause span clause in
+                                       Some
+                                         (c_impl_expr span impl_expr, trait_goal))
+                                     parent_bounds;
+                               });
                        ii_ident;
                        ii_attrs = c_item_attrs item.attributes;
                      })

--- a/engine/lib/phases.ml
+++ b/engine/lib/phases.ml
@@ -11,3 +11,4 @@ module Functionalize_loops = Phase_functionalize_loops.Make
 module Reject = Phase_reject
 module Local_mutation = Phase_local_mutation.Make
 module Traits_specs = Phase_traits_specs.Make
+module Drop_sized_trait = Phase_drop_sized_trait.Make

--- a/engine/lib/phases/phase_drop_references.ml
+++ b/engine/lib/phases/phase_drop_references.ml
@@ -160,6 +160,7 @@ struct
             self_ty;
             of_trait = of_trait_id, of_trait_generics;
             items;
+            parent_bounds;
           } ->
           B.Impl
             {
@@ -169,6 +170,8 @@ struct
                 ( of_trait_id,
                   List.filter_map ~f:(dgeneric_value span) of_trait_generics );
               items = List.map ~f:dimpl_item items;
+              parent_bounds =
+                List.map ~f:(dimpl_expr span *** dimpl_ident span) parent_bounds;
             }
 
     [%%inline_defs ditems]

--- a/engine/lib/phases/phase_drop_sized_trait.ml
+++ b/engine/lib/phases/phase_drop_sized_trait.ml
@@ -1,0 +1,66 @@
+open! Prelude
+
+module Make (F : Features.T) =
+  Phase_utils.MakeMonomorphicPhase
+    (F)
+    (struct
+      let phase_id = Diagnostics.Phase.TraitsSpecs
+
+      open Ast.Make (F)
+      module U = Ast_utils.Make (F)
+      module Visitors = Ast_visitors.Make (F)
+
+      module Error = Phase_utils.MakeError (struct
+        let ctx = Diagnostics.Context.Phase phase_id
+      end)
+
+      let visitor =
+        let keep (ii : impl_ident) =
+          Concrete_ident.eq_name Core__marker__Sized ii.goal.trait |> not
+        in
+        object
+          inherit [_] Visitors.map as super
+
+          method! visit_generics () generics =
+            let generics = super#visit_generics () generics in
+            {
+              generics with
+              constraints =
+                List.filter
+                  ~f:(function GCType ii -> keep ii | _ -> true)
+                  generics.constraints;
+            }
+
+          method! visit_item' () item' =
+            let item' = super#visit_item' () item' in
+            match item' with
+            | Impl payload ->
+                Impl
+                  {
+                    payload with
+                    parent_bounds =
+                      List.filter ~f:(snd >> keep) payload.parent_bounds;
+                  }
+            | _ -> item'
+
+          method! visit_trait_item' () ti' =
+            let ti' = super#visit_trait_item' () ti' in
+            match ti' with
+            | TIType impl_idents -> TIType (List.filter ~f:keep impl_idents)
+            | _ -> ti'
+
+          method! visit_impl_item' () ii' =
+            let ii' = super#visit_impl_item' () ii' in
+            match ii' with
+            | IIType payload ->
+                IIType
+                  {
+                    payload with
+                    parent_bounds =
+                      List.filter ~f:(snd >> keep) payload.parent_bounds;
+                  }
+            | _ -> ii'
+        end
+
+      let ditems = List.map ~f:(visitor#visit_item ())
+    end)

--- a/engine/lib/phases/phase_drop_sized_trait.mli
+++ b/engine/lib/phases/phase_drop_sized_trait.mli
@@ -1,0 +1,5 @@
+(** This phase remove any occurence to the `core::marker::sized`
+trait. This trait appears a lot, but is generally not very useful in
+our backends. *)
+
+module Make : Phase_utils.UNCONSTRAINTED_MONOMORPHIC_PHASE

--- a/engine/lib/phases/phase_traits_specs.ml
+++ b/engine/lib/phases/phase_traits_specs.ml
@@ -4,7 +4,7 @@ module Make (F : Features.T) =
   Phase_utils.MakeMonomorphicPhase
     (F)
     (struct
-      let phase_id = Diagnostics.Phase.DummyA
+      let phase_id = Diagnostics.Phase.TraitsSpecs
 
       module A = Ast.Make (F)
       module FB = F

--- a/engine/lib/phases/phase_traits_specs.ml
+++ b/engine/lib/phases/phase_traits_specs.ml
@@ -57,7 +57,7 @@ module Make (F : Features.T) =
                   List.concat_map ~f:(fun item -> f item @ [ item ]) items
                 in
                 Trait { name; generics; items }
-            | Impl { generics; self_ty; of_trait; items } ->
+            | Impl { generics; self_ty; of_trait; items; parent_bounds } ->
                 let f (item : impl_item) =
                   let mk kind =
                     let ii_ident = mk_name item.ii_ident kind in
@@ -117,7 +117,7 @@ module Make (F : Features.T) =
                 let items =
                   List.concat_map ~f:(fun item -> f item @ [ item ]) items
                 in
-                Impl { generics; self_ty; of_trait; items }
+                Impl { generics; self_ty; of_trait; items; parent_bounds }
             | v -> v
           in
           { item with v }

--- a/engine/lib/print_rust.ml
+++ b/engine/lib/print_rust.ml
@@ -506,7 +506,7 @@ module Raw = struct
             & !"{"
             & List.map ~f:ptrait_item items |> concat ~sep:!"\n"
             & !"}"
-        | Impl { generics; self_ty; of_trait; items } ->
+        | Impl { generics; self_ty; of_trait; items; parent_bounds = _ } ->
             let trait =
               pglobal_ident e.span (fst of_trait)
               & !"<"

--- a/engine/lib/subtype.ml
+++ b/engine/lib/subtype.ml
@@ -372,7 +372,13 @@ struct
 
     let rec dimpl_item' (span : span) (ii : A.impl_item') : B.impl_item' =
       match ii with
-      | IIType g -> IIType (dty span g)
+      | IIType { typ; parent_bounds } ->
+          IIType
+            {
+              typ = dty span typ;
+              parent_bounds =
+                List.map ~f:(dimpl_expr span *** dimpl_ident span) parent_bounds;
+            }
       | IIFn { body; params } ->
           IIFn { body = dexpr body; params = List.map ~f:(dparam span) params }
 

--- a/engine/lib/subtype.ml
+++ b/engine/lib/subtype.ml
@@ -435,8 +435,14 @@ struct
               generics = dgenerics span generics;
               items = List.map ~f:dtrait_item items;
             }
-      | Impl { generics; self_ty; of_trait = trait_id, trait_generics; items }
-        ->
+      | Impl
+          {
+            generics;
+            self_ty;
+            of_trait = trait_id, trait_generics;
+            items;
+            parent_bounds;
+          } ->
           B.Impl
             {
               generics = dgenerics span generics;
@@ -444,6 +450,8 @@ struct
               of_trait =
                 (trait_id, List.map ~f:(dgeneric_value span) trait_generics);
               items = List.map ~f:dimpl_item items;
+              parent_bounds =
+                List.map ~f:(dimpl_expr span *** dimpl_ident span) parent_bounds;
             }
       | Alias { name; item } -> B.Alias { name; item }
       | Use { path; is_external; rename } -> B.Use { path; is_external; rename }

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -422,6 +422,16 @@ pub fn super_predicate_to_clauses_and_impl_expr<'tcx, S: UnderOwnerState<'tcx>>(
     let impl_trait_ref = tcx
         .impl_trait_ref(impl_did)
         .map(|binder| rustc_middle::ty::Binder::dummy(binder.subst_identity()))?;
+    let original_clause_id = {
+        // We don't want the id of the substituted clause id, but the
+        // original clause id (with, i.e., `Self`)
+        let rustc_middle::ty::PredicateKind::Clause(clause) = pred.kind().skip_binder() else {
+            None?
+        };
+        let s = &with_owner_id(s.base(), (), (), impl_trait_ref.def_id());
+        use rustc_middle::ty::ToPredicate;
+        clause_id_of_predicate(s, clause.clone().to_predicate(s.base().tcx))
+    };
     let pred = pred.subst_supertrait(tcx, &impl_trait_ref);
     // TODO: use `let clause = pred.as_clause()?;` when upgrading rustc
     let rustc_middle::ty::PredicateKind::Clause(clause) = pred.kind().skip_binder() else {
@@ -430,7 +440,9 @@ pub fn super_predicate_to_clauses_and_impl_expr<'tcx, S: UnderOwnerState<'tcx>>(
     let impl_expr = pred
         .to_opt_poly_trait_pred()?
         .impl_expr(s, get_param_env(s));
-    Some((clause.sinto(s), impl_expr, span.sinto(s)))
+    let mut clause: Clause = clause.sinto(s);
+    clause.id = original_clause_id;
+    Some((clause, impl_expr, span.sinto(s)))
 }
 
 /// Crafts a unique identifier for a predicate by hashing it. The hash

--- a/frontend/exporter/src/utils.rs
+++ b/frontend/exporter/src/utils.rs
@@ -26,6 +26,8 @@ mod internal_helpers {
     }
     macro_rules! _span_verb_base {
         ($verb:ident, $s:ident, $span:expr, $message:expr) => {{
+            let backtrace = std::backtrace::Backtrace::capture();
+            eprintln!("{}", backtrace);
             let mut builder = $crate::utils::_verb!($verb, $s.base().tcx.sess, $message);
             if let Some(span) = $span {
                 builder.set_span(span.clone());

--- a/test-harness/src/snapshots/toolchain__attribute-opaque into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__attribute-opaque into-fstar.snap
@@ -37,17 +37,7 @@ module Attribute_opaque
 open Core
 open FStar.Mul
 
-val t_OpaqueEnum
-      (v_X: usize)
-      (#v_T #v_U: Type)
-      {| i0: Core.Marker.t_Sized v_T |}
-      {| i1: Core.Marker.t_Sized v_U |}
-    : Type
+val t_OpaqueEnum (v_X: usize) (#v_T #v_U: Type) : Type
 
-val t_OpaqueStruct
-      (v_X: usize)
-      (#v_T #v_U: Type)
-      {| i0: Core.Marker.t_Sized v_T |}
-      {| i1: Core.Marker.t_Sized v_U |}
-    : Type
+val t_OpaqueStruct (v_X: usize) (#v_T #v_U: Type) : Type
 '''

--- a/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
@@ -44,8 +44,7 @@ let impl__SafeIndex__new (i: usize) : Core.Option.t_Option t_SafeIndex =
   else Core.Option.Option_None <: Core.Option.t_Option t_SafeIndex
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl_1 (#v_T: Type) (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: Core.Marker.t_Sized v_T)
-    : Core.Ops.Index.t_Index (t_Array v_T (sz 10)) t_SafeIndex =
+let impl_1 (#v_T: Type) : Core.Ops.Index.t_Index (t_Array v_T (sz 10)) t_SafeIndex =
   {
     f_Output = v_T;
     f_index_pre = (fun (self: t_Array v_T (sz 10)) (index: t_SafeIndex) -> true);

--- a/test-harness/src/snapshots/toolchain__generics into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__generics into-fstar.snap
@@ -35,12 +35,8 @@ module Generics
 open Core
 open FStar.Mul
 
-let impl__Bar__inherent_impl_generics
-      (#v_T: Type)
-      (v_N: usize)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: Core.Marker.t_Sized v_T)
-      (x: t_Array v_T v_N)
-    : Prims.unit = ()
+let impl__Bar__inherent_impl_generics (#v_T: Type) (v_N: usize) (x: t_Array v_T v_N) : Prims.unit =
+  ()
 
 class t_Foo (v_Self: Type) = {
   f_const_add_pre:v_N: usize -> v_Self -> bool;
@@ -57,11 +53,7 @@ let impl_Foo_for_usize: t_Foo usize =
     f_const_add = fun (v_N: usize) (self: usize) -> self +! v_N
   }
 
-let dup
-      (#v_T: Type)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: Core.Marker.t_Sized v_T)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Core.Clone.t_Clone v_T)
-      (x: v_T)
+let dup (#v_T: Type) (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Core.Clone.t_Clone v_T) (x: v_T)
     : (v_T & v_T) = Core.Clone.f_clone x, Core.Clone.f_clone x <: (v_T & v_T)
 
 let f (v_N x: usize) : usize = (v_N +! v_N <: usize) +! x
@@ -71,7 +63,6 @@ let call_f (_: Prims.unit) : usize = (f (sz 10) (sz 3) <: usize) +! sz 3
 let g
       (v_N: usize)
       (#v_T: Type)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: Core.Marker.t_Sized v_T)
       (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Core.Convert.t_Into v_T (t_Array usize v_N))
       (arr: v_T)
     : usize =
@@ -117,7 +108,6 @@ let foo (v_LEN: usize) (arr: t_Array usize v_LEN) : usize =
 let repeat
       (v_LEN: usize)
       (#v_T: Type)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: Core.Marker.t_Sized v_T)
       (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Core.Marker.t_Copy v_T)
       (x: v_T)
     : t_Array v_T v_LEN = Rust_primitives.Hax.repeat x v_LEN

--- a/test-harness/src/snapshots/toolchain__include-flag into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__include-flag into-fstar.snap
@@ -18,6 +18,7 @@ info:
       stderr: false
       stdout: true
     include_flag: ~
+    backend_options: ~
 ---
 exit = 0
 
@@ -39,11 +40,7 @@ let main_a_b (_: Prims.unit) : Prims.unit = ()
 
 let main_a_c (_: Prims.unit) : Prims.unit = ()
 
-let main_a
-      (#v_T: Type)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: Core.Marker.t_Sized v_T)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: t_Trait v_T)
-      (x: v_T)
+let main_a (#v_T: Type) (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: t_Trait v_T) (x: v_T)
     : Prims.unit =
   let _:Prims.unit = main_a_a () in
   let _:Prims.unit = main_a_b () in

--- a/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
@@ -231,7 +231,7 @@ let j (x: t_Bar) : (t_Bar & u8) =
   let hax_temp_output:u8 = hoist1 +! out in
   x, hax_temp_output <: (t_Bar & u8)
 
-type t_Pair (v_T: Type) {| i0: Core.Marker.t_Sized v_T |} = {
+type t_Pair (v_T: Type) = {
   f_a:v_T;
   f_b:t_Foo
 }

--- a/test-harness/src/snapshots/toolchain__naming into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__naming into-fstar.snap
@@ -121,7 +121,6 @@ let v_INHERENT_CONSTANT: usize = sz 3
 
 let constants
       (#v_T: Type)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: Core.Marker.t_Sized v_T)
       (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: t_FooTrait v_T)
       (_: Prims.unit)
     : usize = f_ASSOCIATED_CONSTANT +! v_INHERENT_CONSTANT
@@ -136,7 +135,7 @@ let ff__g__impl_1__g (self: t_Foo) : usize = sz 1
 
 let reserved_names (v_val v_noeq v_of: u8) : u8 = (v_val +! v_noeq <: u8) +! v_of
 
-type t_Arity1 (v_T: Type) {| i0: Core.Marker.t_Sized v_T |} = | Arity1 : v_T -> t_Arity1 v_T
+type t_Arity1 (v_T: Type) = | Arity1 : v_T -> t_Arity1 v_T
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 let impl_T2_e_for_a_for_Arity1_of_tuple_Foo_u8: t_T2_for_a (t_Arity1 (t_Foo & u8)) =

--- a/test-harness/src/snapshots/toolchain__traits into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__traits into-fstar.snap
@@ -41,17 +41,11 @@ class t_Bar (v_Self: Type) = {
   f_bar:x0: v_Self -> Prims.Pure Prims.unit (f_bar_pre x0) (fun result -> f_bar_post x0 result)
 }
 
-let impl_2__method
-      (#v_T: Type)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: Core.Marker.t_Sized v_T)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: t_Bar v_T)
-      (x: v_T)
+let impl_2__method (#v_T: Type) (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: t_Bar v_T) (x: v_T)
     : Prims.unit = f_bar x
 
 class t_Lang (v_Self: Type) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_8328838127052049456:Core.Marker.t_Sized v_Self;
   f_Var:Type;
-  f_Var_6601305896307871948:Core.Marker.t_Sized f_Var;
   f_s_pre:v_Self -> i32 -> bool;
   f_s_post:v_Self -> i32 -> (v_Self & f_Var) -> bool;
   f_s:x0: v_Self -> x1: i32
@@ -71,6 +65,7 @@ class t_SuperTrait (v_Self: Type) = {
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 let impl_SuperTrait_for_i32: t_SuperTrait i32 =
   {
+    _super_2101570567305961368 = FStar.Tactics.Typeclasses.solve ();
     f_function_of_super_trait_pre = (fun (self: i32) -> true);
     f_function_of_super_trait_post = (fun (self: i32) (out: u32) -> true);
     f_function_of_super_trait = fun (self: i32) -> cast (Core.Num.impl__i32__abs self <: i32) <: u32
@@ -80,7 +75,6 @@ class t_Foo (v_Self: Type) = {
   f_AssocType:Type;
   f_AssocType_6857934811705287863:t_SuperTrait f_AssocType;
   f_AssocType_1499648403794240798:Core.Clone.t_Clone f_AssocType;
-  f_AssocType_3786252681321530780:Core.Marker.t_Sized f_AssocType;
   f_N:usize;
   f_assoc_f_pre:Prims.unit -> bool;
   f_assoc_f_post:Prims.unit -> Prims.unit -> bool;
@@ -98,7 +92,6 @@ class t_Foo (v_Self: Type) = {
 
 let closure_impl_expr
       (#v_I: Type)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: Core.Marker.t_Sized v_I)
       (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Core.Iter.Traits.Iterator.t_Iterator v_I)
       (it: v_I)
     : Alloc.Vec.t_Vec Prims.unit Alloc.Alloc.t_Global =
@@ -108,8 +101,6 @@ let closure_impl_expr
 
 let closure_impl_expr_fngen
       (#v_I #v_F: Type)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: Core.Marker.t_Sized v_I)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: Core.Marker.t_Sized v_F)
       (#[FStar.Tactics.Typeclasses.tcresolve ()] i2: Core.Iter.Traits.Iterator.t_Iterator v_I)
       (#[FStar.Tactics.Typeclasses.tcresolve ()] i3: Core.Ops.Function.t_FnMut v_F Prims.unit)
       (it: v_I)
@@ -119,26 +110,18 @@ let closure_impl_expr_fngen
       <:
       Core.Iter.Adapters.Map.t_Map v_I v_F)
 
-let f
-      (#v_T: Type)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: Core.Marker.t_Sized v_T)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: t_Foo v_T)
-      (x: v_T)
-    : Prims.unit =
+let f (#v_T: Type) (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: t_Foo v_T) (x: v_T) : Prims.unit =
   let _:Prims.unit = f_assoc_f () in
   f_method_f x
 
-let g
-      (#v_T: Type)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: Core.Marker.t_Sized v_T)
-      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: t_Foo v_T)
-      (x: i1.f_AssocType)
+let g (#v_T: Type) (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: t_Foo v_T) (x: i1.f_AssocType)
     : u32 = f_function_of_super_trait x
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 let impl_Foo_for_tuple_: t_Foo Prims.unit =
   {
     f_AssocType = i32;
+    f_AssocType_6857934811705287863 = FStar.Tactics.Typeclasses.solve ();
     f_N = sz 32;
     f_assoc_f = () <: Prims.unit;
     f_method_f_pre = (fun (self: Prims.unit) -> true);


### PR DESCRIPTION
This PR:
 - propagate parent bounds impl expr and trait information from the frontend to the AST;
 - in the F* backend: use this information to populate parent bounds fields;
 - introduces a new phase `drop_sized_trait`, that drops the sized trait (which is useless in our backends but extremely verbose).

As a side effect, this also causes some item reordering: now the dependency analysis takes care of parent bounds.
That causes some reordering in the extraction of Kyber, I will push a PR.