### PR TITLE
refactor(exporter): always use `State::param_env`

### DIFF
--- a/frontend/exporter/src/constant_utils.rs
+++ b/frontend/exporter/src/constant_utils.rs
@@ -362,7 +362,7 @@ pub trait ConstantExt<'tcx>: Sized + std::fmt::Debug {
 
                     // Solve the trait obligations
                     let parent_def_id = tcx.parent(ucv.def);
-                    let param_env = tcx.param_env(s.owner_id());
+                    let param_env = s.param_env();
                     let trait_refs =
                         solve_item_traits(s, param_env, parent_def_id, ucv.substs, None);
 
@@ -391,13 +391,13 @@ pub trait ConstantExt<'tcx>: Sized + std::fmt::Debug {
 }
 impl<'tcx> ConstantExt<'tcx> for rustc_middle::ty::Const<'tcx> {
     fn eval_constant<S: UnderOwnerState<'tcx>>(&self, s: &S) -> Option<Self> {
-        let evaluated = self.eval(s.base().tcx, get_param_env(s));
+        let evaluated = self.eval(s.base().tcx, s.param_env());
         (&evaluated != self).then_some(evaluated)
     }
 }
 impl<'tcx> ConstantExt<'tcx> for rustc_middle::mir::ConstantKind<'tcx> {
     fn eval_constant<S: UnderOwnerState<'tcx>>(&self, s: &S) -> Option<Self> {
-        let evaluated = self.eval(s.base().tcx, get_param_env(s));
+        let evaluated = self.eval(s.base().tcx, s.param_env());
         (&evaluated != self).then_some(evaluated)
     }
 }
@@ -505,7 +505,7 @@ pub(crate) fn const_value_reference_to_constant_expr<'tcx, S: UnderOwnerState<'t
     let tcx = s.base().tcx;
 
     // We use [try_destructure_mir_constant] to destructure the constant
-    let param_env = get_param_env(s);
+    let param_env = s.param_env();
     // We have to clone some values: it is a bit annoying, but I don't
     // manage to get the lifetimes working otherwise...
     let cvalue = rustc_middle::mir::ConstantKind::Val(val, ty);

--- a/frontend/exporter/src/rustc_utils.rs
+++ b/frontend/exporter/src/rustc_utils.rs
@@ -212,9 +212,14 @@ pub fn translate_span(span: rustc_span::Span, sess: &rustc_session::Session) -> 
     }
 }
 
-#[tracing::instrument(skip(s))]
-pub(crate) fn get_param_env<'tcx, S: UnderOwnerState<'tcx>>(s: &S) -> ty::ParamEnv<'tcx> {
-    s.base().tcx.param_env(s.owner_id())
+pub trait ParamEnv<'tcx> {
+    fn param_env(&self) -> ty::ParamEnv<'tcx>;
+}
+
+impl<'tcx, S: UnderOwnerState<'tcx>> ParamEnv<'tcx> for S {
+    fn param_env(&self) -> ty::ParamEnv<'tcx> {
+        self.base().tcx.param_env(self.owner_id())
+    }
 }
 
 #[tracing::instrument]

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -409,7 +409,7 @@ pub fn super_clause_to_clause_and_impl_expr<'tcx, S: UnderOwnerState<'tcx>>(
     let impl_expr = new_clause
         .as_predicate()
         .to_opt_poly_trait_pred()?
-        .impl_expr(s, get_param_env(s));
+        .impl_expr(s, s.param_env());
     let mut new_clause_no_binder = new_clause.sinto(s);
     new_clause_no_binder.id = original_predicate_id;
     Some((new_clause_no_binder, impl_expr, span.sinto(s)))

--- a/frontend/exporter/src/types/mir.rs
+++ b/frontend/exporter/src/types/mir.rs
@@ -213,7 +213,7 @@ pub(crate) fn get_function_from_def_id_and_substs<'tcx, S: BaseState<'tcx> + Has
     substs: rustc_middle::ty::subst::SubstsRef<'tcx>,
 ) -> (DefId, Vec<GenericArg>, Vec<ImplExpr>, Option<ImplExpr>) {
     let tcx = s.base().tcx;
-    let param_env = tcx.param_env(s.owner_id());
+    let param_env = s.param_env();
 
     // Retrieve the trait requirements for the **method**.
     // For instance, if we write:
@@ -852,7 +852,7 @@ pub enum AggregateKind {
     Tuple,
     #[custom_arm(rustc_middle::mir::AggregateKind::Adt(def_id, vid, substs, annot, fid) => {
         let adt_kind = s.base().tcx.adt_def(def_id).adt_kind().sinto(s);
-        let param_env = s.base().tcx.param_env(s.owner_id());
+        let param_env = s.param_env();
         let trait_refs = solve_item_traits(s, param_env, *def_id, substs, None);
         AggregateKind::Adt(
             def_id.sinto(s),
@@ -884,7 +884,7 @@ pub enum AggregateKind {
 
         // Solve the trait obligations. Note that we solve the parent
         let tcx = s.base().tcx;
-        let param_env = tcx.param_env(s.owner_id());
+        let param_env = s.param_env();
         let parent_substs = closure.parent_substs();
         let substs = tcx.mk_substs(parent_substs);
         // Retrieve the predicates from the parent (i.e., the function which calls

--- a/frontend/exporter/src/types/mir_traits.rs
+++ b/frontend/exporter/src/types/mir_traits.rs
@@ -8,7 +8,7 @@ pub fn get_trait_info<'tcx, S: UnderOwnerState<'tcx>>(
     assoc: &rustc_middle::ty::AssocItem,
 ) -> ImplExpr {
     let tcx = s.base().tcx;
-    let param_env = tcx.param_env(s.owner_id());
+    let param_env = s.param_env();
 
     // Retrieve the trait
     let tr_def_id = tcx.trait_of_item(assoc.def_id).unwrap();


### PR DESCRIPTION
This PR makes the exporter always use `s.param_env()` instead of `s.base().tcx.param_env(s.owner_id())`.

Status: any merge in hax is blocked by https://github.com/hacspec/hax/pull/679, I'm fixing that PR