### PR TITLE
Basic rec fstar

### DIFF
--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -787,6 +787,9 @@ struct
              ( NoLetQualifier,
                [ (pat, F.term @@ F.AST.Name (pconcrete_ident item)) ] )
     | Fn { name; generics; body; params } ->
+        let is_rec =
+          Set.mem (U.Reducers.collect_concrete_idents#visit_expr () body) name
+        in
         let name = F.id @@ U.Concrete_ident_view.to_definition_name name in
         let pat = F.pat @@ F.AST.PatVar (name, None, []) in
         let generics = FStarBinder.of_generics e.span generics in
@@ -833,7 +836,9 @@ struct
         in
         let pat = F.pat @@ F.AST.PatAscribed (pat, (ty, None)) in
         let full =
-          F.decl @@ F.AST.TopLevelLet (NoLetQualifier, [ (pat, pexpr body) ])
+          F.decl
+          @@ F.AST.TopLevelLet
+               ((if is_rec then Rec else NoLetQualifier), [ (pat, pexpr body) ])
         in
 
         let intf = F.decl ~fsti:true (F.AST.Val (name, arrow_typ)) in

--- a/test-harness/src/snapshots/toolchain__recursion into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__recursion into-fstar.snap
@@ -1,0 +1,39 @@
+---
+source: test-harness/src/harness.rs
+expression: snapshot
+info:
+  kind:
+    Translate:
+      backend: fstar
+  info:
+    name: recursion
+    manifest: recursion/Cargo.toml
+    description: ~
+  spec:
+    optional: false
+    broken: false
+    issue_id: ~
+    positive: true
+    snapshot:
+      stderr: true
+      stdout: true
+    include_flag: ~
+    backend_options: ~
+---
+exit = 0
+stderr = '''
+Compiling recursion v0.1.0 (WORKSPACE_ROOT/recursion)
+    Finished dev [unoptimized + debuginfo] target(s) in XXs'''
+
+[stdout]
+diagnostics = []
+
+[stdout.files]
+"Recursion.fst" = '''
+module Recursion
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let rec f (n: u8) : u8 = if n =. 0uy then 0uy else n +! (f (n -! 1uy <: u8) <: u8)
+'''

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -29,5 +29,6 @@ members = [
         "proverif-noise",
         "proverif-fn-to-letfun",
         "cli/include-flag",
+        "recursion",
 ]
 resolver = "2"

--- a/tests/recursion/Cargo.toml
+++ b/tests/recursion/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "recursion"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[package.metadata.hax-tests]
+into."fstar" = { }

--- a/tests/recursion/src/lib.rs
+++ b/tests/recursion/src/lib.rs
@@ -1,0 +1,9 @@
+#![allow(dead_code)]
+
+pub fn f(n: u8) -> u8 {
+    if n == 0 {
+        0
+    } else {
+        n + f(n - 1)
+    }
+}


### PR DESCRIPTION
This PR makes the F* backend output a `let rec` for simple recursive functions, not mutual ones.

Supporting mutual recursive functions is trickier because of namespaces, see #44.