### PR TITLE
Add an option to downgrade errors to warnings

### DIFF
--- a/cli/driver/src/exporter.rs
+++ b/cli/driver/src/exporter.rs
@@ -285,6 +285,7 @@ impl From<ExtractionCallbacks> for hax_frontend_exporter_options::Options {
     fn from(opts: ExtractionCallbacks) -> hax_frontend_exporter_options::Options {
         hax_frontend_exporter_options::Options {
             inline_macro_calls: opts.inline_macro_calls,
+            downgrade_errors: false,
         }
     }
 }

--- a/cli/options/src/lib.rs
+++ b/cli/options/src/lib.rs
@@ -462,6 +462,7 @@ impl From<Options> for hax_frontend_exporter_options::Options {
     fn from(opts: Options) -> hax_frontend_exporter_options::Options {
         hax_frontend_exporter_options::Options {
             inline_macro_calls: opts.inline_macro_calls,
+            downgrade_errors: false,
         }
     }
 }

--- a/frontend/exporter/options/src/lib.rs
+++ b/frontend/exporter/options/src/lib.rs
@@ -63,7 +63,9 @@ impl Namespace {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct Options {
     pub inline_macro_calls: Vec<Namespace>,
+    /// Whether to emit errors or downgrade them as warnings.
+    pub downgrade_errors: bool,
 }

--- a/frontend/exporter/src/utils.rs
+++ b/frontend/exporter/src/utils.rs
@@ -59,10 +59,27 @@ macro_rules! report {
     };
 }
 
-macro_rules! error { ($($tt:tt)*) => {$crate::utils::report!(error, $($tt)*)} }
-#[allow(unused_macros)]
+macro_rules! fatal {
+    ($s:ident $($tt:tt)*) => {
+        if $s.base().options.downgrade_errors {
+            // Report the error but don't tell rustc.
+            $crate::utils::report!(warn, $s $($tt)*);
+            panic!("Fatal error");
+        } else {
+            $crate::utils::report!(fatal, $s $($tt)*);
+        }
+    }
+}
+macro_rules! error {
+    ($s:ident $($tt:tt)*) => {
+        if $s.base().options.downgrade_errors {
+            $crate::utils::report!(warn, $s $($tt)*);
+        } else {
+            $crate::utils::report!(error, $s $($tt)*);
+        }
+    }
+}
 macro_rules! warning { ($($tt:tt)*) => {$crate::utils::report!(warn, $($tt)*)} }
-macro_rules! fatal { ($($tt:tt)*) => {$crate::utils::report!(fatal, $($tt)*)} }
 
 pub(crate) use format_with_context;
 pub(crate) use internal_helpers::_span_verb_base;


### PR DESCRIPTION
In Charon we want to extract a crate even when there are errors. To achieve that, we use `catch_unwind` when translating any item. Except sometimes this isn't enough, because hax's use of `struct_fatal` and `struct_err` informs rustc that there was an error, which causes Charon to fail. This PR adds an option to avoid that.