### PR TITLE
feat(hax-lib-macros): dependency `schemars`: make optional

### DIFF
--- a/cli/subcommands/Cargo.toml
+++ b/cli/subcommands/Cargo.toml
@@ -48,6 +48,6 @@ hax-frontend-exporter.workspace = true
 hax-diagnostics.workspace = true
 hax-cli-options.workspace = true
 hax-cli-options-engine.workspace = true
-hax-lib-macros-types.workspace = true
+hax-lib-macros-types = {workspace = true, features = ["schemars"]}
 version_check = "0.9"
 toml = "0.8"

--- a/hax-lib-macros/types/Cargo.toml
+++ b/hax-lib-macros/types/Cargo.toml
@@ -11,8 +11,10 @@ readme.workspace = true
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
-schemars.workspace = true
+schemars = {workspace = true, optional = true}
 quote.workspace = true
 proc-macro2.workspace = true
 uuid = { version = "1.5", features = ["v4"] }
 
+[features]
+schemars = ["dep:schemars"]

--- a/hax-lib-macros/types/src/lib.rs
+++ b/hax-lib-macros/types/src/lib.rs
@@ -1,4 +1,3 @@
-use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Each item can be marked with a *u*nique *id*entifier. This is
@@ -15,7 +14,8 @@ use serde::{Deserialize, Serialize};
 /// Morally, we expand `struct Foo { #[refine(x > 3)] x: u32 }` to:
 ///  1. `#[uuid(A_UNIQUE_ID_123)] fn refinement(x: u32) -> bool {x > 3}`;
 ///  2. `struct Foo { #[refined_by(A_UNIQUE_ID_123)] x: u32 }`.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename = "HaUid")]
 pub struct ItemUid {
     /// Currently, this is a UUID.
@@ -31,7 +31,8 @@ impl ItemUid {
 }
 
 /// What shall Hax do with an item?
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename = "HaItemStatus")]
 pub enum ItemStatus {
     /// Include this item in the translation
@@ -43,7 +44,8 @@ pub enum ItemStatus {
     Excluded { modeled_by: Option<String> },
 }
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename = "HaAssocRole")]
 pub enum AssociationRole {
     Requires,
@@ -59,7 +61,8 @@ pub enum AssociationRole {
 /// Hax only understands one attribute: `#[hax::json(PAYLOAD)]` where
 /// `PAYLOAD` is a JSON serialization of an inhabitant of
 /// `AttrPayload`.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(rename = "HaPayload")]
 pub enum AttrPayload {
     ItemStatus(ItemStatus),


### PR DESCRIPTION
This PR makes the schemars dependency optional in the crate `hax-lib-macros`.

Now, `cargo tree` on `hax-lib-macros` gives me:
```
hax-lib-macros v0.1.0-pre.1 (proc-macro) (/home/lucas/repos/hax/main/hax-lib-macros)
├── hax-lib-macros-types v0.1.0-pre.1 (/home/lucas/repos/hax/main/hax-lib-macros/types)
│   ├── proc-macro2 v1.0.69
│   │   └── unicode-ident v1.0.12
│   ├── quote v1.0.33
│   │   └── proc-macro2 v1.0.69 (*)
│   ├── serde v1.0.189
│   │   └── serde_derive v1.0.189 (proc-macro)
│   │       ├── proc-macro2 v1.0.69 (*)
│   │       ├── quote v1.0.33 (*)
│   │       └── syn v2.0.38
│   │           ├── proc-macro2 v1.0.69 (*)
│   │           ├── quote v1.0.33 (*)
│   │           └── unicode-ident v1.0.12
│   ├── serde_json v1.0.107
│   │   ├── itoa v1.0.9
│   │   ├── ryu v1.0.15
│   │   └── serde v1.0.189 (*)
│   └── uuid v1.5.0
│       └── getrandom v0.2.10
│           ├── cfg-if v1.0.0
│           └── libc v0.2.152
├── proc-macro-error v1.0.4
│   ├── proc-macro-error-attr v1.0.4 (proc-macro)
│   │   ├── proc-macro2 v1.0.69 (*)
│   │   └── quote v1.0.33 (*)
│   │   [build-dependencies]
│   │   └── version_check v0.9.4
│   ├── proc-macro2 v1.0.69 (*)
│   ├── quote v1.0.33 (*)
│   └── syn v1.0.109
│       ├── proc-macro2 v1.0.69 (*)
│       └── unicode-ident v1.0.12
│   [build-dependencies]
│   └── version_check v0.9.4
├── proc-macro2 v1.0.69 (*)
├── quote v1.0.33 (*)
└── syn v2.0.38 (*)
```

Wdyt @franziskuskiefer, is that OK? In my opinion such dependencies are not very surprising for a proc-macro.