### PR TITLE
ci: fix push_readme.yml

### DIFF
--- a/.github/workflows/push_readme.yml
+++ b/.github/workflows/push_readme.yml
@@ -30,8 +30,9 @@ jobs:
         git config --local user.name "github-actions[bot]"
         git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git add -A
-        git commit -m "Readme update" \
-          && git push https://$USERNAME:$PUSH_HACSPEC_GITHUB_TOKEN@github.com/hacspec/hacspec.github.io
+        if git commit -m "Readme update"; then
+          git push https://$USERNAME:$PUSH_HACSPEC_GITHUB_TOKEN@github.com/hacspec/hacspec.github.io
+        fi
       env:
         PUSH_HACSPEC_GITHUB_TOKEN: ${{secrets.PUSH_HACSPEC_GITHUB_TOKEN}}
         USERNAME: github-actions[bot]


### PR DESCRIPTION
Use a `if` rather than a `&&`. The action was failing in case nothing changed in the `README.md` file. Now the action will just skip committing & pushing.