### PR TITLE
fix(README): always begin relative path with `./`, rewrite in action

### DIFF
--- a/.github/workflows/push_readme.yml
+++ b/.github/workflows/push_readme.yml
@@ -25,8 +25,13 @@ jobs:
           cat hax/README.md
         ) > website/README.md
         cd website
+
         # Replace the `🌐 Website` link to a GitHub link
         sed -i 's#.*🌐 Website.*#  <a href="https://github.com/hacspec/hax">🔗 GitHub</a> |#' README.md
+        
+        # Replace relative links to absolute links
+        sed -i 's|(\./|(https://github.com/hacspec/hax/tree/main/|g' README.md
+        
         git config --local user.name "github-actions[bot]"
         git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git add -A

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Here are some resources for learning more about hax:
  - [Book](https://hacspec.org/book) (work in progress)
     + [Quick start](https://hacspec.org/book/quick_start/intro.html)
     + [Tutorial](https://hacspec.org/book/tutorial/index.html)
- - [Examples](examples/): the [examples directory](examples/) contains
+ - [Examples](./examples/): the [examples directory](./examples/) contains
    a set of examples that show what hax can do for you.
 
 ## Usage


### PR DESCRIPTION
This PR makes relative links in the README always start with a `./`, and makes the "push README" action rewrite such path that starts with `./` into absolute links.

Closes #701 