### PR TITLE
fix(fstar): `Typeclasses.solve` takes no argument

### DIFF
--- a/engine/backends/fstar/fstar_ast.ml
+++ b/engine/backends/fstar/fstar_ast.ml
@@ -56,12 +56,8 @@ let mk_e_app base args =
 let unit = term AST.(Const Const_unit)
 
 let tc_solve =
-  let solve =
-    term
-    @@ AST.Var
-         (FStar_Parser_Const.fstar_tactics_lid' [ "Typeclasses"; "solve" ])
-  in
-  mk_e_app solve [ unit ]
+  term
+  @@ AST.Var (FStar_Parser_Const.fstar_tactics_lid' [ "Typeclasses"; "solve" ])
 
 let mk_binder ?(aqual : FStar_Parser_AST.arg_qualifier option = Some Implicit) b
     =

--- a/test-harness/src/snapshots/toolchain__traits into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__traits into-fstar.snap
@@ -65,7 +65,7 @@ class t_SuperTrait (v_Self: Type) = {
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 let impl_SuperTrait_for_i32: t_SuperTrait i32 =
   {
-    _super_2101570567305961368 = FStar.Tactics.Typeclasses.solve ();
+    _super_2101570567305961368 = FStar.Tactics.Typeclasses.solve;
     f_function_of_super_trait_pre = (fun (self: i32) -> true);
     f_function_of_super_trait_post = (fun (self: i32) (out: u32) -> true);
     f_function_of_super_trait = fun (self: i32) -> cast (Core.Num.impl__i32__abs self <: i32) <: u32
@@ -121,7 +121,7 @@ let g (#v_T: Type) (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: t_Foo v_T) (x:
 let impl_Foo_for_tuple_: t_Foo Prims.unit =
   {
     f_AssocType = i32;
-    f_AssocType_886671949818196346 = FStar.Tactics.Typeclasses.solve ();
+    f_AssocType_886671949818196346 = FStar.Tactics.Typeclasses.solve;
     f_N = sz 32;
     f_assoc_f = () <: Prims.unit;
     f_method_f_pre = (fun (self: Prims.unit) -> true);


### PR DESCRIPTION
The F* backend used to generate calls `solve ()`, instead we need `solve` with no argument at all.
This PR does this change.