### PR TITLE
Bump rustc version

### DIFF
--- a/engine/backends/coq/dune
+++ b/engine/backends/coq/dune
@@ -22,4 +22,4 @@
 (env
  (_
   (flags
-   (:standard -w +A))))
+   (:standard -w +A-4-40-42-44))))

--- a/engine/bin/dune
+++ b/engine/bin/dune
@@ -37,4 +37,4 @@
 (env
  (_
   (flags
-   (:standard -g -warn-error -A -warn-error +8))))
+   (:standard -g -warn-error -A -warn-error +8 -w -33))))

--- a/engine/bin/lib.ml
+++ b/engine/bin/lib.ml
@@ -1,5 +1,6 @@
 open Hax_engine
 open Base
+open Stdio
 
 let read_options_from_stdin (yojson_from_string : string -> Yojson.Safe.t) :
     Types.engine_options =

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -80,7 +80,6 @@ let c_mutability (witness : 'a) : bool -> 'a Ast.mutability = function
 let c_borrow_kind span : Thir.borrow_kind -> borrow_kind = function
   | Shared -> Shared
   | Shallow -> unimplemented [ span ] "Shallow borrows"
-  | Unique -> Unique
   | Mut _ -> Mut W.mutable_reference
 
 let c_binding_mode span : Thir.binding_mode -> binding_mode = function

--- a/frontend/exporter/src/rustc_utils.rs
+++ b/frontend/exporter/src/rustc_utils.rs
@@ -26,6 +26,7 @@ impl<'tcx> ty::Binder<'tcx, ty::PredicateKind<'tcx>> {
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct AnnotatedPredicate<'tcx> {
     pub is_extra_self_predicate: bool,
+    /// Note: they are all actually `Clause`s.
     pub predicate: ty::Predicate<'tcx>,
     pub span: rustc_span::Span,
 }
