### PR TITLE
feat: include flag: allow for dropping bodies

### DIFF
--- a/cli/options/src/lib.rs
+++ b/cli/options/src/lib.rs
@@ -145,8 +145,11 @@ pub struct FStarOptions {
     ifuel: u32,
     /// Modules for which Hax should extract interfaces (`*.fsti`
     /// files) in supplement to implementations (`*.fst` files). By
-    /// default we extract no interface, only implementations. This
-    /// flag expects a space-separated list of inclusion clauses. An
+    /// default we extract no interface, only implementations. If a
+    /// item is signature only (see the `+:` prefix of the
+    /// `--include_namespaces` flag of the `into` subcommand), then
+    /// its namespace is extracted with an interface. This flag
+    /// expects a space-separated list of inclusion clauses. An
     /// inclusion clause is a Rust path prefixed with `+`, `+!` or
     /// `-`. `-` means implementation only, `+!` means interface only
     /// and `+` means implementation and interface. Rust path chunks
@@ -198,6 +201,7 @@ enum DepsKind {
 enum InclusionKind {
     /// `+query` include the items selected by `query`
     Included(DepsKind),
+    SignatureOnly,
     Excluded,
 }
 
@@ -215,7 +219,7 @@ fn parse_inclusion_clause(
         Err("Expected `-` or `+`, got an empty string")?
     }
     let (prefix, namespace) = {
-        let f = |&c: &char| matches!(c, '+' | '-' | '~' | '!');
+        let f = |&c: &char| matches!(c, '+' | '-' | '~' | '!' | ':');
         (
             s.chars().take_while(f).into_iter().collect::<String>(),
             s.chars().skip_while(f).into_iter().collect::<String>(),
@@ -225,9 +229,10 @@ fn parse_inclusion_clause(
         "+" => InclusionKind::Included(DepsKind::Transitive),
         "+~" => InclusionKind::Included(DepsKind::Shallow),
         "+!" => InclusionKind::Included(DepsKind::None),
+        "+:" => InclusionKind::SignatureOnly,
         "-" => InclusionKind::Excluded,
         prefix => Err(format!(
-            "Expected `-`, `+~`, `+!` or `-`, got an `{prefix}`"
+            "Expected `+`, `+~`, `+!`, `+:` or `-`, got an `{prefix}`"
         ))?,
     };
     Ok(InclusionClause {
@@ -239,13 +244,15 @@ fn parse_inclusion_clause(
 #[derive(JsonSchema, Parser, Debug, Clone, Serialize, Deserialize)]
 pub struct TranslationOptions {
     /// Space-separated list of inclusion clauses. An inclusion clause
-    /// is a Rust path prefixed with `+`, `+~`, `+!` or `-`. `-`
+    /// is a Rust path prefixed with `+`, `+~`, `+:`, `+!` or `-`. `-`
     /// excludes any matched item, `+` includes any matched item and
     /// their dependencies, `+~` includes any matched item and their
     /// direct dependencies, `+!` includes any matched item strictly
-    /// (without including dependencies). By default, every item is
-    /// included. Rust path chunks can be either a concrete string, or
-    /// a glob (just like bash globs, but with Rust paths).
+    /// (without including dependencies) and `+:` includes only types
+    /// and signatures informations about any matched item. By
+    /// default, every item is included. Rust path chunks can be
+    /// either a concrete string, or a glob (just like bash globs, but
+    /// with Rust paths).
     #[arg(
         value_parser = parse_inclusion_clause,
         value_delimiter = ' ',

--- a/cli/options/src/lib.rs
+++ b/cli/options/src/lib.rs
@@ -257,7 +257,7 @@ pub struct TranslationOptions {
 
     /// By default, hax includes all items. Then, the patterns
     /// prefixed by modifiers are processed from left to right,
-    /// exluding or including items. Ecah pattern selects a number of
+    /// excluding or including items. Each pattern selects a number of
     /// item. The modifiers are:
     ///
     ///  - `+`: includes the selected items with their dependencies,

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -1271,8 +1271,8 @@ let make (module M : Attrs.WITH_ITEMS) ctx =
               let ctx = ctx
             end) : S)
 
-let strings_of_item (bo : BackendOptions.t) m items (item : item) :
-    [> `Impl of string | `Intf of string ] list =
+let strings_of_item ~signature_only (bo : BackendOptions.t) m items
+    (item : item) : [> `Impl of string | `Intf of string ] list =
   let interface_mode' : Types.inclusion_kind =
     List.rev bo.interfaces
     |> List.find ~f:(fun (clause : Types.inclusion_clause) ->
@@ -1289,7 +1289,8 @@ let strings_of_item (bo : BackendOptions.t) m items (item : item) :
     |> Option.value ~default:(Types.Excluded : Types.inclusion_kind)
   in
   let interface_mode =
-    not ([%matches? (Types.Excluded : Types.inclusion_kind)] interface_mode')
+    signature_only
+    || not ([%matches? (Types.Excluded : Types.inclusion_kind)] interface_mode')
   in
   let (module Print) =
     make m
@@ -1301,11 +1302,12 @@ let strings_of_item (bo : BackendOptions.t) m items (item : item) :
   in
   let mk_impl = if interface_mode then fun i -> `Impl i else fun i -> `Impl i in
   let mk_intf = if interface_mode then fun i -> `Intf i else fun i -> `Impl i in
+  let no_impl =
+    signature_only
+    || [%matches? (Types.Included None' : Types.inclusion_kind)] interface_mode'
+  in
   Print.pitem item
-  |> (match interface_mode' with
-     | Types.Included None' ->
-         List.filter ~f:(function `Impl _ -> false | _ -> true)
-     | _ -> Fn.id)
+  |> List.filter ~f:(function `Impl _ when no_impl -> false | _ -> true)
   |> List.concat_map ~f:(function
        | `Impl i -> [ mk_impl (decl_to_string i) ]
        | `Intf i -> [ mk_intf (decl_to_string i) ]
@@ -1313,9 +1315,10 @@ let strings_of_item (bo : BackendOptions.t) m items (item : item) :
            let s = "(* " ^ s ^ " *)" in
            if interface_mode then [ `Impl s; `Intf s ] else [ `Impl s ])
 
-let string_of_items (bo : BackendOptions.t) m items : string * string =
+let string_of_items ~signature_only (bo : BackendOptions.t) m items :
+    string * string =
   let strings =
-    List.concat_map ~f:(strings_of_item bo m items) items
+    List.concat_map ~f:(strings_of_item ~signature_only bo m items) items
     |> List.map ~f:(function
          | `Impl s -> `Impl (String.strip s)
          | `Intf s -> `Intf (String.strip s))
@@ -1343,13 +1346,23 @@ let translate m (bo : BackendOptions.t) (items : AST.item list) :
   U.group_items_by_namespace items
   |> Map.to_alist
   |> List.concat_map ~f:(fun (ns, items) ->
+         let signature_only =
+           let is_dropped_body =
+             Concrete_ident.eq_name Rust_primitives__hax__dropped_body
+           in
+           let contains_dropped_body =
+             U.Reducers.collect_concrete_idents#visit_item ()
+             >> Set.exists ~f:is_dropped_body
+           in
+           List.exists ~f:contains_dropped_body items
+         in
          let mod_name =
            String.concat ~sep:"."
              (List.map
                 ~f:(map_first_letter String.uppercase)
                 (fst ns :: snd ns))
          in
-         let impl, intf = string_of_items bo m items in
+         let impl, intf = string_of_items ~signature_only bo m items in
          let make ~ext body =
            if String.is_empty body then None
            else

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -902,8 +902,8 @@ struct
                  AttributeRejected
                    {
                      reason =
-                       "a type cannot be opaque if it's module is not \
-                        extracted as an interface";
+                       "a type cannot be opaque if its module is not extracted \
+                        as an interface";
                    };
                span = e.span;
              }

--- a/engine/lib/dependencies.ml
+++ b/engine/lib/dependencies.ml
@@ -249,6 +249,7 @@ module Make (F : Features.T) = struct
     let show_inclusion_clause Types.{ kind; namespace } =
       (match kind with
       | Excluded -> "-"
+      | SignatureOnly -> "+:"
       | Included deps_kind -> (
           match deps_kind with
           | Transitive -> "+"
@@ -270,6 +271,7 @@ module Make (F : Features.T) = struct
         | Included Transitive -> (true, false)
         | Included Shallow -> (true, true)
         | Included None' -> (false, false)
+        | SignatureOnly -> (false, true)
         | Excluded -> (false, false)
       in
       let matched = matched0 |> if with_deps then deps_of else Fn.id in
@@ -282,7 +284,9 @@ module Make (F : Features.T) = struct
             (match clause.kind with Excluded -> "remove" | _ -> "add")
           @@ show_ident_set matched);
       let set_op =
-        match clause.kind with Included _ -> Set.union | Excluded -> Set.diff
+        match clause.kind with
+        | Included _ | SignatureOnly -> Set.union
+        | Excluded -> Set.diff
       in
       let result = set_op selection' matched in
       result

--- a/engine/lib/import_thir.mli
+++ b/engine/lib/import_thir.mli
@@ -5,5 +5,6 @@ val import_predicate_kind :
   Types.span -> Types.predicate_kind -> Ast.Rust.trait_goal option
 
 val import_item :
+  drop_body:bool ->
   Types.item_for__decorated_for__expr_kind ->
   Concrete_ident.t * (Ast.Rust.item list * Diagnostics.t list)

--- a/engine/names/src/lib.rs
+++ b/engine/names/src/lib.rs
@@ -144,6 +144,10 @@ mod hax {
     fn array_of_list() {}
     fn never_to_any() {}
 
+    /// The engine uses this `dropped_body` symbol as a marker value
+    /// to signal that a item was extracted without body.
+    fn dropped_body() {}
+
     mod control_flow_monad {
         trait ControlFlowMonad {
             fn lift() {}

--- a/hax-lib-macros/src/lib.rs
+++ b/hax-lib-macros/src/lib.rs
@@ -145,7 +145,8 @@ pub fn lemma(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
             );
         }
     }
-    quote! { #attr #item }.into()
+    use AttrPayload::NeverDropBody;
+    quote! { #attr #NeverDropBody #item }.into()
 }
 
 /*

--- a/hax-lib-macros/src/utils.rs
+++ b/hax-lib-macros/src/utils.rs
@@ -187,6 +187,7 @@ pub fn make_fn_decoration(
         } else {
             quote! {}
         };
+        use AttrPayload::NeverDropBody;
         quote! {
             #[cfg(#DebugOrHaxCfgExpr)]
             #late_skip
@@ -197,6 +198,7 @@ pub fn make_fn_decoration(
                 #uid_attr
                 #late_skip
                 #[allow(unused)]
+                #NeverDropBody
                 #decoration_sig {
                     #phi
                 }

--- a/hax-lib-macros/types/src/lib.rs
+++ b/hax-lib-macros/types/src/lib.rs
@@ -71,6 +71,10 @@ pub enum AttrPayload {
         item: ItemUid,
     },
     Uid(ItemUid),
+    /// Mark an item so that hax never drop its body (this is useful
+    /// for pre- and post- conditions of a function we dropped the
+    /// body of: pre and post are part of type signature)
+    NeverDropBody,
     /// Mark an item as a lemma statement to prove in the backend
     Lemma,
     Language,

--- a/test-harness/src/snapshots/toolchain__interface-only into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__interface-only into-fstar.snap
@@ -42,4 +42,24 @@ val f (x: u8)
         fun r ->
           let r:t_Array u8 (sz 4) = r in
           (r.[ sz 0 ] <: u8) >. x)
+
+type t_Bar = | Bar : t_Bar
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl: Core.Convert.t_From t_Bar Prims.unit =
+  {
+    f_from_pre = (fun ((): Prims.unit) -> true);
+    f_from_post = (fun ((): Prims.unit) (out: t_Bar) -> true);
+    f_from = fun ((): Prims.unit) -> Bar <: t_Bar
+  }
+
+val from__from: u8 -> Prims.Pure t_Bar Prims.l_True (fun _ -> Prims.l_True)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_1: Core.Convert.t_From t_Bar u8 =
+  {
+    f_from_pre = (fun (x: u8) -> true);
+    f_from_post = (fun (x: u8) (out: t_Bar) -> true);
+    f_from = fun (x: u8) -> from__from x
+  }
 '''

--- a/test-harness/src/snapshots/toolchain__interface-only into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__interface-only into-fstar.snap
@@ -35,5 +35,11 @@ module Interface_only
 open Core
 open FStar.Mul
 
-val f (x: u8) : Prims.Pure Prims.unit Prims.l_True (fun _ -> Prims.l_True)
+val f (x: u8)
+    : Prims.Pure (t_Array u8 (sz 4))
+      (requires x <. 254uy)
+      (ensures
+        fun r ->
+          let r:t_Array u8 (sz 4) = r in
+          (r.[ sz 0 ] <: u8) >. x)
 '''

--- a/test-harness/src/snapshots/toolchain__interface-only into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__interface-only into-fstar.snap
@@ -1,0 +1,39 @@
+---
+source: test-harness/src/harness.rs
+expression: snapshot
+info:
+  kind:
+    Translate:
+      backend: fstar
+  info:
+    name: interface-only
+    manifest: cli/interface-only/Cargo.toml
+    description: ~
+  spec:
+    optional: false
+    broken: false
+    issue_id: ~
+    positive: true
+    snapshot:
+      stderr: true
+      stdout: true
+    include_flag: "+:** -interface_only::Foo"
+    backend_options: ~
+---
+exit = 0
+stderr = '''
+Compiling interface-only v0.1.0 (WORKSPACE_ROOT/cli/interface-only)
+    Finished dev [unoptimized + debuginfo] target(s) in XXs'''
+
+[stdout]
+diagnostics = []
+
+[stdout.files]
+"Interface_only.fsti" = '''
+module Interface_only
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+val f (x: u8) : Prims.Pure Prims.unit Prims.l_True (fun _ -> Prims.l_True)
+'''

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -365,6 +365,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "interface-only"
+version = "0.1.0"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -367,6 +367,10 @@ dependencies = [
 [[package]]
 name = "interface-only"
 version = "0.1.0"
+dependencies = [
+ "hax-lib",
+ "hax-lib-macros",
+]
 
 [[package]]
 name = "itertools"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -29,6 +29,7 @@ members = [
         "proverif-noise",
         "proverif-fn-to-letfun",
         "cli/include-flag",
+        "cli/interface-only",
         "recursion",
 ]
 resolver = "2"

--- a/tests/cli/interface-only/Cargo.toml
+++ b/tests/cli/interface-only/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+hax-lib-macros = { path = "../../../hax-lib-macros" }
+hax-lib = { path = "../../../hax-lib" }
 
 [package.metadata.hax-tests]
 into."fstar" = { include-flag = "+:** -interface_only::Foo" }

--- a/tests/cli/interface-only/Cargo.toml
+++ b/tests/cli/interface-only/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "interface-only"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[package.metadata.hax-tests]
+into."fstar" = { include-flag = "+:** -interface_only::Foo" }

--- a/tests/cli/interface-only/src/lib.rs
+++ b/tests/cli/interface-only/src/lib.rs
@@ -26,3 +26,24 @@ fn f(x: u8) -> [u8; 4] {
 struct Foo {
     unsupported_field: *const u8,
 }
+
+struct Bar;
+
+/// Non-inherent implementations are extracted, their bodies are not
+/// dropped. This might be a bit surprising: see
+/// https://github.com/hacspec/hax/issues/616.
+impl From<()> for Bar {
+    fn from((): ()) -> Self {
+        Bar
+    }
+}
+
+/// If you need to drop the body of a method, please hoist it:
+impl From<u8> for Bar {
+    fn from(x: u8) -> Self {
+        fn from(_: u8) -> Bar {
+            Bar
+        }
+        from(x)
+    }
+}

--- a/tests/cli/interface-only/src/lib.rs
+++ b/tests/cli/interface-only/src/lib.rs
@@ -1,0 +1,19 @@
+#![allow(dead_code)]
+
+/// This item contains unsafe blocks and raw references, two features
+/// not supported by hax. Thanks to the `-i` flag and the `+:`
+/// modifier, `f` is still extractable as an interface.
+fn f(x: u8) {
+    let y = x as *const i8;
+
+    unsafe {
+        println!("{}", *y);
+    }
+}
+
+/// This struct contains a field which uses raw pointers, which are
+/// not supported by hax. This item cannot be extracted at all: we
+/// need to exclude it with `-i '-*::Foo'`.
+struct Foo {
+    unsupported_field: *const u8,
+}

--- a/tests/cli/interface-only/src/lib.rs
+++ b/tests/cli/interface-only/src/lib.rs
@@ -1,14 +1,23 @@
 #![allow(dead_code)]
 
+use hax_lib as hax;
+
 /// This item contains unsafe blocks and raw references, two features
 /// not supported by hax. Thanks to the `-i` flag and the `+:`
 /// modifier, `f` is still extractable as an interface.
-fn f(x: u8) {
+///
+/// Expressions within type are still extracted, as well as pre- and
+/// post-conditions.
+#[hax::requires(x < 254)]
+#[hax::ensures(|r| r[0] > x)]
+fn f(x: u8) -> [u8; 4] {
     let y = x as *const i8;
 
     unsafe {
         println!("{}", *y);
     }
+
+    [x + 1, x, x, x]
 }
 
 /// This struct contains a field which uses raw pointers, which are


### PR DESCRIPTION
This PR adds the `+:` modifier to inclusion clauses. `-i '... +:some::glob::pattern'` will extract signature-only for the items matched by `some::glob::pattern`.

I added some doc in the book, see https://github.com/hacspec/book/pull/15