### PR TITLE
feat(hax): logging: enable tracing in release, add trait-related logs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ syn = { version = "1.0.107", features = [
 ] }
 tracing = { version = "0.1", features = [
      "max_level_trace",
-     "release_max_level_warn",
+     "release_max_level_trace",
 ] }
 tracing-subscriber = { version = "0.3", features = [
      "env-filter",

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -154,6 +154,7 @@ pub(crate) mod search_clause {
 
     #[extension_traits::extension(pub trait TraitPredicateExt)]
     impl<'tcx, S: UnderOwnerState<'tcx>> PolyTraitPredicate<'tcx> {
+        #[tracing::instrument(level = "trace", skip(s))]
         fn parents_trait_predicates(self, s: &S) -> Vec<(usize, PolyTraitPredicate<'tcx>)> {
             let tcx = s.base().tcx;
             let predicates = tcx
@@ -164,6 +165,7 @@ pub(crate) mod search_clause {
                 .enumerate()
                 .collect()
         }
+        #[tracing::instrument(level = "trace", skip(s))]
         fn associated_items_trait_predicates(
             self,
             s: &S,
@@ -191,6 +193,7 @@ pub(crate) mod search_clause {
                 .collect()
         }
 
+        #[tracing::instrument(level = "trace", skip(s))]
         fn path_to(
             self,
             s: &S,
@@ -265,6 +268,7 @@ impl ImplExprAtom {
     }
 }
 
+#[tracing::instrument(level = "trace", skip(s))]
 fn impl_exprs<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
     obligations: &Vec<
@@ -306,6 +310,7 @@ impl<'tcx> IntoImplExpr<'tcx> for rustc_middle::ty::PolyTraitPredicate<'tcx> {
     }
 }
 impl<'tcx> IntoImplExpr<'tcx> for rustc_middle::ty::PolyTraitRef<'tcx> {
+    #[tracing::instrument(level = "trace", skip(s))]
     fn impl_expr<S: UnderOwnerState<'tcx>>(
         &self,
         s: &S,

--- a/frontend/exporter/src/types/copied.rs
+++ b/frontend/exporter/src/types/copied.rs
@@ -1525,6 +1525,7 @@ pub enum AliasKind {
 }
 
 impl Alias {
+    #[tracing::instrument(level = "trace", skip(s))]
     fn from<'tcx, S: BaseState<'tcx> + HasOwnerId>(
         s: &S,
         alias_kind: &rustc_type_ir::sty::AliasKind,


### PR DESCRIPTION
This PR makes hax built with release mode ship with all logs available.

It also adds some logs on trait functions.