### PR TITLE
Exporter: fix #474

### DIFF
--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -967,14 +967,15 @@ end) : EXPR = struct
       =
     let browse_path (impl : impl_expr) (chunk : Thir.impl_expr_path_chunk) =
       match chunk with
-      | AssocItem { item; predicate = { trait_ref; _ }; clause_id; _ } ->
+      | AssocItem
+          { item; predicate = { value = { trait_ref; _ }; _ }; clause_id; _ } ->
           let ident = { goal = c_trait_ref span trait_ref; name = clause_id } in
           let kind : Concrete_ident.Kind.t =
             match item.kind with Const | Fn -> Value | Type -> Type
           in
           let item = Concrete_ident.of_def_id kind item.def_id in
           Projection { impl; ident; item }
-      | Parent { predicate = { trait_ref; _ }; clause_id; _ } ->
+      | Parent { predicate = { value = { trait_ref; _ }; _ }; clause_id; _ } ->
           let ident = { goal = c_trait_ref span trait_ref; name = clause_id } in
           Parent { impl; ident }
     in

--- a/frontend/exporter/src/rustc_utils.rs
+++ b/frontend/exporter/src/rustc_utils.rs
@@ -8,18 +8,14 @@ impl<'tcx, T: ty::TypeFoldable<ty::TyCtxt<'tcx>>> ty::Binder<'tcx, T> {
     }
 }
 
-#[extension_traits::extension(pub trait PredicateToPolyTraitRef)]
-impl<'tcx> ty::Predicate<'tcx> {
-    fn as_poly_trait_ref(self) -> Option<ty::PolyTraitRef<'tcx>> {
-        self.kind()
-            .try_map_bound(|kind| {
-                if let ty::PredicateKind::Clause(ty::Clause::Trait(trait_predicate)) = kind {
-                    Ok(trait_predicate.trait_ref)
-                } else {
-                    Err(())
-                }
-            })
-            .ok()
+#[extension_traits::extension(pub trait PredicateToPolyTraitPredicate)]
+impl<'tcx> ty::Binder<'tcx, ty::PredicateKind<'tcx>> {
+    fn as_poly_trait_predicate(self) -> Option<ty::PolyTraitPredicate<'tcx>> {
+        self.try_map_bound(|kind| match kind {
+            ty::PredicateKind::Clause(ty::Clause::Trait(trait_pred)) => Ok(trait_pred),
+            _ => Err(()),
+        })
+        .ok()
     }
 }
 

