### PR TITLE
fix(ci): newer version of `ppx_deriving` (6.0.2) loops indefinitely

### DIFF
--- a/engine/utils/ocaml_of_json_schema/ocaml_of_json_schema.js
+++ b/engine/utils/ocaml_of_json_schema/ocaml_of_json_schema.js
@@ -532,8 +532,14 @@ end
 open ParseError
 `;
 
-    impl += ('type ' + items.map(({name, type}) =>
-        `${name} = ${type}\n${derive_items.length ? `[@@deriving ${derive_items.join(', ')}]` : ''}`).join('\nand ')
+    let derive_clause = derive_items.length ? `[@@deriving ${derive_items.join(', ')}]` : '';
+
+    impl += (
+        'type '
+            + items.map(({name, type}) =>
+                `${name} = ${type}\n`
+            ).join('\nand ')
+            + derive_clause
     );
     impl += ('');
     impl += ('let rec ' + items.map(({name, type, parse}) =>


### PR DESCRIPTION
The new version of ppx_deriving was extremely slow. ppx_deriving used to discard extra deriving annotations on type bundles, but it seems like it does not any longer. This PR fixes the JS script that generates the ocaml module `types.ml` so that it generates only one last annotation instead of one on each type. This fixes the issue (see the CI link below).

**old status:**
 - pinning ppx_deriving works, but I'm trying another fix to stop it from looping. Also, it seems like it's just extremely slow, not endlessly looping. My JS script generates a deriving clause per type, while only one at the end is enough. That is probably what is causing the extreme slowness.
 - I'm waiting to see if https://github.com/hacspec/hax/actions/runs/9347802540/job/25725550131 is green

**Status:**
The fix works, let's merge it