### PR TITLE
fix(engine/fstar): use `Base.String.hash` instead of `String.hash`

### DIFF
--- a/.github/workflows/install_and_test.yml
+++ b/.github/workflows/install_and_test.yml
@@ -51,7 +51,6 @@ jobs:
       env:
         CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
       run: |
-        nix profile install nixpkgs#cachix nixpkgs#jq
         nix build .# .#fstar --json \
           | jq -r '.[].outputs | to_entries[].value' \
           | cachix push hax

--- a/.github/workflows/install_and_test.yml
+++ b/.github/workflows/install_and_test.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: DeterminateSystems/nix-installer-action@main
+    - uses: cachix/cachix-action@v15
+      with:
+        name: hax
+        skipPush: true
     - uses: DeterminateSystems/magic-nix-cache-action@main
     - name: Build
       run: nix build -L

--- a/engine/backends/fstar/fstar-surface-ast/z.ml
+++ b/engine/backends/fstar/fstar-surface-ast/z.ml
@@ -5,7 +5,7 @@ let of_t = Base.Int.to_string
 
 let compare = String.compare
 let pp_print = pp
-let hash = String.hash
+let hash = Base.String.hash
 
 
 let to_int: String.t -> Base.Int.t = Base.Int.of_string


### PR DESCRIPTION
This is a small fix in the engine so that we use `Base.String.hash` instead of `String.hash`, which is only available in most recent versions of OCaml.

This is required to fix a failing `setup.sh` job