--- a/frontend/exporter/src/rustc_utils.rs
+++ b/frontend/exporter/src/rustc_utils.rs
@@ -58,7 +58,21 @@ impl<'tcx> ty::TyCtxt<'tcx> {
     ) {
         let with_self = self.predicates_of(did);
         let parent = with_self.parent;
-        let with_self = with_self.predicates;
+        let with_self = {
+            let extra_predicates = if rustc_hir::def::DefKind::OpaqueTy == self.def_kind(did) {
+                // An opaque type (e.g. `impl Trait`) provides
+                // predicates by itself: we need to account for them.
+                self.explicit_item_bounds(did)
+                    .skip_binder()
+                    .iter()
+                    .collect()
+            } else {
+                vec![]
+            }
+            .into_iter()
+            .cloned();
+            with_self.predicates.iter().cloned().chain(extra_predicates)
+        };
         let without_self: Vec<ty::Predicate> = self
             .predicates_defined_on(did)
             .predicates
@@ -67,14 +81,11 @@ impl<'tcx> ty::TyCtxt<'tcx> {
             .map(|(pred, _)| pred)
             .collect();
         (
-            with_self
-                .into_iter()
-                .cloned()
-                .map(move |(predicate, span)| AnnotatedPredicate {
-                    is_extra_self_predicate: !without_self.contains(&predicate),
-                    predicate,
-                    span,
-                }),
+            with_self.map(move |(predicate, span)| AnnotatedPredicate {
+                is_extra_self_predicate: !without_self.contains(&predicate),
+                predicate,
+                span,
+            }),
             parent,
         )
     }

--- a/frontend/exporter/src/rustc_utils.rs
+++ b/frontend/exporter/src/rustc_utils.rs
@@ -3,8 +3,12 @@ use rustc_middle::ty;
 
 #[extension_traits::extension(pub trait SubstBinder)]
 impl<'tcx, T: ty::TypeFoldable<ty::TyCtxt<'tcx>>> ty::Binder<'tcx, T> {
-    fn subst(self, tcx: ty::TyCtxt<'tcx>, substs: &[ty::subst::GenericArg<'tcx>]) -> T {
-        ty::EarlyBinder::bind(self.skip_binder()).subst(tcx, substs)
+    fn subst(
+        self,
+        tcx: ty::TyCtxt<'tcx>,
+        substs: &[ty::subst::GenericArg<'tcx>],
+    ) -> ty::Binder<'tcx, T> {
+        self.rebind(ty::EarlyBinder::bind(self.clone().skip_binder()).subst(tcx, substs))
     }
 }
 

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -8,12 +8,12 @@ use crate::prelude::*;
 pub enum ImplExprPathChunk {
     AssocItem {
         item: AssocItem,
-        predicate: TraitPredicate,
+        predicate: Binder<TraitPredicate>,
         clause_id: u64,
         index: usize,
     },
     Parent {
-        predicate: TraitPredicate,
+        predicate: Binder<TraitPredicate>,
         clause_id: u64,
         index: usize,
     },
@@ -67,34 +67,30 @@ pub struct ImplExpr {
 }
 
 mod search_clause {
-    use super::SubstBinder;
     use crate::prelude::UnderOwnerState;
-    use crate::rustc_utils::TyCtxtExtPredOrAbove;
+    use crate::rustc_utils::*;
     use rustc_middle::ty::*;
 
-    fn predicates_to_trait_predicates<'tcx>(
+    fn predicates_to_poly_trait_predicates<'tcx>(
         tcx: TyCtxt<'tcx>,
         predicates: impl Iterator<Item = Predicate<'tcx>>,
         substs: subst::SubstsRef<'tcx>,
-    ) -> impl Iterator<Item = TraitPredicate<'tcx>> {
+    ) -> impl Iterator<Item = PolyTraitPredicate<'tcx>> {
         predicates
             .map(move |pred| pred.kind().subst(tcx, substs))
-            .filter_map(|x| match x {
-                PredicateKind::Clause(Clause::Trait(c)) => Some(c),
-                _ => None,
-            })
+            .filter_map(|pred| pred.as_poly_trait_predicate())
     }
 
     #[derive(Clone, Debug)]
     pub enum PathChunk<'tcx> {
         AssocItem {
             item: AssocItem,
-            predicate: TraitPredicate<'tcx>,
+            predicate: PolyTraitPredicate<'tcx>,
             clause_id: u64,
             index: usize,
         },
         Parent {
-            predicate: TraitPredicate<'tcx>,
+            predicate: PolyTraitPredicate<'tcx>,
             clause_id: u64,
             index: usize,
         },
@@ -150,23 +146,27 @@ mod search_clause {
     }
 
     #[extension_traits::extension(pub trait TraitPredicateExt)]
