### PR TITLE
fix(backends/fstar): no `__marker_trait` if parent bounds

### DIFF
--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -1324,11 +1324,6 @@ struct
                        parent_bounds)
             items
         in
-        let fields =
-          if List.is_empty fields then
-            [ (F.lid [ "__marker_trait" ], pexpr (U.unit_expr e.span)) ]
-          else fields
-        in
         let parent_bounds_fields =
           List.map
             ~f:(fun (_impl_expr, impl_ident) ->
@@ -1336,6 +1331,11 @@ struct
             parent_bounds
         in
         let fields = parent_bounds_fields @ fields in
+        let fields =
+          if List.is_empty fields then
+            [ (F.lid [ "__marker_trait" ], pexpr (U.unit_expr e.span)) ]
+          else fields
+        in
         let body = F.term @@ F.AST.Record (None, fields) in
         let tcinst = F.term @@ F.AST.Var FStar_Parser_Const.tcinstance_lid in
         F.decls ~fsti:ctx.interface_mode ~attrs:[ tcinst ]


### PR DESCRIPTION
    Parent bounds are translated as record fields in F*.  Also, F* classes
    are records, and F* records cannot be empty. Thus, we insert a dummy
    field `__marker_trait` on empty traits (marker traits).

    On trait definitions, we were inserting this `__marker_trait` fields
    only when a trait had no parent bounds and no associated item (method,
    assoc. type, assoc fun.).

    On instance definitons, we were inserting `__marker_trait` when the
    trait was empty, disregarding parent bounds.

    This difference of treatments lead to TC issues in F*.

    This PR fixes this discrepancy.
