### PR TITLE
fix(test-harness): set `current_dir`

### DIFF
--- a/test-harness/src/command_hax_ext.rs
+++ b/test-harness/src/command_hax_ext.rs
@@ -39,6 +39,7 @@ impl CommandHaxExt for Command {
                 // available.
                 assert!(Command::new("cargo")
                             .args(&["build", "--bins"])
+                            .current_dir(&root)
                             .status()
                             .unwrap()
                             .success());
@@ -50,6 +51,7 @@ impl CommandHaxExt for Command {
                         .args(&["build", "--workspace", "--bin", "hax-engine-names-extract"])
                         .env("HAX_CARGO_COMMAND_PATH", &cargo_hax)
                         .env("HAX_RUSTC_DRIVER_BINARY", &driver)
+                        .current_dir(&root)
                         .status()
                         .unwrap()
                         .success());


### PR DESCRIPTION
The `cargo build --bins` command was ran in the directory of the test harness, resulting in a no-op. This commit sets the current dir to the root of the repository so that binaries are indeed built.