### PR TITLE
 exporter: make it need nightly only when feature `rustc` is on

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Test
         run: cargo test --workspace --exclude hax-engine-names-extract --verbose
 
+      - name: Test `hax-frontend-exporter` with feature `rustc` off
+        run: cargo check -p hax-frontend-exporter --no-default-features --verbose
+
   no-std-lib:
     runs-on: ubuntu-latest
     steps:

--- a/frontend/exporter/src/lib.rs
+++ b/frontend/exporter/src/lib.rs
@@ -1,8 +1,8 @@
-#![feature(trait_alias)]
 #![allow(rustdoc::private_intra_doc_links)]
 #![cfg_attr(feature = "rustc", feature(type_changing_struct_update))]
 #![cfg_attr(feature = "rustc", feature(macro_metavar_expr))]
 #![cfg_attr(feature = "rustc", feature(concat_idents))]
+#![cfg_attr(feature = "rustc", feature(trait_alias))]
 #![cfg_attr(feature = "rustc", feature(rustc_private))]
 
 macro_rules! cfg_feature_rustc {

--- a/frontend/exporter/src/lib.rs
+++ b/frontend/exporter/src/lib.rs
@@ -1,8 +1,8 @@
-#![feature(concat_idents)]
 #![feature(trait_alias)]
 #![allow(rustdoc::private_intra_doc_links)]
 #![cfg_attr(feature = "rustc", feature(type_changing_struct_update))]
 #![cfg_attr(feature = "rustc", feature(macro_metavar_expr))]
+#![cfg_attr(feature = "rustc", feature(concat_idents))]
 #![cfg_attr(feature = "rustc", feature(rustc_private))]
 
 macro_rules! cfg_feature_rustc {

--- a/frontend/exporter/src/lib.rs
+++ b/frontend/exporter/src/lib.rs
@@ -1,8 +1,8 @@
 #![feature(concat_idents)]
 #![feature(trait_alias)]
-#![feature(macro_metavar_expr)]
 #![allow(rustdoc::private_intra_doc_links)]
 #![cfg_attr(feature = "rustc", feature(type_changing_struct_update))]
+#![cfg_attr(feature = "rustc", feature(macro_metavar_expr))]
 #![cfg_attr(feature = "rustc", feature(rustc_private))]
 
 macro_rules! cfg_feature_rustc {

--- a/frontend/exporter/src/lib.rs
+++ b/frontend/exporter/src/lib.rs
@@ -2,8 +2,6 @@
 #![feature(trait_alias)]
 #![feature(type_changing_struct_update)]
 #![feature(macro_metavar_expr)]
-#![feature(if_let_guard)]
-#![feature(let_chains)]
 #![allow(rustdoc::private_intra_doc_links)]
 #![cfg_attr(feature = "rustc", feature(rustc_private))]
 

--- a/frontend/exporter/src/lib.rs
+++ b/frontend/exporter/src/lib.rs
@@ -1,8 +1,8 @@
 #![feature(concat_idents)]
 #![feature(trait_alias)]
-#![feature(type_changing_struct_update)]
 #![feature(macro_metavar_expr)]
 #![allow(rustdoc::private_intra_doc_links)]
+#![cfg_attr(feature = "rustc", feature(type_changing_struct_update))]
 #![cfg_attr(feature = "rustc", feature(rustc_private))]
 
 macro_rules! cfg_feature_rustc {

--- a/frontend/exporter/src/lib.rs
+++ b/frontend/exporter/src/lib.rs
@@ -4,8 +4,6 @@
 #![feature(macro_metavar_expr)]
 #![feature(if_let_guard)]
 #![feature(let_chains)]
-#![allow(incomplete_features)]
-#![feature(specialization)]
 #![allow(rustdoc::private_intra_doc_links)]
 #![cfg_attr(feature = "rustc", feature(rustc_private))]
 

--- a/frontend/exporter/src/state.rs
+++ b/frontend/exporter/src/state.rs
@@ -235,8 +235,13 @@ pub fn with_owner_id<'tcx, THIR, MIR>(
 }
 
 pub trait BaseState<'tcx> = HasBase<'tcx> + Clone + IsState<'tcx>;
+
 /// State of anything below a `owner_id`
 pub trait UnderOwnerState<'tcx> = BaseState<'tcx> + HasOwnerId;
+
+/// While translating expressions, we expect to always have a THIR
+/// body and an `owner_id` in the state
+pub trait ExprState<'tcx> = UnderOwnerState<'tcx> + HasThir<'tcx>;
 
 impl ImplInfos {
     fn from<'tcx>(base: Base<'tcx>, did: rustc_hir::def_id::DefId) -> Self {

--- a/frontend/exporter/src/types/copied.rs
+++ b/frontend/exporter/src/types/copied.rs
@@ -1322,11 +1322,6 @@ impl<'tcx, S: ExprState<'tcx>> SInto<S, Stmt> for rustc_middle::thir::StmtId {
     }
 }
 
-/// While translating expressions, we expect to always have a THIR
-/// body and an `owner_id` in the state
-#[cfg(feature = "rustc")]
-pub trait ExprState<'tcx> = UnderOwnerState<'tcx> + HasThir<'tcx>;
-
 #[cfg(feature = "rustc")]
 impl<'tcx, S: ExprState<'tcx>> SInto<S, Expr> for rustc_middle::thir::Expr<'tcx> {
     fn sinto(&self, s: &S) -> Expr {


### PR DESCRIPTION
This PR removes some use of nightly features or feature-gate them, based on the `rustc` feature introduced by #743.
This is useful for Rust projects that depend on the ASTs of hax but not on librustc_driver (e.g. Testify).

Fixes #749