### PR TITLE
feat(nix): reduce closure size for hax-engine

### DIFF
--- a/engine/default.nix
+++ b/engine/default.nix
@@ -128,4 +128,4 @@
     };
   };
 in
-  hax-engine
+  hax-engine.overrideAttrs (_: {name = "hax-engine";})

--- a/flake.nix
+++ b/flake.nix
@@ -62,7 +62,17 @@
           inherit rustc ocamlformat rustfmt fstar hax-env;
           hax-engine = pkgs.callPackage ./engine {
             hax-rust-frontend = packages.hax-rust-frontend.unwrapped;
-            hax-engine-names-extract = packages.hax-rust-frontend.hax-engine-names-extract;
+            # `hax-engine-names-extract` extracts Rust names but also
+            # some informations about `impl`s when names are `impl`
+            # blocks. That includes some span information, which
+            # includes full paths to Rust sources. Sometimes those
+            # Rust sources happens to be in the Nix store. That
+            # creates useless dependencies, this wrapper below takes
+            # care of removing those extra depenedencies.
+            hax-engine-names-extract = pkgs.writeScriptBin "hax-engine-names-extract" ''
+              #!${pkgs.stdenv.shell}
+              ${packages.hax-rust-frontend.hax-engine-names-extract}/bin/hax-engine-names-extract | sed 's|/nix/store/\(.\{6\}\)|/nix_store/\1-|g'
+            '';
             inherit rustc;
           };
           hax-rust-frontend = pkgs.callPackage ./cli {


### PR DESCRIPTION
This PR:
 - remove some rustc runtime dependencies in the nix build of hax-engine;
 - renames the nix derivation of the hax engine.

After this PR, `nix bundle --bundler github:ralismark/nix-appimage ".#hax-engine.bin"` produces a 21M self contained portable AppImage!