### PR TITLE
feat(hax-lib): export proc-macros from `hax-lib-macros`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,6 +550,9 @@ dependencies = [
 [[package]]
 name = "hax-lib"
 version = "0.1.0-pre.1"
+dependencies = [
+ "hax-lib-macros",
+]
 
 [[package]]
 name = "hax-lib-macros"

--- a/hax-lib/Cargo.toml
+++ b/hax-lib/Cargo.toml
@@ -12,3 +12,4 @@ description = "Hax-specific helpers for Rust programs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+hax-lib-macros = {path = "../hax-lib-macros"}

--- a/hax-lib/src/lib.rs
+++ b/hax-lib/src/lib.rs
@@ -129,3 +129,5 @@ pub fn exists<T>(_f: impl Fn(T) -> bool) -> bool {
 pub fn implies(lhs: bool, rhs: impl Fn() -> bool) -> bool {
     !lhs || rhs()
 }
+
+pub use hax_lib_macros::*;


### PR DESCRIPTION
This PR just re-exports `hax-lib-macros` in `hax-lib`, so that only one dependency is required.