### PR TITLE
fix: rename action for extracting ml-kem

### DIFF
--- a/.github/workflows/mlkem.yml
+++ b/.github/workflows/mlkem.yml
@@ -1,4 +1,4 @@
-name: Extract and TC Kyber
+name: Extract and TC ML-Kem
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  hax:
+  extract-mlkem:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group' }}
     runs-on: "ubuntu-latest"
 


### PR DESCRIPTION
This PR just renames the action that extracts ML-Kem from `hax` to `extract-mlkem`. Having this workflow named `hax` was very confusing (`git blame` blames myself sadly 😅).

Note: when merging this PR, we'll need to change the required jobs for merging in `main`