-    impl<'tcx, S: UnderOwnerState<'tcx>> TraitPredicate<'tcx> {
-        fn parents_trait_predicates(self, s: &S) -> Vec<(usize, TraitPredicate<'tcx>)> {
+    impl<'tcx, S: UnderOwnerState<'tcx>> PolyTraitPredicate<'tcx> {
+        fn parents_trait_predicates(self, s: &S) -> Vec<(usize, PolyTraitPredicate<'tcx>)> {
             let tcx = s.base().tcx;
             let predicates = tcx
                 .predicates_defined_on_or_above(self.def_id())
                 .into_iter()
                 .map(|apred| apred.predicate);
-            predicates_to_trait_predicates(tcx, predicates, self.trait_ref.substs)
-                .enumerate()
-                .collect()
+            predicates_to_poly_trait_predicates(
+                tcx,
+                predicates,
+                self.skip_binder().trait_ref.substs,
+            )
+            .enumerate()
+            .collect()
         }
         fn associated_items_trait_predicates(
             self,
             s: &S,
         ) -> Vec<(
             AssocItem,
-            subst::EarlyBinder<Vec<(usize, TraitPredicate<'tcx>)>>,
+            subst::EarlyBinder<Vec<(usize, PolyTraitPredicate<'tcx>)>>,
         )> {
             let tcx = s.base().tcx;
             tcx.associated_items(self.def_id())
@@ -175,10 +175,10 @@ mod search_clause {
                 .copied()
                 .map(|item| {
                     let bounds = tcx.item_bounds(item.def_id).map_bound(|predicates| {
-                        predicates_to_trait_predicates(
+                        predicates_to_poly_trait_predicates(
                             tcx,
                             predicates.into_iter(),
-                            self.trait_ref.substs,
+                            self.skip_binder().trait_ref.substs,
                         )
                         .enumerate()
                         .collect()
@@ -348,9 +348,8 @@ impl<'tcx> IntoImplExpr<'tcx> for rustc_middle::ty::PolyTraitRef<'tcx> {
                         .predicate
                         .to_opt_poly_trait_pred()
                         .map(|poly_trait_predicate| poly_trait_predicate)
-                        .and_then(|poly_trait_predicate| poly_trait_predicate.no_bound_vars())
-                        .and_then(|trait_predicate| {
-                            trait_predicate.path_to(s, self.clone(), param_env)
+                        .and_then(|poly_trait_predicate| {
+                            poly_trait_predicate.path_to(s, self.clone(), param_env)
                         })
                         .map(|path| (apred, path))
                 }) else {

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -282,8 +282,13 @@ fn impl_exprs<'tcx, S: UnderOwnerState<'tcx>>(
         .flat_map(|obligation| {
             obligation
                 .predicate
-                .as_poly_trait_ref()
-                .map(|trait_ref| trait_ref.impl_expr(s, obligation.param_env))
+                .kind()
+                .as_poly_trait_predicate()
+                .map(|trait_ref| {
+                    trait_ref
+                        .map_bound(|p| p.trait_ref)
+                        .impl_expr(s, obligation.param_env)
+                })
         })
         .collect()
 }

--- a/test-harness/src/snapshots/toolchain__traits into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__traits into-fstar.snap
@@ -44,6 +44,15 @@ class t_Bar (v_Self: Type) = {
 let impl_2__method (#v_T: Type) (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: t_Bar v_T) (x: v_T)
     : Prims.unit = f_bar x
 
+type t_Error = | Error_Fail : t_Error
+
+let impl__Error__for_application_callback (_: Prims.unit) :  Prims.unit -> t_Error =
+  fun temp_0_ ->
+    let _:Prims.unit = temp_0_ in
+    Error_Fail <: t_Error
+
+let t_Error_cast_to_repr (x: t_Error) : isize = match x with | Error_Fail  -> isz 0
+
 class t_Lang (v_Self: Type) = {
   f_Var:Type;
   f_s_pre:v_Self -> i32 -> bool;

--- a/tests/traits/src/lib.rs
+++ b/tests/traits/src/lib.rs
@@ -66,3 +66,14 @@ pub trait Lang: Sized {
     type Var;
     fn s(self, _: i32) -> (Self, Self::Var);
 }
+
+pub enum Error {
+    Fail,
+}
+
+// From issue #474
+impl Error {
+    pub fn for_application_callback() -> impl FnOnce() -> Self {
+        || Self::Fail
+    }
+}


### PR DESCRIPTION
This PR fixes #474.
The issue in #474 was about opaque types. An opaque type is an existential type: there exists a type for which some traits are implemented.
When looking at an opaque type, we were not including those implemented traits, resulting in systematic failures.
This PR fixes that, and also improves the `subts` function from the ext trait `SubstBinder` (as spotted by @Nadrieril: we were not re-wrapping binders after substs them!).