### PR TITLE
Generalize bounded ints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "duplicate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de78e66ac9061e030587b2a2e75cc88f22304913c907b11307bca737141230cb"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,7 +454,9 @@ dependencies = [
 name = "hax-bounded-integers"
 version = "0.1.0-pre.1"
 dependencies = [
+ "duplicate",
  "hax-lib",
+ "paste",
 ]
 
 [[package]]
@@ -966,9 +978,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "path-clean"

--- a/engine/lib/phases/phase_newtype_as_refinement.ml
+++ b/engine/lib/phases/phase_newtype_as_refinement.ml
@@ -25,6 +25,7 @@ module Make (F : Features.T) =
             | App { f = { e = GlobalVar f; _ }; args = [ inner ]; _ }
               when Ast.Global_ident.eq_name Hax_lib__Refinement__new f
                    || Ast.Global_ident.eq_name Hax_lib__RefineAs__into_checked f
+                   || Ast.Global_ident.eq_name Hax_lib__Refinement__get_mut f
                    || Ast.Global_ident.eq_name Hax_lib__Refinement__get f ->
                 { e with e = Ascription { typ = e.typ; e = inner } }
             | _ -> super#visit_expr () e

--- a/engine/names/src/lib.rs
+++ b/engine/names/src/lib.rs
@@ -50,7 +50,8 @@ fn dummy_hax_concrete_ident_wrapper<I: core::iter::Iterator<Item = u8>>(x: I, mu
     let _ = hax_lib::inline("");
     use hax_lib::{RefineAs, Refinement};
 
-    fn refinements<T: Refinement, U: RefineAs<T>>(x: T, y: U) -> T {
+    fn refinements<T: Refinement + Clone, U: RefineAs<T>>(x: T, y: U) -> T {
+        let _ = x.clone().get_mut();
         T::new(x.get());
         y.into_checked()
     }

--- a/hax-bounded-integers/Cargo.toml
+++ b/hax-bounded-integers/Cargo.toml
@@ -9,4 +9,6 @@ repository.workspace = true
 readme.workspace = true
 
 [dependencies]
+duplicate = "1.0.0"
 hax-lib.workspace = true
+paste = "1.0.15"

--- a/hax-bounded-integers/proofs/fstar/extraction/Hax_bounded_integers.Num_traits.fst
+++ b/hax-bounded-integers/proofs/fstar/extraction/Hax_bounded_integers.Num_traits.fst
@@ -3,8 +3,8 @@ module Hax_bounded_integers.Num_traits
 open Core
 open FStar.Mul
 
-class t_BitOps (v_Self: Type) = {
-  f_Output:Type;
+class t_BitOps (v_Self: Type0) = {
+  f_Output:Type0;
   f_count_ones_pre:v_Self -> bool;
   f_count_ones_post:v_Self -> u32 -> bool;
   f_count_ones:x0: v_Self
@@ -59,19 +59,8 @@ class t_BitOps (v_Self: Type) = {
     -> Prims.Pure f_Output (f_pow_pre x0 x1) (fun result -> f_pow_post x0 x1 result)
 }
 
-class t_Bounded (v_Self: Type) = {
-  f_min_value_pre:Prims.unit -> bool;
-  f_min_value_post:Prims.unit -> v_Self -> bool;
-  f_min_value:x0: Prims.unit
-    -> Prims.Pure v_Self (f_min_value_pre x0) (fun result -> f_min_value_post x0 result);
-  f_max_value_pre:Prims.unit -> bool;
-  f_max_value_post:Prims.unit -> v_Self -> bool;
-  f_max_value:x0: Prims.unit
-    -> Prims.Pure v_Self (f_max_value_pre x0) (fun result -> f_max_value_post x0 result)
-}
-
-class t_CheckedAdd (v_Self: Type) (v_Rhs: Type) = {
-  f_Output:Type;
+class t_CheckedAdd (v_Self: Type0) (v_Rhs: Type0) = {
+  f_Output:Type0;
   f_checked_add_pre:v_Self -> v_Rhs -> bool;
   f_checked_add_post:v_Self -> v_Rhs -> Core.Option.t_Option f_Output -> bool;
   f_checked_add:x0: v_Self -> x1: v_Rhs
@@ -80,8 +69,8 @@ class t_CheckedAdd (v_Self: Type) (v_Rhs: Type) = {
         (fun result -> f_checked_add_post x0 x1 result)
 }
 
-class t_CheckedDiv (v_Self: Type) (v_Rhs: Type) = {
-  f_Output:Type;
+class t_CheckedDiv (v_Self: Type0) (v_Rhs: Type0) = {
+  f_Output:Type0;
   f_checked_div_pre:v_Self -> v_Rhs -> bool;
   f_checked_div_post:v_Self -> v_Rhs -> Core.Option.t_Option f_Output -> bool;
   f_checked_div:x0: v_Self -> x1: v_Rhs
@@ -90,8 +79,8 @@ class t_CheckedDiv (v_Self: Type) (v_Rhs: Type) = {
         (fun result -> f_checked_div_post x0 x1 result)
 }
 
-class t_CheckedMul (v_Self: Type) (v_Rhs: Type) = {
-  f_Output:Type;
+class t_CheckedMul (v_Self: Type0) (v_Rhs: Type0) = {
+  f_Output:Type0;
   f_checked_mul_pre:v_Self -> v_Rhs -> bool;
   f_checked_mul_post:v_Self -> v_Rhs -> Core.Option.t_Option f_Output -> bool;
   f_checked_mul:x0: v_Self -> x1: v_Rhs
@@ -100,8 +89,8 @@ class t_CheckedMul (v_Self: Type) (v_Rhs: Type) = {
         (fun result -> f_checked_mul_post x0 x1 result)
 }
 
-class t_CheckedNeg (v_Self: Type) = {
-  f_Output:Type;
+class t_CheckedNeg (v_Self: Type0) = {
+  f_Output:Type0;
   f_checked_neg_pre:v_Self -> bool;
   f_checked_neg_post:v_Self -> Core.Option.t_Option f_Output -> bool;
   f_checked_neg:x0: v_Self
@@ -110,8 +99,8 @@ class t_CheckedNeg (v_Self: Type) = {
         (fun result -> f_checked_neg_post x0 result)
 }
 
-class t_CheckedSub (v_Self: Type) (v_Rhs: Type) = {
-  f_Output:Type;
+class t_CheckedSub (v_Self: Type0) (v_Rhs: Type0) = {
+  f_Output:Type0;
   f_checked_sub_pre:v_Self -> v_Rhs -> bool;
   f_checked_sub_post:v_Self -> v_Rhs -> Core.Option.t_Option f_Output -> bool;
   f_checked_sub:x0: v_Self -> x1: v_Rhs
@@ -120,8 +109,8 @@ class t_CheckedSub (v_Self: Type) (v_Rhs: Type) = {
         (fun result -> f_checked_sub_post x0 x1 result)
 }
 
-class t_FromBytes (v_Self: Type) = {
-  f_BYTES:Type;
+class t_FromBytes (v_Self: Type0) = {
+  f_BYTES:Type0;
   f_from_le_bytes_pre:f_BYTES -> bool;
   f_from_le_bytes_post:f_BYTES -> v_Self -> bool;
   f_from_le_bytes:x0: f_BYTES
@@ -132,43 +121,43 @@ class t_FromBytes (v_Self: Type) = {
     -> Prims.Pure v_Self (f_from_be_bytes_pre x0) (fun result -> f_from_be_bytes_post x0 result)
 }
 
-class t_NumOps (v_Self: Type) (v_Rhs: Type) (v_Output: Type) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_3420555054487092457:Core.Ops.Arith.t_Add v_Self
+class t_NumOps (v_Self: Type0) (v_Rhs: Type0) (v_Output: Type0) = {
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_9126539072073536218:Core.Ops.Arith.t_Add v_Self
     v_Rhs;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_16858356355397389837:Core.Ops.Arith.t_Sub v_Self
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_9784678892199232396:Core.Ops.Arith.t_Sub v_Self
     v_Rhs;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_3009625865770964073:Core.Ops.Arith.t_Mul v_Self
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_7005199110250618039:Core.Ops.Arith.t_Mul v_Self
     v_Rhs;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_9111207129981210576:Core.Ops.Arith.t_Div v_Self
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_12366019628759357413:Core.Ops.Arith.t_Div v_Self
     v_Rhs;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_16804214316696687705:Core.Ops.Arith.t_Rem v_Self
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_11859756759858186302:Core.Ops.Arith.t_Rem v_Self
     v_Rhs
 }
 
-class t_One (v_Self: Type) = {
+class t_One (v_Self: Type0) = {
   f_one_pre:Prims.unit -> bool;
   f_one_post:Prims.unit -> v_Self -> bool;
   f_one:x0: Prims.unit -> Prims.Pure v_Self (f_one_pre x0) (fun result -> f_one_post x0 result)
 }
 
-class t_ToBytes (v_Self: Type) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_4530633244223603628:t_FromBytes v_Self;
+class t_ToBytes (v_Self: Type0) = {
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_3732703090464998751:t_FromBytes v_Self;
   f_to_le_bytes_pre:v_Self -> bool;
-  f_to_le_bytes_post:v_Self -> v_4530633244223603628.f_BYTES -> bool;
+  f_to_le_bytes_post:v_Self -> v_3732703090464998751.f_BYTES -> bool;
   f_to_le_bytes:x0: v_Self
-    -> Prims.Pure v_4530633244223603628.f_BYTES
+    -> Prims.Pure v_3732703090464998751.f_BYTES
         (f_to_le_bytes_pre x0)
         (fun result -> f_to_le_bytes_post x0 result);
   f_to_be_bytes_pre:v_Self -> bool;
-  f_to_be_bytes_post:v_Self -> v_4530633244223603628.f_BYTES -> bool;
+  f_to_be_bytes_post:v_Self -> v_3732703090464998751.f_BYTES -> bool;
   f_to_be_bytes:x0: v_Self
-    -> Prims.Pure v_4530633244223603628.f_BYTES
+    -> Prims.Pure v_3732703090464998751.f_BYTES
         (f_to_be_bytes_pre x0)
         (fun result -> f_to_be_bytes_post x0 result)
 }
 
-class t_WrappingAdd (v_Self: Type) (v_Rhs: Type) = {
-  f_Output:Type;
+class t_WrappingAdd (v_Self: Type0) (v_Rhs: Type0) = {
+  f_Output:Type0;
   f_wrapping_add_pre:v_Self -> v_Rhs -> bool;
   f_wrapping_add_post:v_Self -> v_Rhs -> f_Output -> bool;
   f_wrapping_add:x0: v_Self -> x1: v_Rhs
@@ -177,8 +166,8 @@ class t_WrappingAdd (v_Self: Type) (v_Rhs: Type) = {
         (fun result -> f_wrapping_add_post x0 x1 result)
 }
 
-class t_WrappingDiv (v_Self: Type) (v_Rhs: Type) = {
-  f_Output:Type;
+class t_WrappingDiv (v_Self: Type0) (v_Rhs: Type0) = {
+  f_Output:Type0;
   f_wrapping_div_pre:v_Self -> v_Rhs -> bool;
   f_wrapping_div_post:v_Self -> v_Rhs -> f_Output -> bool;
   f_wrapping_div:x0: v_Self -> x1: v_Rhs
@@ -187,8 +176,8 @@ class t_WrappingDiv (v_Self: Type) (v_Rhs: Type) = {
         (fun result -> f_wrapping_div_post x0 x1 result)
 }
 
-class t_WrappingMul (v_Self: Type) (v_Rhs: Type) = {
-  f_Output:Type;
+class t_WrappingMul (v_Self: Type0) (v_Rhs: Type0) = {
+  f_Output:Type0;
   f_wrapping_mul_pre:v_Self -> v_Rhs -> bool;
   f_wrapping_mul_post:v_Self -> v_Rhs -> f_Output -> bool;
   f_wrapping_mul:x0: v_Self -> x1: v_Rhs
@@ -197,8 +186,8 @@ class t_WrappingMul (v_Self: Type) (v_Rhs: Type) = {
         (fun result -> f_wrapping_mul_post x0 x1 result)
 }
 
-class t_WrappingSub (v_Self: Type) (v_Rhs: Type) = {
-  f_Output:Type;
+class t_WrappingSub (v_Self: Type0) (v_Rhs: Type0) = {
+  f_Output:Type0;
   f_wrapping_sub_pre:v_Self -> v_Rhs -> bool;
   f_wrapping_sub_post:v_Self -> v_Rhs -> f_Output -> bool;
   f_wrapping_sub:x0: v_Self -> x1: v_Rhs
@@ -207,44 +196,43 @@ class t_WrappingSub (v_Self: Type) (v_Rhs: Type) = {
         (fun result -> f_wrapping_sub_post x0 x1 result)
 }
 
-class t_Zero (v_Self: Type) = {
+class t_Zero (v_Self: Type0) = {
   f_zero_pre:Prims.unit -> bool;
   f_zero_post:Prims.unit -> v_Self -> bool;
   f_zero:x0: Prims.unit -> Prims.Pure v_Self (f_zero_pre x0) (fun result -> f_zero_post x0 result)
 }
 
-class t_MachineInt (v_Self: Type) (v_Output: Type) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_957087622381469234:Core.Marker.t_Copy v_Self;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_7243498280507755391:t_Bounded v_Self;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_9802961870013064174:Core.Cmp.t_PartialOrd v_Self
+class t_MachineInt (v_Self: Type0) (v_Output: Type0) = {
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_11581440318597584651:Core.Marker.t_Copy v_Self;
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_12866954522599331834:Core.Cmp.t_PartialOrd v_Self
     v_Self;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_15372362079243870652:Core.Cmp.t_Ord v_Self;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_1959006841676202949:Core.Cmp.t_PartialEq v_Self
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_13035911912416111195:Core.Cmp.t_Ord v_Self;
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_12632649257025169145:Core.Cmp.t_PartialEq v_Self
     v_Self;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_8995075768394296398:Core.Cmp.t_Eq v_Self;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_2630392019625310516:t_Zero v_Self;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_6913784476497246329:t_One v_Self;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_9936546819275964215:Core.Ops.Bit.t_Not v_Self;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_1531387235085686842:t_NumOps v_Self
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_8099741844003281729:Core.Cmp.t_Eq v_Self;
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_9841570312332416173:t_Zero v_Self;
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_12668241202577409386:t_One v_Self;
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_9487321769118300762:Core.Ops.Bit.t_Not v_Self;
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_1980884762883925305:t_NumOps v_Self
     v_Self
     v_Output;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_3786882699227749486:Core.Ops.Bit.t_BitAnd v_Self
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_13929479875548649875:Core.Ops.Bit.t_BitAnd v_Self
     v_Self;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_8095144530696857283:Core.Ops.Bit.t_BitOr v_Self
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_1708325062211865233:Core.Ops.Bit.t_BitOr v_Self
     v_Self;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_15313863003467220491:Core.Ops.Bit.t_BitXor v_Self
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_1501688608269502122:Core.Ops.Bit.t_BitXor v_Self
     v_Self;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_13306778606414288955:Core.Ops.Bit.t_Shl v_Self
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_15083490293093561556:Core.Ops.Bit.t_Shl v_Self
     v_Self;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_2333720355461387358:Core.Ops.Bit.t_Shr v_Self
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_9065931548762825726:Core.Ops.Bit.t_Shr v_Self
     v_Self;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_10133521522977299931:t_CheckedAdd v_Self v_Self;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_16509367665728242671:t_CheckedSub v_Self v_Self;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_261087305577220356:t_CheckedMul v_Self v_Self;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_4808020806666262858:t_CheckedDiv v_Self v_Self;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_18005178388944789845:t_WrappingAdd v_Self v_Self;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_11471591230230619611:t_WrappingSub v_Self v_Self;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_5940229659009370734:t_WrappingMul v_Self v_Self;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_1640938766960073185:t_WrappingDiv v_Self v_Self;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_12477248635475532096:t_BitOps v_Self
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_5052970308637232515:t_CheckedAdd v_Self v_Self;
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_739902999637339236:t_CheckedSub v_Self v_Self;
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_15323401662629887609:t_CheckedMul v_Self v_Self;
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_8119502507145032897:t_CheckedDiv v_Self v_Self;
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_12846047806852469117:t_WrappingAdd v_Self v_Self;
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_12408554086330550784:t_WrappingSub v_Self v_Self;
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_8633193508996485932:t_WrappingMul v_Self v_Self;
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_16339457892016115661:t_WrappingDiv v_Self v_Self;
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_12348120774285878195:t_BitOps v_Self
 }

--- a/hax-bounded-integers/proofs/fstar/extraction/Hax_bounded_integers.fst
+++ b/hax-bounded-integers/proofs/fstar/extraction/Hax_bounded_integers.fst
@@ -37,4 +37,31 @@ let t_BoundedU64 (v_MIN v_MAX: u64) = x: u64{x >=. v_MIN && x <=. v_MAX}
 let t_BoundedU8 (v_MIN v_MAX: u8) = x: u8{x >=. v_MIN && x <=. v_MAX}
 
 ///Bounded usize integers. This struct enforces the invariant that values are greater or equal to `MIN` and less or equal to `MAX`.
-unfold let t_BoundedUsize (v_MIN v_MAX: usize) = x: usize{x >=. v_MIN && x <=. v_MAX}
+let t_BoundedUsize (v_MIN v_MAX: usize) = x: usize{x >=. v_MIN && x <=. v_MAX}
+
+let t_Test (v_B: usize) =
+  x:
+  i16
+    { x >=. (Core.Ops.Arith.Neg.neg (cast (v_B <: usize) <: i16) <: i16) &&
+      x <=. (cast (v_B <: usize) <: i16) }
+
+let tests (_: Prims.unit) : Prims.unit =
+  let (zzz: t_Test (sz 123)):t_Test (sz 123) = (-122s) <: t_Test (sz 123) in
+  let zzz:t_Test (sz 123) = Core.Ops.Arith.f_add_assign #(t_Test (sz 123)) #i16 zzz 32s in
+  let (x: t_BoundedU8 0uy 5uy):t_BoundedU8 0uy 5uy = 2uy <: t_BoundedU8 0uy 5uy in
+  let (y: t_BoundedU8 5uy 10uy):t_BoundedU8 5uy 10uy = x +! x <: t_BoundedU8 5uy 10uy in
+  let _:u8 = x >>! 3uy in
+  let _:u8 = x >>! (3uy <: t_BoundedU8 0uy 5uy) in
+  let _:u8 = x /! y in
+  let _:u8 = x *! y in
+  let _:u8 = x +! y in
+  let _:u8 = y -! x in
+  let _:u8 = x /! 1uy in
+  let _:u8 = x *! 1uy in
+  let _:u8 = x +! 1uy in
+  let _:u8 = x -! 1uy in
+  let _:u8 = 4uy /! y in
+  let _:u8 = 4uy *! y in
+  let _:u8 = 4uy +! y in
+  let _:u8 = 4uy -! y in
+  ()

--- a/hax-bounded-integers/proofs/fstar/extraction/Hax_bounded_integers.fst
+++ b/hax-bounded-integers/proofs/fstar/extraction/Hax_bounded_integers.fst
@@ -38,30 +38,3 @@ let t_BoundedU8 (v_MIN v_MAX: u8) = x: u8{x >=. v_MIN && x <=. v_MAX}
 
 ///Bounded usize integers. This struct enforces the invariant that values are greater or equal to `MIN` and less or equal to `MAX`.
 let t_BoundedUsize (v_MIN v_MAX: usize) = x: usize{x >=. v_MIN && x <=. v_MAX}
-
-let t_Test (v_B: usize) =
-  x:
-  i16
-    { x >=. (Core.Ops.Arith.Neg.neg (cast (v_B <: usize) <: i16) <: i16) &&
-      x <=. (cast (v_B <: usize) <: i16) }
-
-let tests (_: Prims.unit) : Prims.unit =
-  let (zzz: t_Test (sz 123)):t_Test (sz 123) = (-122s) <: t_Test (sz 123) in
-  let zzz:t_Test (sz 123) = Core.Ops.Arith.f_add_assign #(t_Test (sz 123)) #i16 zzz 32s in
-  let (x: t_BoundedU8 0uy 5uy):t_BoundedU8 0uy 5uy = 2uy <: t_BoundedU8 0uy 5uy in
-  let (y: t_BoundedU8 5uy 10uy):t_BoundedU8 5uy 10uy = x +! x <: t_BoundedU8 5uy 10uy in
-  let _:u8 = x >>! 3uy in
-  let _:u8 = x >>! (3uy <: t_BoundedU8 0uy 5uy) in
-  let _:u8 = x /! y in
-  let _:u8 = x *! y in
-  let _:u8 = x +! y in
-  let _:u8 = y -! x in
-  let _:u8 = x /! 1uy in
-  let _:u8 = x *! 1uy in
-  let _:u8 = x +! 1uy in
-  let _:u8 = x -! 1uy in
-  let _:u8 = 4uy /! y in
-  let _:u8 = 4uy *! y in
-  let _:u8 = 4uy +! y in
-  let _:u8 = 4uy -! y in
-  ()

--- a/hax-bounded-integers/src/lib.rs
+++ b/hax-bounded-integers/src/lib.rs
@@ -363,7 +363,7 @@ const _: () = {
 #[test]
 fn tests() {
     refinement_int!(
-        Test<const B: usize>(i16, 2, |x| x >= -(B as i16) && x <= (B as i16))
+        Test<const B: usize>(i16, 2, |x| B < 32768 && x >= -(B as i16) && x <= (B as i16))
     );
 
     use hax_lib::*;

--- a/hax-bounded-integers/src/num_traits.rs
+++ b/hax-bounded-integers/src/num_traits.rs
@@ -31,10 +31,10 @@ pub trait NumOps<Rhs = Self, Output = Self>:
 {
 }
 
-pub trait Bounded {
-    fn min_value() -> Self;
-    fn max_value() -> Self;
-}
+// pub trait Bounded {
+//     fn min_value() -> Self;
+//     fn max_value() -> Self;
+// }
 
 pub trait WrappingAdd<Rhs = Self> {
     type Output;
@@ -95,7 +95,7 @@ pub trait ToBytes: FromBytes {
 
 pub trait MachineInt<Output>:
     Copy
-    + Bounded
+    // + Bounded
     + PartialOrd
     + Ord
     + PartialEq

--- a/hax-lib-macros/src/lib.rs
+++ b/hax-lib-macros/src/lib.rs
@@ -836,6 +836,9 @@ pub fn refinement_type(mut attr: pm::TokenStream, item: pm::TokenStream) -> pm::
                 fn get(self) -> Self::InnerType {
                     self.0
                 }
+                fn get_mut(&mut self) -> &mut Self::InnerType {
+                    &mut self.0
+                }
                 fn invariant(#ret_binder: Self::InnerType) -> bool {
                     #phi
                 }

--- a/hax-lib/src/lib.rs
+++ b/hax-lib/src/lib.rs
@@ -156,6 +156,8 @@ pub trait Refinement {
     fn new(x: Self::InnerType) -> Self;
     /// Destructor for the refined type
     fn get(self) -> Self::InnerType;
+    /// Gets a mutable reference to a refinement
+    fn get_mut(&mut self) -> &mut Self::InnerType;
     /// Tests wether a value satisfies the refinement
     fn invariant(value: Self::InnerType) -> bool;
 }

--- a/proof-libs/fstar/core/Core.Num.fsti
+++ b/proof-libs/fstar/core/Core.Num.fsti
@@ -45,3 +45,53 @@ val impl__u8__from_str_radix: string -> u32 -> Core.Result.t_Result u8 Core.Num.
 val impl__usize__ilog2: i32 -> u32 
 val impl__usize__leading_zeros: usize -> u32
 
+open Core.Ops.Arith
+unfold instance add_assign_num_refined_refined t ($phi1 $phi2: int_t t -> bool)
+  : t_AddAssign (x: int_t t {phi1 x}) (y: int_t t {phi2 y}) = {
+    f_add_assign_pre = (fun (x: int_t t {phi1 x}) (y: int_t t {phi2 y}) -> phi1 (x +. y));
+    f_add_assign_post = (fun x y r -> x +. y = r);
+    f_add_assign = (fun x y -> x +. y);
+  }
+unfold instance add_assign_num_lhs_refined t ($phi1: int_t t -> bool)
+  : t_AddAssign (x: int_t t {phi1 x}) (y: int_t t) = {
+    f_add_assign_pre = (fun (x: int_t t {phi1 x}) (y: int_t t) -> phi1 (x +. y));
+    f_add_assign_post = (fun x y r -> x +. y = r);
+    f_add_assign = (fun x y -> x +. y);
+  }
+unfold instance add_assign_num_rhs_refined t ($phi1: int_t t -> bool)
+  : t_AddAssign (x: int_t t) (y: int_t t {phi1 y}) = {
+    f_add_assign_pre = (fun (x: int_t t) (y: int_t t {phi1 y}) -> true);
+    f_add_assign_post = (fun x y r -> x +. y = r);
+    f_add_assign = (fun x y -> x +. y);
+  }
+unfold instance add_assign_num t
+  : t_AddAssign (x: int_t t) (y: int_t t) = {
+    f_add_assign_pre = (fun (x: int_t t) (y: int_t t) -> true);
+    f_add_assign_post = (fun x y r -> x +. y = r);
+    f_add_assign = (fun x y -> x +. y);
+  }
+
+unfold instance sub_assign_num_refined_refined t ($phi1 $phi2: int_t t -> bool)
+  : t_SubAssign (x: int_t t {phi1 x}) (y: int_t t {phi2 y}) = {
+    f_sub_assign_pre = (fun (x: int_t t {phi1 x}) (y: int_t t {phi2 y}) -> phi1 (x -. y));
+    f_sub_assign_post = (fun x y r -> x -. y = r);
+    f_sub_assign = (fun x y -> x -. y);
+  }
+unfold instance sub_assign_num_lhs_refined t ($phi1: int_t t -> bool)
+  : t_SubAssign (x: int_t t {phi1 x}) (y: int_t t) = {
+    f_sub_assign_pre = (fun (x: int_t t {phi1 x}) (y: int_t t) -> phi1 (x -. y));
+    f_sub_assign_post = (fun x y r -> x -. y = r);
+    f_sub_assign = (fun x y -> x -. y);
+  }
+unfold instance sub_assign_num_rhs_refined t ($phi1: int_t t -> bool)
+  : t_SubAssign (x: int_t t) (y: int_t t {phi1 y}) = {
+    f_sub_assign_pre = (fun (x: int_t t) (y: int_t t {phi1 y}) -> true);
+    f_sub_assign_post = (fun x y r -> x -. y = r);
+    f_sub_assign = (fun x y -> x -. y);
+  }
+unfold instance sub_assign_num t
+  : t_SubAssign (x: int_t t) (y: int_t t) = {
+    f_sub_assign_pre = (fun (x: int_t t) (y: int_t t) -> true);
+    f_sub_assign_post = (fun x y r -> x -. y = r);
+    f_sub_assign = (fun x y -> x -. y);
+  }

--- a/proof-libs/fstar/core/Core.Ops.Arith.fsti
+++ b/proof-libs/fstar/core/Core.Ops.Arith.fsti
@@ -33,3 +33,16 @@ class t_Div self rhs = {
    f_div_post: self -> rhs -> f_Output -> bool;
    f_div: x:self -> y:rhs -> Pure f_Output (f_div_pre x y) (fun r -> f_div_post x y r);
 }
+
+class t_AddAssign self rhs = {
+  f_add_assign_pre: self -> rhs -> bool;
+  f_add_assign_post: self -> rhs -> self -> bool;
+  f_add_assign: x:self -> y:rhs -> Pure self (f_add_assign_pre x y) (fun r -> f_add_assign_post x y r);
+}
+
+class t_SubAssign self rhs = {
+  f_sub_assign_pre: self -> rhs -> bool;
+  f_sub_assign_post: self -> rhs -> self -> bool;
+  f_sub_assign: x:self -> y:rhs -> Pure self (f_sub_assign_pre x y) (fun r -> f_sub_assign_post x y r);
+}
+


### PR DESCRIPTION
This PR refactors the macros in `hax-bounded-integers` and exposes a new `refinement_int` macro that behaves liuke `refinement_type`, but also derives "all" instances we'd expect from an integer type.