### PR TITLE
Add support for math integers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,6 +553,8 @@ name = "hax-lib"
 version = "0.1.0-pre.1"
 dependencies = [
  "hax-lib-macros",
+ "num-bigint",
+ "num-traits",
 ]
 
 [[package]]
@@ -880,6 +882,35 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,4 +87,5 @@ hax-diagnostics = { path = "frontend/diagnostics", version = "=0.1.0-pre.1" }
 hax-lint = { path = "frontend/lint", version = "=0.1.0-pre.1" }
 hax-phase-debug-webapp = { path = "engine/utils/phase-debug-webapp", version = "=0.1.0-pre.1" }
 hax-lib-macros-types = { path = "hax-lib-macros/types", version = "=0.1.0-pre.1" }
+hax-lib-macros = { path = "hax-lib-macros", version = "=0.1.0-pre.1" }
 hax-engine-names = { path = "engine/names", version = "=0.1.0-pre.1" }

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -253,6 +253,17 @@ struct
       (c Core__cmp__PartialOrd__gt, (2, ">."));
       (`Primitive (LogicalOp And), (2, "&&"));
       (`Primitive (LogicalOp Or), (2, "||"));
+      (c Rust_primitives__hax__int__add, (2, "+"));
+      (c Rust_primitives__hax__int__sub, (2, "-"));
+      (c Rust_primitives__hax__int__mul, (2, "*"));
+      (c Rust_primitives__hax__int__div, (2, "/"));
+      (c Rust_primitives__hax__int__rem, (2, "%"));
+      (c Rust_primitives__hax__int__ge, (2, ">="));
+      (c Rust_primitives__hax__int__le, (2, "<="));
+      (c Rust_primitives__hax__int__gt, (2, ">"));
+      (c Rust_primitives__hax__int__lt, (2, "<"));
+      (c Rust_primitives__hax__int__ne, (2, "<>"));
+      (c Rust_primitives__hax__int__eq, (2, "="));
     ]
     |> Map.of_alist_exn (module Global_ident)
 

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -1504,6 +1504,7 @@ module TransformToInputLanguage =
   [%functor_application
   Phases.Reject.RawOrMutPointer(Features.Rust)
   |> Phases.Transform_hax_lib_inline
+  |> Phases.Specialize
   |> Phases.Drop_sized_trait
   |> Phases.Simplify_question_marks
   |> Phases.And_mut_defsite

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -421,6 +421,24 @@ struct
           Error.assertion_failure e.span
             "pexpr: bad arity for operator application";
         F.term @@ F.AST.Op (F.Ident.id_of_text op, List.map ~f:pexpr args)
+    | App
+        {
+          f = { e = GlobalVar f; _ };
+          args = [ { e = Literal (String s); _ } ];
+          generic_args;
+        }
+      when Global_ident.eq_name Hax_lib__int__Impl_4___unsafe_from_str f ->
+        (match
+           String.chop_prefix ~prefix:"-" s
+           |> Option.value ~default:s
+           |> String.filter ~f:([%matches? '0' .. '9'] >> not)
+         with
+        | "" -> ()
+        | s ->
+            Error.assertion_failure e.span
+            @@ "pexpr: expected a integer, found the following non-digit \
+                chars: '" ^ s ^ "'");
+        F.AST.Const (F.Const.Const_int (s, None)) |> F.term
     | App { f; args; generic_args } ->
         let const_generics =
           List.filter_map

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -438,7 +438,7 @@ struct
           args = [ { e = Literal (String s); _ } ];
           generic_args;
         }
