### PR TITLE
Export discriminant values in `AdtDef`

### DIFF
--- a/frontend/exporter/src/index_vec.rs
+++ b/frontend/exporter/src/index_vec.rs
@@ -15,6 +15,9 @@ impl<I: Idx, T: Sized> IndexVec<I, T> {
     ) -> impl DoubleEndedIterator<Item = (I, T)> + ExactSizeIterator {
         rustc_index::IndexVec::from_raw(self.raw).into_iter_enumerated()
     }
+    pub fn into_iter(self) -> impl DoubleEndedIterator<Item = T> + ExactSizeIterator {
+        self.raw.into_iter()
+    }
 }
 
 impl<I: Idx, T: Sized> std::ops::Deref for IndexVec<I, T> {
@@ -45,6 +48,19 @@ impl<S, J: Idx, I: Idx + SInto<S, J>, U: Clone /*TODO: remove me?*/, T: SInto<S,
     fn sinto(&self, s: &S) -> IndexVec<J, U> {
         IndexVec {
             raw: self.raw.sinto(s),
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<I, T> FromIterator<T> for IndexVec<I, T>
+where
+    I: Idx,
+{
+    #[inline]
+    fn from_iter<It: IntoIterator<Item = T>>(iter: It) -> Self {
+        Self {
+            raw: Vec::from_iter(iter),
             _marker: std::marker::PhantomData,
         }
     }

--- a/frontend/exporter/src/index_vec.rs
+++ b/frontend/exporter/src/index_vec.rs
@@ -1,14 +1,36 @@
 use crate::prelude::*;
+use rustc_index::{Idx, IndexSlice};
 
 #[derive(
     Clone, Debug, Serialize, Deserialize, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord,
 )]
-pub struct IndexVec<I: rustc_index::Idx, T> {
+pub struct IndexVec<I: Idx, T> {
     pub raw: Vec<T>,
     _marker: std::marker::PhantomData<fn(_: &I)>,
 }
 
-impl<I: rustc_index::Idx, T> Into<IndexVec<I, T>> for rustc_index::IndexVec<I, T> {
+impl<I: Idx, T: Sized> IndexVec<I, T> {
+    pub fn into_iter_enumerated(
+        self,
+    ) -> impl DoubleEndedIterator<Item = (I, T)> + ExactSizeIterator {
+        rustc_index::IndexVec::from_raw(self.raw).into_iter_enumerated()
+    }
+}
+
+impl<I: Idx, T: Sized> std::ops::Deref for IndexVec<I, T> {
+    type Target = IndexSlice<I, T>;
+    fn deref(&self) -> &Self::Target {
+        Self::Target::from_raw(&self.raw)
+    }
+}
+
+impl<I: Idx, T: Sized> std::ops::DerefMut for IndexVec<I, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        Self::Target::from_raw_mut(&mut self.raw)
+    }
+}
+
+impl<I: Idx, T> Into<IndexVec<I, T>> for rustc_index::IndexVec<I, T> {
     fn into(self) -> IndexVec<I, T> {
         IndexVec {
             raw: self.raw,
@@ -17,34 +39,8 @@ impl<I: rustc_index::Idx, T> Into<IndexVec<I, T>> for rustc_index::IndexVec<I, T
     }
 }
 
-impl<I: rustc_index::Idx, T: Sized> std::ops::Deref for IndexVec<I, T> {
-    type Target = rustc_index::IndexSlice<I, T>;
-    fn deref(&self) -> &Self::Target {
-        Self::Target::from_raw(&self.raw)
-    }
-}
-
-impl<I: rustc_index::Idx, T: Sized> std::ops::DerefMut for IndexVec<I, T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        Self::Target::from_raw_mut(&mut self.raw)
-    }
-}
-
-impl<I: rustc_index::Idx, T: Sized> IndexVec<I, T> {
-    pub fn into_iter_enumerated(
-        self,
-    ) -> impl DoubleEndedIterator<Item = (I, T)> + ExactSizeIterator {
-        rustc_index::IndexVec::from_raw(self.raw).into_iter_enumerated()
-    }
-}
-
-impl<
-        S,
-        J: rustc_index::Idx,
-        I: rustc_index::Idx + SInto<S, J>,
-        U: Clone, /*TODO: remove me?*/
-        T: SInto<S, U>,
-    > SInto<S, IndexVec<J, U>> for rustc_index::IndexSlice<I, T>
+impl<S, J: Idx, I: Idx + SInto<S, J>, U: Clone /*TODO: remove me?*/, T: SInto<S, U>>
+    SInto<S, IndexVec<J, U>> for IndexSlice<I, T>
 {
     fn sinto(&self, s: &S) -> IndexVec<J, U> {
         IndexVec {

--- a/frontend/exporter/src/index_vec.rs
+++ b/frontend/exporter/src/index_vec.rs
@@ -30,6 +30,14 @@ impl<I: rustc_index::Idx, T: Sized> std::ops::DerefMut for IndexVec<I, T> {
     }
 }
 
+impl<I: rustc_index::Idx, T: Sized> IndexVec<I, T> {
+    pub fn into_iter_enumerated(
+        self,
+    ) -> impl DoubleEndedIterator<Item = (I, T)> + ExactSizeIterator {
+        rustc_index::IndexVec::from_raw(self.raw).into_iter_enumerated()
+    }
+}
+
 impl<
         S,
         J: rustc_index::Idx,


### PR DESCRIPTION
The discriminant is the runtime integer value used to identify a given enum variant. It's the value on which we do a `SwitchInt`. This PR makes hax export them.

I would have prefered a `discriminant` field in `VariantDef` but that would have been tricky to fit into the `SInto` scheme.