### PR TITLE
setting universe 0 for SIMD vector type

### DIFF
--- a/proof-libs/fstar/core/Core.Core_arch.X86.fsti
+++ b/proof-libs/fstar/core/Core.Core_arch.X86.fsti
@@ -1,3 +1,3 @@
 module Core.Core_arch.X86
 
-val t____m256i:Type
+val t____m256i:Type0


### PR DESCRIPTION
This fixes an F* type error for code that uses AVX2.