-      when Global_ident.eq_name Hax_lib__int__Impl_4___unsafe_from_str f ->
+      when Global_ident.eq_name Hax_lib__int__Impl_5___unsafe_from_str f ->
         (match
            String.chop_prefix ~prefix:"-" s
            |> Option.value ~default:s

--- a/engine/lib/diagnostics.ml
+++ b/engine/lib/diagnostics.ml
@@ -35,6 +35,7 @@ module Phase = struct
     | ResugarForIndexLoops
     | ResugarQuestionMarks
     | SimplifyQuestionMarks
+    | Specialize
     | HoistSideEffects
     | LocalMutation
     | TrivializeAssignLhs

--- a/engine/lib/phases/phase_specialize.ml
+++ b/engine/lib/phases/phase_specialize.ml
@@ -1,0 +1,165 @@
+open! Prelude
+
+module Make (F : Features.T) =
+  Phase_utils.MakeMonomorphicPhase
+    (F)
+    (struct
+      let phase_id = Diagnostics.Phase.Specialize
+
+      module A = Ast.Make (F)
+      module FB = F
+      module B = Ast.Make (F)
+      module U = Ast_utils.Make (F)
+      module Visitors = Ast_visitors.Make (F)
+      open A
+
+      open struct
+        open Concrete_ident_generated
+
+        type pattern = {
+          fn : name;
+          fn_replace : name;
+          args : (expr -> bool) list;
+          ret : ty -> bool;
+        }
+
+        type ('a, 'b) predicate = 'a -> 'b option
+
+        let mk (args : ('a, 'b) predicate list) (ret : ('c, 'd) predicate)
+            (fn : name) (fn_replace : name) : pattern =
+          let args = List.map ~f:(fun p x -> p x |> Option.is_some) args in
+          let ret t = ret t |> Option.is_some in
+          { fn; fn_replace; args; ret }
+
+        open struct
+          let etyp (e : expr) : ty = e.typ
+          let tref = function TRef { typ; _ } -> Some typ | _ -> None
+
+          let tapp0 = function
+            | TApp { ident; args = [] } -> Some ident
+            | _ -> None
+
+          let ( >>& ) (f1 : ('a, 'b) predicate) (f2 : ('b, 'c) predicate) :
+              ('a, 'c) predicate =
+           fun x -> Option.bind (f1 x) ~f:f2
+
+          let eq : 'a 'b. eq:('a -> 'b -> bool) -> 'a -> ('b, 'b) predicate =
+           fun ~eq x x' -> if eq x x' then Some x' else None
+
+          let eq_global_ident :
+              name -> (Ast.Global_ident.t, Ast.Global_ident.t) predicate =
+            eq ~eq:Ast.Global_ident.eq_name
+
+          let erase : 'a. ('a, unit) predicate = fun _ -> Some ()
+
+          let is_int : (ty, unit) predicate =
+            tapp0 >>& eq_global_ident Hax_lib__int__Int >>& erase
+
+          let any _ = Some ()
+          let int_any = mk [ etyp >> is_int ] any
+          let int_int_any = mk [ etyp >> is_int; etyp >> is_int ] any
+          let any_int = mk [ any ] is_int
+          let rint_any = mk [ etyp >> (tref >>& is_int) ] any
+
+          let rint_rint_any =
+            mk [ etyp >> (tref >>& is_int); etyp >> (tref >>& is_int) ] any
+
+          let any_rint = mk [ any ] (tref >>& is_int)
+
+          (* let is_type0 (ty_name : name) : (expr -> bool) option = *)
+          (*   Some *)
+          (*     (typ *)
+          (*     >> [%matches? *)
+          (*          TApp { ident; args = [] } when Ast.Global_ident.eq_name *)
+          (*                                           ty_name ident]) *)
+
+          (* let is_ref_type0 (ty_name : name) : (expr -> bool) option = *)
+          (*   Some *)
+          (*     (typ *)
+          (*     >> [%matches? *)
+          (*          TRef { typ = TApp { ident; args = [] }; _ } when Ast *)
+          (*                                                           .Global_ident *)
+          (*                                                           .eq_name *)
+          (*                                                             ty_name *)
+          (*                                                             ident]) *)
+
+          (* let is_int = is_type0 Hax_lib__int__Int *)
+          (* let is_ref_int = is_ref_type0 Hax_lib__int__Int *)
+
+          (* let mk_ref_int n f f' = *)
+          (*   { *)
+          (*     fn = f; *)
+          (*     fn_replace = f'; *)
+          (*     args = List.init n ~f:(fun _ -> is_ref_int); *)
+          (*   } *)
+        end
+
+        let patterns =
+          [
+            int_int_any Core__ops__arith__Add__add
+              Rust_primitives__hax__int__add;
+            int_int_any Core__ops__arith__Sub__sub
+              Rust_primitives__hax__int__sub;
+            int_int_any Core__ops__arith__Mul__mul
+              Rust_primitives__hax__int__mul;
+            int_int_any Core__ops__arith__Div__div
+              Rust_primitives__hax__int__div;
+            int_int_any Core__ops__arith__Rem__rem
+              Rust_primitives__hax__int__rem;
+            rint_rint_any Core__cmp__PartialOrd__gt
+              Rust_primitives__hax__int__gt;
+            rint_rint_any Core__cmp__PartialOrd__ge
+              Rust_primitives__hax__int__ge;
+            rint_rint_any Core__cmp__PartialOrd__lt
+              Rust_primitives__hax__int__lt;
+            rint_rint_any Core__cmp__PartialOrd__le
+              Rust_primitives__hax__int__le;
+            rint_rint_any Core__cmp__PartialEq__ne Rust_primitives__hax__int__ne;
+            rint_rint_any Core__cmp__PartialEq__eq Rust_primitives__hax__int__eq;
+            any_rint Hax_lib__int__Abstraction__lift
+              Rust_primitives__hax__int__from_machine;
+            int_any Hax_lib__int__Concretization__concretize
+              Rust_primitives__hax__int__into_machine;
+          ]
+      end
+
+      module Error = Phase_utils.MakeError (struct
+        let ctx = Diagnostics.Context.Phase phase_id
+      end)
+
+      module Attrs = Attr_payloads.Make (F) (Error)
+
+      let visitor =
+        object (self)
+          inherit [_] Visitors.map as super
+
+          method! visit_expr () e =
+            match e.e with
+            | App { f = { e = GlobalVar f; _ } as f'; args = l; _ } -> (
+                let l = List.map ~f:(self#visit_expr ()) l in
+                let matching =
+                  List.filter patterns ~f:(fun { fn; args; _ } ->
+                      Ast.Global_ident.eq_name fn f
+                      &&
+                      match List.for_all2 args l ~f:apply with
+                      | Ok r -> r
+                      | _ -> false)
+                in
+                match matching with
+                | [ { fn_replace; _ } ] ->
+                    let f = Ast.Global_ident.of_name Value fn_replace in
+                    let f = { f' with e = GlobalVar f } in
+                    {
+                      e with
+                      e = App { f; args = l; impl = None; generic_args = [] };
+                    }
+                | [] -> super#visit_expr () e
+                | _ ->
+                    Error.assertion_failure e.span
+                      "Found multiple matching patterns")
+            | _ -> super#visit_expr () e
+        end
+
+      let ditems (l : A.item list) : B.item list =
+        List.map ~f:(visitor#visit_item ()) l
+    end)

--- a/engine/lib/phases/phase_specialize.ml
+++ b/engine/lib/phases/phase_specialize.ml
@@ -22,9 +22,13 @@ module Make (F : Features.T) =
           args : (expr -> bool) list;
           ret : ty -> bool;
         }
+        (** A pattern that helps matching against function applications *)
 
         type ('a, 'b) predicate = 'a -> 'b option
+        (** Instead of working directly with boolean predicate, we
+        work with `_ -> _ option` so that we can chain them *)
 
+        (** Constructs a predicate out of predicates and names *)
         let mk (args : ('a, 'b) predicate list) (ret : ('c, 'd) predicate)
             (fn : name) (fn_replace : name) : pattern =
           let args = List.map ~f:(fun p x -> p x |> Option.is_some) args in
@@ -65,35 +69,9 @@ module Make (F : Features.T) =
             mk [ etyp >> (tref >>& is_int); etyp >> (tref >>& is_int) ] any
 
           let any_rint = mk [ any ] (tref >>& is_int)
-
-          (* let is_type0 (ty_name : name) : (expr -> bool) option = *)
-          (*   Some *)
-          (*     (typ *)
-          (*     >> [%matches? *)
-          (*          TApp { ident; args = [] } when Ast.Global_ident.eq_name *)
-          (*                                           ty_name ident]) *)
-
-          (* let is_ref_type0 (ty_name : name) : (expr -> bool) option = *)
-          (*   Some *)
-          (*     (typ *)
-          (*     >> [%matches? *)
-          (*          TRef { typ = TApp { ident; args = [] }; _ } when Ast *)
-          (*                                                           .Global_ident *)
-          (*                                                           .eq_name *)
-          (*                                                             ty_name *)
-          (*                                                             ident]) *)
-
-          (* let is_int = is_type0 Hax_lib__int__Int *)
-          (* let is_ref_int = is_ref_type0 Hax_lib__int__Int *)
-
-          (* let mk_ref_int n f f' = *)
-          (*   { *)
-          (*     fn = f; *)
-          (*     fn_replace = f'; *)
-          (*     args = List.init n ~f:(fun _ -> is_ref_int); *)
-          (*   } *)
         end
 
+        (** The list of replacements *)
         let patterns =
           [
             int_int_any Core__ops__arith__Add__add

--- a/engine/lib/phases/phase_specialize.mli
+++ b/engine/lib/phases/phase_specialize.mli
@@ -1,0 +1,9 @@
+(** This phase specializes certain specific method applications
+(according to their name and the type it is being used on) into plain
+functions.
+
+This is useful espcially for math integers: the methods of the traits
+`Add`, `Sub`, `Mul` etc. are mapped to "primitive" functions in
+backends (e.g. Prims.whatever in FStar). *)
+
+module Make : Phase_utils.UNCONSTRAINTED_MONOMORPHIC_PHASE

--- a/engine/lib/utils.ml
+++ b/engine/lib/utils.ml
@@ -21,6 +21,7 @@ let curry3 f x y z = f (x, y, z)
 let uncurry3 f (x, y, z) = f x y z
 let tup2 a b = (a, b)
 let swap (a, b) = (b, a)
+let apply f x = f x
 let ( let* ) x f = Option.bind ~f x
 let some_if_true = function true -> Some () | _ -> None
 

--- a/engine/names/src/lib.rs
+++ b/engine/names/src/lib.rs
@@ -34,6 +34,14 @@ fn dummy_hax_concrete_ident_wrapper<I: core::iter::Iterator<Item = u8>>(x: I, mu
     let _ = ..;
     let _ = ..1;
 
+    {
+        use hax_lib::int::*;
+        let a: Int = 3u8.lift();
+        let _ = a.clone().pow2();
+        let _ = Int::_unsafe_from_str("1");
+        let _: u32 = a.concretize();
+    }
+
     fn question_mark_result<A, B: From<A>>(x: A) -> Result<(), B> {
         Err(x)?;
         Ok(())
@@ -147,6 +155,25 @@ mod hax {
     /// The engine uses this `dropped_body` symbol as a marker value
     /// to signal that a item was extracted without body.
     fn dropped_body() {}
+
+    mod int {
+        fn add() {}
+        fn sub() {}
+        fn div() {}
+        fn mul() {}
+        fn rem() {}
+
+        fn le() {}
+        fn lt() {}
+        fn ge() {}
+        fn gt() {}
+
+        fn eq() {}
+        fn ne() {}
+
+        fn from_machine() {}
+        fn into_machine() {}
+    }
 
     mod control_flow_monad {
         trait ControlFlowMonad {

--- a/hax-lib/Cargo.toml
+++ b/hax-lib/Cargo.toml
@@ -13,5 +13,5 @@ description = "Hax-specific helpers for Rust programs"
 
 [dependencies]
 hax-lib-macros = { path = "../hax-lib-macros" }
-num-bigint = { version = "0.4.4", default-features = false, features = [] }
-num-traits = { version = "0.2.18", default-features = false, features = [] }
+num-bigint = { version = "0.4.3", default-features = false, features = [] }
+num-traits = { version = "0.2.15", default-features = false, features = [] }

--- a/hax-lib/Cargo.toml
+++ b/hax-lib/Cargo.toml
@@ -13,5 +13,5 @@ description = "Hax-specific helpers for Rust programs"
 
 [dependencies]
 hax-lib-macros = { path = "../hax-lib-macros" }
-num-bigint = { version = "0.4.3", default-features = false, features = [] }
-num-traits = { version = "0.2.15", default-features = false, features = [] }
+num-bigint = { version = "0.4.3", default-features = false }
+num-traits = { version = "0.2.15", default-features = false }

--- a/hax-lib/Cargo.toml
+++ b/hax-lib/Cargo.toml
@@ -12,8 +12,6 @@ description = "Hax-specific helpers for Rust programs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hax-lib-macros = { path = "../hax-lib-macros", optional = true }
-
-[features]
-default = ["macros"]
-macros = ["dep:hax-lib-macros"]
+hax-lib-macros = { path = "../hax-lib-macros" }
+num-bigint = "0.4.4"
+num-traits = "0.2.18"

--- a/hax-lib/Cargo.toml
+++ b/hax-lib/Cargo.toml
@@ -12,6 +12,6 @@ description = "Hax-specific helpers for Rust programs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hax-lib-macros = { path = "../hax-lib-macros" }
+hax-lib-macros.workspace = true
 num-bigint = { version = "0.4.3", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }

--- a/hax-lib/Cargo.toml
+++ b/hax-lib/Cargo.toml
@@ -13,5 +13,5 @@ description = "Hax-specific helpers for Rust programs"
 
 [dependencies]
 hax-lib-macros = { path = "../hax-lib-macros" }
-num-bigint = "0.4.4"
-num-traits = "0.2.18"
+num-bigint = { version = "0.4.4", default-features = false, features = [] }
+num-traits = { version = "0.2.18", default-features = false, features = [] }

--- a/hax-lib/Cargo.toml
+++ b/hax-lib/Cargo.toml
@@ -12,6 +12,10 @@ description = "Hax-specific helpers for Rust programs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hax-lib-macros.workspace = true
+hax-lib-macros = { workspace = true, optional = true }
 num-bigint = { version = "0.4.3", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
+
+[features]
+default = ["macros"]
+macros = ["dep:hax-lib-macros"]

--- a/hax-lib/proofs/fstar/extraction/Hax_lib.Int.fst
+++ b/hax-lib/proofs/fstar/extraction/Hax_lib.Int.fst
@@ -1,0 +1,20 @@
+module Hax_lib.Int
+
+open Core
+
+unfold type t_Int = int
+unfold type impl__Int__to_u16
+
+unfold let impl__Int__to_u8 (#t:inttype) (n:range_t t) : int_t t = mk_int #t n
+unfold let impl__Int__to_u16 (#t:inttype) (n:range_t t) : int_t t = mk_int #t n
+unfold let impl__Int__to_u32 (#t:inttype) (n:range_t t) : int_t t = mk_int #t n
+unfold let impl__Int__to_u64 (#t:inttype) (n:range_t t) : int_t t = mk_int #t n
+unfold let impl__Int__to_u128 (#t:inttype) (n:range_t t) : int_t t = mk_int #t n
+unfold let impl__Int__to_usize (#t:inttype) (n:range_t t) : int_t t = mk_int #t n
+
+unfold let impl__Int__to_i8 (#t:inttype) (n:range_t t) : int_t t = mk_int #t n
+unfold let impl__Int__to_i16 (#t:inttype) (n:range_t t) : int_t t = mk_int #t n
+unfold let impl__Int__to_i32 (#t:inttype) (n:range_t t) : int_t t = mk_int #t n
+unfold let impl__Int__to_i64 (#t:inttype) (n:range_t t) : int_t t = mk_int #t n
+unfold let impl__Int__to_i128 (#t:inttype) (n:range_t t) : int_t t = mk_int #t n
+unfold let impl__Int__to_isize (#t:inttype) (n:range_t t) : int_t t = mk_int #t n

--- a/hax-lib/proofs/fstar/extraction/Makefile
+++ b/hax-lib/proofs/fstar/extraction/Makefile
@@ -1,0 +1,106 @@
+# This is a generically useful Makefile for F* that is self-contained
+#
+# It is tempting to factor this out into multiple Makefiles but that
+# makes it less portable, so resist temptation, or move to a more
+# sophisticated build system.
+#
+# We expect FSTAR_HOME to be set to your FSTAR repo/install directory
+# We expect HACL_HOME to be set to your HACL* repo location
+# We expect HAX_PROOF_LIBS_HOME to be set to the folder containing core, rust_primitives etc.
+# We expect HAX_LIBS_HOME to be set to the folder containing the crate `hax-lib`.
+#
+# ROOTS contains all the top-level F* files you wish to verify
+# The default target `verify` verified ROOTS and its dependencies
+# To lax-check instead, set `OTHERFLAGS="--lax"` on the command-line
+#
+#
+# To make F* emacs mode use the settings in this file, you need to
+# add the following lines to your .emacs
+#
+# (setq-default fstar-executable "<YOUR_FSTAR_HOME>/bin/fstar.exe")
+# (setq-default fstar-smt-executable "<YOUR_Z3_HOME>/bin/z3")
+#
+# (defun my-fstar-compute-prover-args-using-make ()
+#   "Construct arguments to pass to F* by calling make."
+#   (with-demoted-errors "Error when constructing arg string: %S"
+#     (let* ((fname (file-name-nondirectory buffer-file-name))
+# 	   (target (concat fname "-in"))
+# 	   (argstr (car (process-lines "make" "--quiet" target))))
+#       (split-string argstr))))
+# (setq fstar-subp-prover-args #'my-fstar-compute-prover-args-using-make)
+#
+
+HAX_HOME       ?= $(shell git rev-parse --show-toplevel)
+FSTAR_HOME     ?= $(HAX_HOME)/../../../FStar
+HACL_HOME      ?= $(HAX_HOME)/../../../hacl-star
+
+FSTAR_BIN      ?= $(shell command -v fstar.exe 1>&2 2> /dev/null && echo "fstar.exe" || echo "$(FSTAR_HOME)/bin/fstar.exe")
+
+HAX_PROOF_LIBS_HOME ?= $(HAX_HOME)/proof-libs/fstar
+HAX_LIBS_HOME        ?= $(HAX_HOME)/hax-lib/proofs/fstar/extraction
+
+CACHE_DIR      ?= $(HAX_PROOF_LIBS_HOME)/.cache
+HINT_DIR       ?= $(HAX_PROOF_LIBS_HOME)/.hints
+
+.PHONY: all verify clean
+
+all:
+	rm -f .depend && $(MAKE) .depend
+	$(MAKE) verify
+
+# By default, we process all the files in the current directory. Here, we
+# *extend* the set of relevant files with the tests.
+ROOTS = $(*.fst)
+
+FSTAR_INCLUDE_DIRS = $(HACL_HOME)/lib \
+	$(HAX_PROOF_LIBS_HOME)/rust_primitives $(HAX_PROOF_LIBS_HOME)/core \
+	$(HAX_PROOF_LIBS_HOME)/hax_lib \
+	$(HAX_LIBS_HOME)
+
+FSTAR_FLAGS = --cmi \
+  --warn_error -331 \
+  --cache_checked_modules --cache_dir $(CACHE_DIR) \
+  --already_cached "+Prims+FStar+LowStar+C+Spec.Loops+TestLib" \
+  $(addprefix --include ,$(FSTAR_INCLUDE_DIRS))
+
+FSTAR = $(FSTAR_BIN) $(FSTAR_FLAGS)
+
+
+.depend: $(HINT_DIR) $(CACHE_DIR) $(ROOTS)
+	$(info $(ROOTS))
+	$(FSTAR) --cmi --dep full $(ROOTS) --extract '* -Prims -LowStar -FStar' > $@
+
+include .depend
+
+$(HINT_DIR):
+	mkdir -p $@
+
+$(CACHE_DIR):
+	mkdir -p $@
+
+$(CACHE_DIR)/Chacha20.Hacspec_helper.fst.checked: | .depend $(HINT_DIR) $(CACHE_DIR)
+	$(FSTAR) --lax $(OTHERFLAGS) $< $(ENABLE_HINTS) --hint_file $(HINT_DIR)/$(notdir $*).hints
+
+$(CACHE_DIR)/%.checked: | .depend $(HINT_DIR) $(CACHE_DIR)
+	$(FSTAR) $(OTHERFLAGS) $< $(ENABLE_HINTS) --hint_file $(HINT_DIR)/$(notdir $*).hints
+
+verify: $(addsuffix .checked, $(addprefix $(CACHE_DIR)/,$(ROOTS)))
+
+# Targets for interactive mode
+
+%.fst-in:
+	$(info $(FSTAR_FLAGS) \
+	  $(ENABLE_HINTS) --hint_file $(HINT_DIR)/$(basename $@).fst.hints)
+
+%.fsti-in:
+	$(info $(FSTAR_FLAGS) \
+	  $(ENABLE_HINTS) --hint_file $(HINT_DIR)/$(basename $@).fsti.hints)
+
+
+# Clean targets
+
+SHELL ?= /usr/bin/env bash
+
+clean:
+	rm -rf $(CACHE_DIR)/*
+	rm *.fst

--- a/hax-lib/src/int/bigint.rs
+++ b/hax-lib/src/int/bigint.rs
@@ -1,0 +1,45 @@
+//! This module provides an approximation of `BigInt` which is
+//! copiable, via an big array of `u8` of an fixed arbitrary size
+//! `BYTES`.
+//! Its interface provides bridges to `num_bigint::BigInt`.
+
+#[crate::exclude]
+mod no_extraction {
+    const BYTES: usize = 128;
+    #[derive(Copy, Clone)]
+    pub struct BigInt {
+        sign: num_bigint::Sign,
+        data: [u8; BYTES],
+    }
+    impl BigInt {
+        pub fn new(i: &num_bigint::BigInt) -> Self {
+            let (sign, data) = i.to_bytes_be();
+            let data = data.try_into().expect(
+                "`copiable_bigint::BigInt::new`: too big, please consider increasing `BYTES`",
+            );
+            BigInt { sign, data }
+        }
+        pub fn get(self) -> num_bigint::BigInt {
+            num_bigint::BigInt::from_bytes_be(self.sign, &self.data)
+        }
+    }
+
+    impl core::cmp::PartialEq for BigInt {
+        fn eq(&self, other: &Self) -> bool {
+            self.get() == other.get()
+        }
+    }
+    impl core::cmp::Eq for BigInt {}
+    impl core::cmp::Ord for BigInt {
+        fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+            self.get().cmp(&other.get())
+        }
+    }
+    impl core::cmp::PartialOrd for BigInt {
+        fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+            self.get().partial_cmp(&other.get())
+        }
+    }
+}
+
+pub(super) use no_extraction::BigInt;

--- a/hax-lib/src/int/bigint.rs
+++ b/hax-lib/src/int/bigint.rs
@@ -5,7 +5,7 @@
 
 #[crate::exclude]
 mod no_extraction {
-    const BYTES: usize = 128;
+    const BYTES: usize = 1024;
     #[derive(Copy, Clone)]
     pub struct BigInt {
         sign: num_bigint::Sign,

--- a/hax-lib/src/int/bigint.rs
+++ b/hax-lib/src/int/bigint.rs
@@ -23,6 +23,7 @@ mod no_extraction {
             );
             BigInt { sign, data }
         }
+
         /// Constructs a [`num_bigint::BigInt`] out of a [`BigInt`].
         pub(crate) fn get(self) -> num_bigint::BigInt {
             num_bigint::BigInt::from_bytes_be(self.sign, &self.data)

--- a/hax-lib/src/int/bigint.rs
+++ b/hax-lib/src/int/bigint.rs
@@ -3,49 +3,44 @@
 //! `BYTES`.
 //! Its interface provides bridges to `num_bigint::BigInt`.
 
-#[crate::exclude]
-mod no_extraction {
-    /// Maximal number of bytes stored in our copiable `BigInt`s.
-    const BYTES: usize = 1024;
-    #[derive(Copy, Clone)]
-    pub(crate) struct BigInt {
-        sign: num_bigint::Sign,
-        data: [u8; BYTES],
-    }
-    impl BigInt {
-        /// Construct a [`BigInt`] from a [`num_bigint::BigInt`]. This
-        /// operation panics when the provided [`num_bigint::BigInt`]
-        /// has more than [`BYTES`] bytes.
-        pub(crate) fn new(i: &num_bigint::BigInt) -> Self {
-            let (sign, data) = i.to_bytes_be();
-            let data = data.try_into().expect(
-                "`copiable_bigint::BigInt::new`: too big, please consider increasing `BYTES`",
-            );
-            BigInt { sign, data }
-        }
-
-        /// Constructs a [`num_bigint::BigInt`] out of a [`BigInt`].
-        pub(crate) fn get(self) -> num_bigint::BigInt {
-            num_bigint::BigInt::from_bytes_be(self.sign, &self.data)
-        }
+/// Maximal number of bytes stored in our copiable `BigInt`s.
+const BYTES: usize = 1024;
+#[derive(Copy, Clone)]
+pub(super) struct BigInt {
+    sign: num_bigint::Sign,
+    data: [u8; BYTES],
+}
+impl BigInt {
+    /// Construct a [`BigInt`] from a [`num_bigint::BigInt`]. This
+    /// operation panics when the provided [`num_bigint::BigInt`]
+    /// has more than [`BYTES`] bytes.
+    pub(super) fn new(i: &num_bigint::BigInt) -> Self {
+        let (sign, data) = i.to_bytes_be();
+        let data = data
+            .try_into()
+            .expect("`copiable_bigint::BigInt::new`: too big, please consider increasing `BYTES`");
+        BigInt { sign, data }
     }
 
-    impl core::cmp::PartialEq for BigInt {
-        fn eq(&self, other: &Self) -> bool {
-            self.get() == other.get()
-        }
-    }
-    impl core::cmp::Eq for BigInt {}
-    impl core::cmp::Ord for BigInt {
-        fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-            self.get().cmp(&other.get())
-        }
-    }
-    impl core::cmp::PartialOrd for BigInt {
-        fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-            self.get().partial_cmp(&other.get())
-        }
+    /// Constructs a [`num_bigint::BigInt`] out of a [`BigInt`].
+    pub(super) fn get(self) -> num_bigint::BigInt {
+        num_bigint::BigInt::from_bytes_be(self.sign, &self.data)
     }
 }
 
-pub(super) use no_extraction::BigInt;
+impl core::cmp::PartialEq for BigInt {
+    fn eq(&self, other: &Self) -> bool {
+        self.get() == other.get()
+    }
+}
+impl core::cmp::Eq for BigInt {}
+impl core::cmp::Ord for BigInt {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.get().cmp(&other.get())
+    }
+}
+impl core::cmp::PartialOrd for BigInt {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        self.get().partial_cmp(&other.get())
+    }
+}

--- a/hax-lib/src/int/bigint.rs
+++ b/hax-lib/src/int/bigint.rs
@@ -5,21 +5,26 @@
 
 #[crate::exclude]
 mod no_extraction {
+    /// Maximal number of bytes stored in our copiable `BigInt`s.
     const BYTES: usize = 1024;
     #[derive(Copy, Clone)]
-    pub struct BigInt {
+    pub(crate) struct BigInt {
         sign: num_bigint::Sign,
         data: [u8; BYTES],
     }
     impl BigInt {
-        pub fn new(i: &num_bigint::BigInt) -> Self {
+        /// Construct a [`BigInt`] from a [`num_bigint::BigInt`]. This
+        /// operation panics when the provided [`num_bigint::BigInt`]
+        /// has more than [`BYTES`] bytes.
+        pub(crate) fn new(i: &num_bigint::BigInt) -> Self {
             let (sign, data) = i.to_bytes_be();
             let data = data.try_into().expect(
                 "`copiable_bigint::BigInt::new`: too big, please consider increasing `BYTES`",
             );
             BigInt { sign, data }
         }
-        pub fn get(self) -> num_bigint::BigInt {
+        /// Constructs a [`num_bigint::BigInt`] out of a [`BigInt`].
+        pub(crate) fn get(self) -> num_bigint::BigInt {
             num_bigint::BigInt::from_bytes_be(self.sign, &self.data)
         }
     }

--- a/hax-lib/src/int/mod.rs
+++ b/hax-lib/src/int/mod.rs
@@ -9,9 +9,7 @@ use bigint::*;
 /// or underflow.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Int(BigInt);
-pub use hax_lib_macros::int;
 
-#[crate::exclude]
 impl Int {
     fn new(x: impl Into<num_bigint::BigInt>) -> Self {
         Int(BigInt::new(&x.into()))

--- a/hax-lib/src/int/mod.rs
+++ b/hax-lib/src/int/mod.rs
@@ -61,8 +61,8 @@ impl Int {
     }
 
     /// Constructs a `Int` out of a string literal. This function
-    /// assumes its argument consists only of digits, with optionally
-    /// a minus sign prefix.
+    /// assumes its argument consists only of decimal digits, with
+    /// optionally a minus sign prefix.
     pub fn _unsafe_from_str(s: &str) -> Self {
         use core::str::FromStr;
         Self::new(num_bigint::BigInt::from_str(s).unwrap())

--- a/hax-lib/src/int/mod.rs
+++ b/hax-lib/src/int/mod.rs
@@ -4,6 +4,9 @@ use num_traits::cast::ToPrimitive;
 mod bigint;
 use bigint::*;
 
+#[cfg(feature = "macros")]
+pub use hax_lib_macros::int;
+
 /// Mathematical integers for writting specifications. Mathematical
 /// integers are unbounded and arithmetic operation on them never over
 /// or underflow.

--- a/hax-lib/src/int/mod.rs
+++ b/hax-lib/src/int/mod.rs
@@ -1,0 +1,133 @@
+use core::ops::*;
+use num_traits::cast::ToPrimitive;
+
+mod bigint;
+use bigint::*;
+
+/// Mathematical integers for writting specifications. Mathematical
+/// integers are unbounded and arithmetic operation on them never over
+/// or underflow.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct Int(BigInt);
+pub use hax_lib_macros::int;
+
+#[crate::exclude]
+impl Int {
+    fn new(x: impl Into<num_bigint::BigInt>) -> Self {
+        Int(BigInt::new(&x.into()))
+    }
+    fn get(self) -> num_bigint::BigInt {
+        self.0.get()
+    }
+}
+
+impl Add for Int {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self::Output {
+        Self::new(self.get() + other.get())
+    }
+}
+
+impl Sub for Int {
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self::Output {
+        Self::new(self.get() - other.get())
+    }
+}
+
+impl Mul for Int {
+    type Output = Self;
+
+    fn mul(self, other: Self) -> Self::Output {
+        Self::new(self.get() * other.get())
+    }
+}
+
+impl Div for Int {
+    type Output = Self;
+
+    fn div(self, other: Self) -> Self::Output {
+        Self::new(self.get() / other.get())
+    }
+}
+
+impl Int {
+    /// Raises `2` at the power `self`
+    pub fn pow2(self) -> Self {
+        let exponent = self.get().to_u32().expect("Exponent doesn't fit in a u32");
+        Self::new(num_bigint::BigInt::from(2u8).pow(exponent))
+    }
+
+    /// Constructs a `Int` out of a string literal. This function
+    /// assumes its argument consists only of digits, with optionally
+    /// a minus sign prefix.
+    pub fn _unsafe_from_str(s: &str) -> Self {
+        use core::str::FromStr;
+        Self::new(num_bigint::BigInt::from_str(s).unwrap())
+    }
+}
+
+/// Marks a type as abstractable: its values can be mapped to an
+/// idealized version of the type. For instance, machine integers,
+/// which have bounds, can be mapped to mathematical integers.
+///
+/// Each type can have only one abstraction.
+pub trait Abstraction {
+    /// What is the ideal type values should be mapped to?
+    type AbstractType;
+    /// Maps a concrete value to its abstract counterpart
+    fn lift(self) -> Self::AbstractType;
+}
+
+/// Marks a type as abstract: its values can be lowered to concrete
+/// values. This might panic.
+pub trait Concretization<T> {
+    /// Maps an abstract value and lowers it to its concrete counterpart.
+    fn concretize(self) -> T;
+}
+
+impl<T: Into<num_bigint::BigInt>> Abstraction for T {
+    type AbstractType = Int;
+    fn lift(self) -> Self::AbstractType {
+        Int::new(self.into())
+    }
+}
+
+macro_rules! implement_concretize {
+    ($ty:ident $method:ident) => {
+        impl Concretization<$ty> for Int {
+            fn concretize(self) -> $ty {
+                let concretized = self.get().$method();
+                debug_assert!(concretized.is_some());
+                concretized.unwrap().into()
+            }
+        }
+        impl Int {
+            pub fn $method(self) -> $ty {
+                self.concretize()
+            }
+        }
+    };
+    ($ty:ident $method:ident, $($tt:tt)*) => {
+        implement_concretize!($ty $method);
+        implement_concretize!($($tt)*);
+    };
+    () => {};
+}
+
+implement_concretize!(
+    u8    to_u8,
+    u16   to_u16,
+    u32   to_u32,
+    u64   to_u64,
+    u128  to_u128,
+    usize to_usize,
+    i8    to_i8,
+    i16   to_i16,
+    i32   to_i32,
+    i64   to_i64,
+    i128  to_i128,
+    isize to_isize,
+);

--- a/hax-lib/src/lib.rs
+++ b/hax-lib/src/lib.rs
@@ -17,7 +17,9 @@
 
 pub mod int;
 
+#[cfg(feature = "macros")]
 mod proc_macros;
+#[cfg(feature = "macros")]
 pub use proc_macros::*;
 
 #[doc(hidden)]

--- a/hax-lib/src/lib.rs
+++ b/hax-lib/src/lib.rs
@@ -15,6 +15,8 @@
 
 #![no_std]
 
+pub mod int;
+
 mod proc_macros;
 pub use proc_macros::*;
 

--- a/proof-libs/fstar/rust_primitives/Rust_primitives.Hax.Int.fst
+++ b/proof-libs/fstar/rust_primitives/Rust_primitives.Hax.Int.fst
@@ -1,0 +1,8 @@
+module Rust_primitives.Hax.Int
+
+open Core
+open Rust_primitives
+module LI = Lib.IntTypes
+
+unfold let from_machine (#t:inttype) (x:int_t t) : range_t t = v #t x
+unfold let into_machine (#t:inttype) (n:range_t t) : int_t t = mk_int #t n

--- a/test-harness/src/snapshots/toolchain__literals into-coq.snap
+++ b/test-harness/src/snapshots/toolchain__literals into-coq.snap
@@ -37,6 +37,9 @@ Import List.ListNotations.
 Open Scope Z_scope.
 Open Scope bool_scope.
 
+Require Import Hax_lib_Int.
+Export Hax_lib_Int.
+
 (*Not implemented yet? todo(item)*)
 
 Definition casts (x8 : int8) (x16 : int16) (x32 : int32) (x64 : int64) (xs : uint_size) : unit :=
@@ -57,6 +60,30 @@ Definition numeric (_ : unit) : unit :=
   let (_ : int32) := (@repr WORDSIZE32 42) : int32 in
   let (_ : int128) := (@repr WORDSIZE128 22222222222222222222) : int128 in
   tt.
+
+Definition math_integers (x : t_Int_t) : int8 :=
+  let (_ : t_Int_t) := f_lift (@repr WORDSIZE32 3) : t_Int_t in
+  let _ := (impl__Int___unsafe_from_str -340282366920938463463374607431768211455000)>.?(impl__Int___unsafe_from_str 340282366920938463463374607431768211455000) : bool in
+  let _ := x<.?x : bool in
+  let _ := x>=.?x : bool in
+  let _ := x<=.?x : bool in
+  let _ := x<>x : bool in
+  let _ := x=.?x : bool in
+  let _ := x.+x : t_Int_t in
+  let _ := x.-x : t_Int_t in
+  let _ := x.*x : t_Int_t in
+  let _ := x./x : t_Int_t in
+  let (_ : int16) := impl__Int__to_i16 x : int16 in
+  let (_ : int32) := impl__Int__to_i32 x : int32 in
+  let (_ : int64) := impl__Int__to_i64 x : int64 in
+  let (_ : int128) := impl__Int__to_i128 x : int128 in
+  let (_ : uint_size) := impl__Int__to_isize x : uint_size in
+  let (_ : int16) := impl__Int__to_u16 x : int16 in
+  let (_ : int32) := impl__Int__to_u32 x : int32 in
+  let (_ : int64) := impl__Int__to_u64 x : int64 in
+  let (_ : int128) := impl__Int__to_u128 x : int128 in
+  let (_ : uint_size) := impl__Int__to_usize x : uint_size in
+  impl__Int__to_u8 (x.+(x.*x)).
 
 Definition empty_array (_ : unit) : unit :=
   let (_ : seq int8) := unsize !TODO empty array! : seq int8 in

--- a/test-harness/src/snapshots/toolchain__literals into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__literals into-fstar.snap
@@ -112,6 +112,36 @@ let numeric (_: Prims.unit) : Prims.unit =
   let (_: u128):u128 = pub_u128 22222222222222222222 in
   ()
 
+let math_integers (x: Hax_lib.Int.t_Int)
+    : Prims.Pure u8
+      (requires x > (0 <: Hax_lib.Int.t_Int) && x < (16 <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) =
+  let (_: Hax_lib.Int.t_Int):Hax_lib.Int.t_Int = Rust_primitives.Hax.Int.from_machine (sz 3) in
+  let _:bool =
+    ((-340282366920938463463374607431768211455000) <: Hax_lib.Int.t_Int) >
+    (340282366920938463463374607431768211455000 <: Hax_lib.Int.t_Int)
+  in
+  let _:bool = x < x in
+  let _:bool = x >= x in
+  let _:bool = x <= x in
+  let _:bool = x <> x in
+  let _:bool = x = x in
+  let _:Hax_lib.Int.t_Int = x + x in
+  let _:Hax_lib.Int.t_Int = x - x in
+  let _:Hax_lib.Int.t_Int = x * x in
+  let _:Hax_lib.Int.t_Int = x / x in
+  let (_: i16):i16 = Hax_lib.Int.impl__Int__to_i16 x in
+  let (_: i32):i32 = Hax_lib.Int.impl__Int__to_i32 x in
+  let (_: i64):i64 = Hax_lib.Int.impl__Int__to_i64 x in
+  let (_: i128):i128 = Hax_lib.Int.impl__Int__to_i128 x in
+  let (_: isize):isize = Hax_lib.Int.impl__Int__to_isize x in
+  let (_: u16):u16 = Hax_lib.Int.impl__Int__to_u16 x in
+  let (_: u32):u32 = Hax_lib.Int.impl__Int__to_u32 x in
+  let (_: u64):u64 = Hax_lib.Int.impl__Int__to_u64 x in
+  let (_: u128):u128 = Hax_lib.Int.impl__Int__to_u128 x in
+  let (_: usize):usize = Hax_lib.Int.impl__Int__to_usize x in
+  Hax_lib.Int.impl__Int__to_u8 (x + (x * x <: Hax_lib.Int.t_Int) <: Hax_lib.Int.t_Int)
+
 let empty_array (_: Prims.unit) : Prims.unit =
   let (_: t_Slice u8):t_Slice u8 =
     Rust_primitives.unsize (let list:Prims.list u8 = [] in

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -295,6 +295,8 @@ name = "hax-lib"
 version = "0.1.0-pre.1"
 dependencies = [
  "hax-lib-macros",
+ "num-bigint",
+ "num-traits",
 ]
 
 [[package]]
@@ -461,6 +463,9 @@ dependencies = [
 [[package]]
 name = "literals"
 version = "0.1.0"
+dependencies = [
+ "hax-lib",
+]
 
 [[package]]
 name = "log"
@@ -533,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -586,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
 ]

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -538,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -591,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]

--- a/tests/literals/Cargo.toml
+++ b/tests/literals/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+hax-lib = { path = "../../hax-lib" }
 
 [package.metadata.hax-tests]
 into."fstar" = { broken = false, issue_id = "85" }

--- a/tests/literals/src/lib.rs
+++ b/tests/literals/src/lib.rs
@@ -1,4 +1,32 @@
 #![allow(dead_code)]
+use hax_lib::int::*;
+
+#[hax_lib::requires(x > int!(0) && x < int!(16))]
+fn math_integers(x: Int) -> u8 {
+    let _: Int = 3usize.lift();
+    let _ = int!(-340282366920938463463374607431768211455000)
+        > int!(340282366920938463463374607431768211455000);
+    let _ = x < x;
+    let _ = x >= x;
+    let _ = x <= x;
+    let _ = x != x;
+    let _ = x == x;
+    let _ = x + x;
+    let _ = x - x;
+    let _ = x * x;
+    let _ = x / x;
+    let _: i16 = x.to_i16();
+    let _: i32 = x.to_i32();
+    let _: i64 = x.to_i64();
+    let _: i128 = x.to_i128();
+    let _: isize = x.to_isize();
+    let _: u16 = x.to_u16();
+    let _: u32 = x.to_u32();
+    let _: u64 = x.to_u64();
+    let _: u128 = x.to_u128();
+    let _: usize = x.to_usize();
+    (x + x * x).to_u8()
+}
 
 pub fn panic_with_msg() {
     panic!("with msg")


### PR DESCRIPTION
This PR adds support for math integers. Will fix #607.

This PR:
 - introduces a `Int` type  (for math integers) that implements common operations;
 - translate `Int` as primitive `int` in F*, and same thing for methods on `Int`;
 - introduces a Specialize phase that "monomorphize" operations (e.g. std's add becomes a specific function);
 - provides a `int` macro for math int literals;
 - adds tests for math ints and their operations.