### PR TITLE
Add bounds impls on calls in expressions

### DIFF
--- a/engine/lib/ast.ml
+++ b/engine/lib/ast.ml
@@ -194,6 +194,7 @@ functor
           f : expr;
           args : expr list (* ; f_span: span *);
           generic_args : generic_value list;
+          bounds_impls : impl_expr list;
           impl : impl_expr option;
         }
       | Literal of literal

--- a/engine/lib/ast_visitors.ml
+++ b/engine/lib/ast_visitors.ml
@@ -270,10 +270,14 @@ functor
                 self#visit_list self#visit_generic_value env
                   record_payload.generic_args
               in
+              let bounds_impls =
+                self#visit_list self#visit_impl_expr env
+                  record_payload.bounds_impls
+              in
               let impl =
                 self#visit_option self#visit_impl_expr env record_payload.impl
               in
-              App { f; args; generic_args; impl }
+              App { f; args; generic_args; impl; bounds_impls }
           | Literal x0 ->
               let x0 = self#visit_literal env x0 in
               Literal x0
@@ -1242,11 +1246,16 @@ functor
                   record_payload.generic_args
               in
               let reduce_acc = self#plus reduce_acc reduce_acc' in
+              let bounds_impls, reduce_acc' =
+                self#visit_list self#visit_impl_expr env
+                  record_payload.bounds_impls
+              in
+              let reduce_acc = self#plus reduce_acc reduce_acc' in
               let impl, reduce_acc' =
                 self#visit_option self#visit_impl_expr env record_payload.impl
               in
               let reduce_acc = self#plus reduce_acc reduce_acc' in
-              (App { f; args; generic_args; impl }, reduce_acc)
+              (App { f; args; generic_args; impl; bounds_impls }, reduce_acc)
           | Literal x0 ->
               let x0, reduce_acc = self#visit_literal env x0 in
               (Literal x0, reduce_acc)
@@ -2401,6 +2410,11 @@ functor
               let reduce_acc' =
                 self#visit_list self#visit_generic_value env
                   record_payload.generic_args
+              in
+              let reduce_acc = self#plus reduce_acc reduce_acc' in
+              let reduce_acc' =
+                self#visit_list self#visit_impl_expr env
+                  record_payload.bounds_impls
               in
               let reduce_acc = self#plus reduce_acc reduce_acc' in
               let reduce_acc' =

--- a/engine/lib/generic_printer/generic_printer_base.ml
+++ b/engine/lib/generic_printer/generic_printer_base.ml
@@ -181,9 +181,7 @@ module Make (F : Features.T) = struct
       method expr' : par_state -> expr' fn =
         fun _ctx e ->
           match e with
-          | App
-              { f = { e = GlobalVar i; _ } as f; args; generic_args; impl = _ }
-            -> (
+          | App { f = { e = GlobalVar i; _ } as f; args; generic_args; _ } -> (
               let expect_one_arg where =
                 match args with
                 | [ arg ] -> arg

--- a/engine/lib/phases/phase_drop_references.ml
+++ b/engine/lib/phases/phase_drop_references.ml
@@ -111,14 +111,15 @@ struct
               body = dexpr body;
               captures = List.map ~f:dexpr captures;
             }
-      | App { f; args; generic_args; impl } ->
+      | App { f; args; generic_args; impl; bounds_impls } ->
           let f = dexpr f in
           let args = List.map ~f:dexpr args in
           let impl = Option.map ~f:(dimpl_expr span) impl in
           let generic_args =
             List.filter_map ~f:(dgeneric_value span) generic_args
           in
-          App { f; args; generic_args; impl }
+          let bounds_impls = List.map ~f:(dimpl_expr span) bounds_impls in
+          App { f; args; generic_args; impl; bounds_impls }
       | _ -> .
       [@@inline_ands bindings_of dexpr - dbinding_mode]
 

--- a/engine/lib/phases/phase_specialize.ml
+++ b/engine/lib/phases/phase_specialize.ml
@@ -129,7 +129,15 @@ module Make (F : Features.T) =
                     let f = { f' with e = GlobalVar f } in
                     {
                       e with
-                      e = App { f; args = l; impl = None; generic_args = [] };
+                      e =
+                        App
+                          {
+                            f;
+                            args = l;
+                            impl = None;
+                            generic_args = [];
+                            bounds_impls = [];
+                          };
                     }
                 | [] -> super#visit_expr () e
                 | _ ->

--- a/engine/lib/print_rust.ml
+++ b/engine/lib/print_rust.ml
@@ -236,7 +236,7 @@ module Raw = struct
           match else_ with Some e -> !" else {" & pexpr e & !"}" | None -> !""
         in
         !"(" & !"if " & pexpr cond & !"{" & pexpr then_ & !"}" & else_ & !")"
-    | App { f; args; generic_args; impl = _ } ->
+    | App { f; args; generic_args; _ } ->
         let args = concat ~sep:!"," @@ List.map ~f:pexpr args in
         let generic_args =
           let f = pgeneric_value e.span in

--- a/engine/lib/side_effect_utils.ml
+++ b/engine/lib/side_effect_utils.ml
@@ -347,7 +347,7 @@ struct
                     m#plus (m#plus (no_lbs ethen) (no_lbs eelse)) effects
                   in
                   ({ e with e = If { cond; then_; else_ } }, effects))
-          | App { f; args; generic_args; impl } ->
+          | App { f; args; generic_args; impl; bounds_impls } ->
               HoistSeq.many env
                 (List.map ~f:(self#visit_expr env) (f :: args))
                 (fun l effects ->
@@ -356,7 +356,11 @@ struct
                     | f :: args -> (f, args)
                     | _ -> HoistSeq.err_hoist_invariant e.span Stdlib.__LOC__
                   in
-                  ({ e with e = App { f; args; generic_args; impl } }, effects))
+                  ( {
+                      e with
+                      e = App { f; args; generic_args; impl; bounds_impls };
+                    },
+                    effects ))
           | Literal _ -> (e, m#zero)
           | Block (inner, witness) ->
               HoistSeq.one env (self#visit_expr env inner) (fun inner effects ->

--- a/engine/lib/subtype.ml
+++ b/engine/lib/subtype.ml
@@ -157,12 +157,13 @@ struct
             then_ = dexpr then_;
             else_ = Option.map ~f:dexpr else_;
           }
-    | App { f; args; generic_args; impl } ->
+    | App { f; args; generic_args; bounds_impls; impl } ->
         App
           {
             f = dexpr f;
             args = List.map ~f:dexpr args;
             generic_args = List.map ~f:(dgeneric_value span) generic_args;
+            bounds_impls = List.map ~f:(dimpl_expr span) bounds_impls;
             impl = Option.map ~f:(dimpl_expr span) impl;
           }
     | Literal lit -> Literal lit


### PR DESCRIPTION
This PR fixes #668 by:
 - fetching impl expressions for bounds on function calls in THIR and inlining that information in the AST of hax' frontend;
 - propagate this information in the engine by adding a similar field on applications in the engine AST.

This change is required for #667, but this PR only adds the impl information internally. This PR does nothing with this information. That's why this PR doesn't add any test.