@@ -59,31 +60,31 @@ impl<'tcx> ty::TyCtxt<'tcx> {
         let with_self = self.predicates_of(did);
         let parent = with_self.parent;
         let with_self = {
-            let extra_predicates: Vec<(ty::Predicate<'_>, rustc_span::Span)> =
+            let extra_predicates: Vec<(ty::Clause<'_>, rustc_span::Span)> =
                 if rustc_hir::def::DefKind::OpaqueTy == self.def_kind(did) {
                     // An opaque type (e.g. `impl Trait`) provides
                     // predicates by itself: we need to account for them.
                     self.explicit_item_bounds(did)
                         .skip_binder()
                         .iter()
-                        .map(|(clause, span)| (clause.as_predicate(), *span))
+                        .copied()
                         .collect()
                 } else {
                     vec![]
                 };
             with_self.predicates.iter().copied().chain(extra_predicates)
         };
-        let without_self: Vec<ty::Predicate> = self
+        let without_self: Vec<ty::Clause<'_>> = self
             .predicates_defined_on(did)
             .predicates
             .iter()
             .copied()
-            .map(|(pred, _)| pred)
+            .map(|(clause, _)| clause)
             .collect();
         (
-            with_self.map(move |(predicate, span)| AnnotatedPredicate {
-                is_extra_self_predicate: !without_self.contains(&predicate),
-                predicate,
+            with_self.map(move |(clause, span)| AnnotatedPredicate {
+                is_extra_self_predicate: !without_self.contains(&clause),
+                predicate: clause.as_predicate(),
                 span,
             }),
             parent,

--- a/frontend/exporter/src/rustc_utils.rs
+++ b/frontend/exporter/src/rustc_utils.rs
@@ -16,7 +16,7 @@ impl<'tcx, T: ty::TypeFoldable<ty::TyCtxt<'tcx>>> ty::Binder<'tcx, T> {
 impl<'tcx> ty::Binder<'tcx, ty::PredicateKind<'tcx>> {
     fn as_poly_trait_predicate(self) -> Option<ty::PolyTraitPredicate<'tcx>> {
         self.try_map_bound(|kind| match kind {
-            ty::PredicateKind::Clause(ty::Clause::Trait(trait_pred)) => Ok(trait_pred),
+            ty::PredicateKind::Clause(ty::ClauseKind::Trait(trait_pred)) => Ok(trait_pred),
             _ => Err(()),
         })
         .ok()

--- a/frontend/exporter/src/state.rs
+++ b/frontend/exporter/src/state.rs
@@ -250,7 +250,7 @@ impl ImplInfos {
             .predicates_defined_on(did)
             .predicates
             .iter()
-            .map(|(x, _)| x.sinto(s))
+            .map(|(clause, _)| clause.as_predicate().sinto(s))
             .collect();
         Self {
             generics: tcx.generics_of(did).sinto(s),

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -457,8 +457,8 @@ pub fn clause_id_of_predicate<'tcx, S: UnderOwnerState<'tcx>>(
         let bvs: Vec<BoundVariableKind> = binder.bound_vars().sinto(s);
         let ck: ClauseKind = ck.sinto(s);
         hasher.write_u8(0);
-        bvs.hash(&mut hasher);
         ck.hash(&mut hasher);
+        bvs.hash(&mut hasher);
     } else {
         hasher.write_u8(1);
         predicate.sinto(s).hash(&mut hasher);

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -418,14 +418,15 @@ pub fn super_clause_to_clause_and_impl_expr<'tcx, S: UnderOwnerState<'tcx>>(
         let clause: Clause = clause.kind().skip_binder().sinto(s);
         clause.id
     };
-    let pred = clause.as_predicate().subst_supertrait(tcx, &impl_trait_ref);
-    let impl_expr = pred
+    let new_clause = clause.subst_supertrait(tcx, &impl_trait_ref);
+    let impl_expr = new_clause
+        .as_predicate()
         .to_opt_poly_trait_pred()?
         .impl_expr(s, get_param_env(s));
     // Build the new clause, again without binder.
-    let mut new_clause: Clause = pred.as_clause()?.kind().skip_binder().sinto(s);
-    new_clause.id = original_clause_id;
-    Some((new_clause, impl_expr, span.sinto(s)))
+    let mut new_clause_no_binder: Clause = new_clause.kind().skip_binder().sinto(s);
+    new_clause_no_binder.id = original_clause_id;
+    Some((new_clause_no_binder, impl_expr, span.sinto(s)))
 }
 
 fn deterministic_hash<T: std::hash::Hash>(x: &T) -> u64 {

--- a/frontend/exporter/src/types/copied.rs
+++ b/frontend/exporter/src/types/copied.rs
@@ -1960,8 +1960,19 @@ pub enum PointerCast {
 pub enum BorrowKind {
     Shared,
     Shallow,
-    Unique,
-    Mut { allow_two_phase_borrow: bool },
+    Mut { kind: MutBorrowKind },
+}
+
+/// Reflects [`rustc_middle::mir::MutBorrowKind`]
+#[derive(AdtInto)]
+#[args(<S>, from: rustc_middle::mir::MutBorrowKind, state: S as _s)]
+#[derive(
+    Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
+)]
+pub enum MutBorrowKind {
+    Default,
+    TwoPhaseBorrow,
+    ClosureCapture,
 }
 
 /// Reflects [`rustc_ast::ast::StrStyle`]
@@ -3244,9 +3255,9 @@ impl<'tcx, S: BaseState<'tcx> + HasOwnerId> SInto<S, ProjectionPredicate>
     }
 }
 
-/// Reflects [`rustc_middle::ty::Clause`]
+/// Reflects [`rustc_middle::ty::ClauseKind`]
 #[derive(AdtInto)]
-#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::Clause<'tcx>, state: S as tcx)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_middle::ty::ClauseKind<'tcx>, state: S as tcx)]
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -3260,7 +3271,7 @@ pub enum ClauseKind {
     ConstEvaluatable(ConstantExpr),
 }
 
-/// Reflects [`rustc_middle::ty::Clause`]
+/// Reflects [`rustc_middle::ty::ClauseKind`] and adds a hash-consed clause identifier.
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
@@ -3269,7 +3280,7 @@ pub struct Clause {
     pub id: u64,
 }
 
-impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, Clause> for rustc_middle::ty::Clause<'tcx> {
+impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, Clause> for rustc_middle::ty::ClauseKind<'tcx> {
     fn sinto(&self, s: &S) -> Clause {
         use rustc_middle::ty::ToPredicate;
         Clause {

--- a/frontend/exporter/src/types/mir.rs
+++ b/frontend/exporter/src/types/mir.rs
@@ -400,7 +400,7 @@ fn translate_terminator_kind_call<'tcx, S: BaseState<'tcx> + HasMir<'tcx> + HasO
         destination,
         target,
         unwind,
-        from_hir_call,
+        call_source,
         fn_span,
     } = terminator
     {
@@ -413,7 +413,7 @@ fn translate_terminator_kind_call<'tcx, S: BaseState<'tcx> + HasMir<'tcx> + HasO
             destination: destination.sinto(s),
             target: target.sinto(s),
             unwind: unwind.sinto(s),
-            from_hir_call: from_hir_call.sinto(s),
+            call_source: call_source.sinto(s),
             fn_span: fn_span.sinto(s),
             trait_refs,
             trait_info,
@@ -554,7 +554,7 @@ pub enum TerminatorKind {
         destination: Place,
         target: Option<BasicBlock>,
         unwind: UnwindAction,
-        from_hir_call: bool,
+        call_source: CallSource,
         fn_span: Span,
         trait_refs: Vec<ImplExpr>,
         trait_info: Option<ImplExpr>,
@@ -981,4 +981,5 @@ sinto_todo!(rustc_middle::mir, UserTypeProjection);
 sinto_todo!(rustc_middle::mir, MirSource<'tcx>);
 sinto_todo!(rustc_middle::mir, GeneratorInfo<'tcx>);
 sinto_todo!(rustc_middle::mir, VarDebugInfo<'tcx>);
+sinto_todo!(rustc_middle::mir, CallSource);
 sinto_todo!(rustc_span, ErrorGuaranteed);

--- a/frontend/exporter/src/types/mir_traits.rs
+++ b/frontend/exporter/src/types/mir_traits.rs
@@ -81,8 +81,8 @@ pub fn solve_item_traits<'tcx, S: UnderOwnerState<'tcx>>(
         };
 
         // Explore only the trait predicates
-        use rustc_middle::ty::{ClauseKind, PredicateKind};
-        if let PredicateKind::Clause(ClauseKind::Trait(trait_pred)) = bare_pred_kind {
+        use rustc_middle::ty::ClauseKind;
+        if let ClauseKind::Trait(trait_pred) = bare_pred_kind {
             // Rewrap the now-substituted kind with the original binder. Substitution dealt with
             // early bound variables; this binds late bound ones.
             let trait_ref = pred_kind.rebind(trait_pred.trait_ref);
@@ -192,12 +192,12 @@ pub fn get_params_info<'tcx, S: BaseState<'tcx> + HasOwnerId>(
     // which is not what we want.
     let preds = tcx.predicates_defined_on(def_id);
     for (pred, _) in preds.predicates {
-        use rustc_middle::ty::{ClauseKind, PredicateKind};
+        use rustc_middle::ty::ClauseKind;
         match &pred.kind().skip_binder() {
-            PredicateKind::Clause(ClauseKind::Trait(_)) => num_trait_clauses += 1,
-            PredicateKind::Clause(ClauseKind::RegionOutlives(_)) => num_regions_outlive += 1,
-            PredicateKind::Clause(ClauseKind::TypeOutlives(_)) => num_types_outlive += 1,
-            PredicateKind::Clause(ClauseKind::Projection(_)) => num_trait_type_constraints += 1,
+            ClauseKind::Trait(_) => num_trait_clauses += 1,
+            ClauseKind::RegionOutlives(_) => num_regions_outlive += 1,
+            ClauseKind::TypeOutlives(_) => num_types_outlive += 1,
+            ClauseKind::Projection(_) => num_trait_type_constraints += 1,
             _ => (),
         }
     }

--- a/frontend/exporter/src/types/mir_traits.rs
+++ b/frontend/exporter/src/types/mir_traits.rs
@@ -81,8 +81,8 @@ pub fn solve_item_traits<'tcx, S: UnderOwnerState<'tcx>>(
         };
 
         // Explore only the trait predicates
-        use rustc_middle::ty::{Clause, PredicateKind};
-        if let PredicateKind::Clause(Clause::Trait(trait_pred)) = bare_pred_kind {
+        use rustc_middle::ty::{ClauseKind, PredicateKind};
+        if let PredicateKind::Clause(ClauseKind::Trait(trait_pred)) = bare_pred_kind {
             // Rewrap the now-substituted kind with the original binder. Substitution dealt with
             // early bound variables; this binds late bound ones.
             let trait_ref = pred_kind.rebind(trait_pred.trait_ref);
@@ -192,12 +192,12 @@ pub fn get_params_info<'tcx, S: BaseState<'tcx> + HasOwnerId>(
     // which is not what we want.
     let preds = tcx.predicates_defined_on(def_id);
     for (pred, _) in preds.predicates {
-        use rustc_middle::ty::{Clause, PredicateKind};
+        use rustc_middle::ty::{ClauseKind, PredicateKind};
         match &pred.kind().skip_binder() {
-            PredicateKind::Clause(Clause::Trait(_)) => num_trait_clauses += 1,
-            PredicateKind::Clause(Clause::RegionOutlives(_)) => num_regions_outlive += 1,
-            PredicateKind::Clause(Clause::TypeOutlives(_)) => num_types_outlive += 1,
-            PredicateKind::Clause(Clause::Projection(_)) => num_trait_type_constraints += 1,
+            PredicateKind::Clause(ClauseKind::Trait(_)) => num_trait_clauses += 1,
+            PredicateKind::Clause(ClauseKind::RegionOutlives(_)) => num_regions_outlive += 1,
+            PredicateKind::Clause(ClauseKind::TypeOutlives(_)) => num_types_outlive += 1,
+            PredicateKind::Clause(ClauseKind::Projection(_)) => num_trait_type_constraints += 1,
             _ => (),
         }
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-06-22"
+channel = "nightly-2023-06-26"
 components = [ "rustc-dev", "llvm-tools-preview" , "rust-analysis" , "rust-src" , "rustfmt" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-06-21"
+channel = "nightly-2023-06-22"
 components = [ "rustc-dev", "llvm-tools-preview" , "rust-analysis" , "rust-src" , "rustfmt" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-06-26"
+channel = "nightly-2023-06-28"
 components = [ "rustc-dev", "llvm-tools-preview" , "rust-analysis" , "rust-src" , "rustfmt" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-06-20"
+channel = "nightly-2023-06-21"
 components = [ "rustc-dev", "llvm-tools-preview" , "rust-analysis" , "rust-src" , "rustfmt" ]

--- a/test-harness/src/snapshots/toolchain__traits into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__traits into-fstar.snap
@@ -62,7 +62,7 @@ class t_Lang (v_Self: Type) = {
 }
 
 class t_SuperTrait (v_Self: Type) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_2101570567305961368:Core.Clone.t_Clone v_Self;
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_4075428158603710007:Core.Clone.t_Clone v_Self;
   f_function_of_super_trait_pre:v_Self -> bool;
   f_function_of_super_trait_post:v_Self -> u32 -> bool;
   f_function_of_super_trait:x0: v_Self
@@ -74,7 +74,7 @@ class t_SuperTrait (v_Self: Type) = {
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 let impl_SuperTrait_for_i32: t_SuperTrait i32 =
   {
-    _super_2101570567305961368 = FStar.Tactics.Typeclasses.solve;
+    _super_4075428158603710007 = FStar.Tactics.Typeclasses.solve;
     f_function_of_super_trait_pre = (fun (self: i32) -> true);
     f_function_of_super_trait_post = (fun (self: i32) (out: u32) -> true);
     f_function_of_super_trait = fun (self: i32) -> cast (Core.Num.impl__i32__abs self <: i32) <: u32
@@ -82,8 +82,8 @@ let impl_SuperTrait_for_i32: t_SuperTrait i32 =
 
 class t_Foo (v_Self: Type) = {
   f_AssocType:Type;
-  f_AssocType_7709027004138830043:t_SuperTrait f_AssocType;
-  f_AssocType_11415341696577095690:Core.Clone.t_Clone f_AssocType;
+  f_AssocType_12975176671554111340:t_SuperTrait f_AssocType;
+  f_AssocType_15292246028710717365:Core.Clone.t_Clone f_AssocType;
   f_N:usize;
   f_assoc_f_pre:Prims.unit -> bool;
   f_assoc_f_post:Prims.unit -> Prims.unit -> bool;
@@ -130,7 +130,7 @@ let g (#v_T: Type) (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: t_Foo v_T) (x:
 let impl_Foo_for_tuple_: t_Foo Prims.unit =
   {
     f_AssocType = i32;
-    f_AssocType_7709027004138830043 = FStar.Tactics.Typeclasses.solve;
+    f_AssocType_12975176671554111340 = FStar.Tactics.Typeclasses.solve;
     f_N = sz 32;
     f_assoc_f_pre = (fun (_: Prims.unit) -> true);
     f_assoc_f_post = (fun (_: Prims.unit) (out: Prims.unit) -> true);


### PR DESCRIPTION
Some interesting clause-related changes.

Regarding `Clause` hashing, I think we should either never hash the binder or prevent hashing without a binder; the current middle-ground is error-prone. Consistently ignoring the binder seems fine.