### PR TITLE
fix(test-harness): `hax-engine-names-extract` needs hax in PATH

### DIFF
--- a/engine/names/extract/build.rs
+++ b/engine/names/extract/build.rs
@@ -123,7 +123,8 @@ fn target_dir(suffix: &str) -> camino::Utf8PathBuf {
 }
 
 fn get_json() -> String {
-    let mut cmd = Command::new("cargo-hax");
+    let mut cmd =
+        Command::new(std::env::var("HAX_CARGO_COMMAND_PATH").unwrap_or("cargo-hax".to_string()));
     cmd.args([
         "hax",
         "-C",


### PR DESCRIPTION
This commit fixes the test harness: since
https://github.com/hacspec/hax/pull/428, the test harness silently assumes hax is in PATH while building the crate
`hax-engine-names-extract`.

This crate `hax-engine-names-extract` is used at build time by the engine to list and import the Rust names we rely on.

`hax-engine-names-extract` itself requires the Rust part of hax at build time.

This PR fixes the test harness so that:
 1. it asks cargo to build `cargo-hax` and the driver
 2. it looks for the path of `cargo-hax` & driver just built (somewhere local in `target/bin/something/someting`), injects thoses paths as env vars in a `cargo build --bin hax-engine-names-extract`;
 3. it compiles the engine with the three paths mentioned above (which are required by the engine at compile time);
 4. it runs full hax (frontend + engine) on the actual tests;
 5. compare with snapshots.

Tagging @Nadrieril who found that bug, thanks!