### PR TITLE
fix(frontend): kill `crate_type` in `HaxMeta`

### DIFF
--- a/cli/driver/src/exporter.rs
+++ b/cli/driver/src/exporter.rs
@@ -252,14 +252,9 @@ impl Callbacks for ExtractionCallbacks {
 
             let cg_metadata = opts.cg.metadata[0].clone();
             let crate_name = opts.crate_name.clone().unwrap();
-            let crate_type = match &opts.crate_types[..] {
-                [crate_type] => format!("{}", crate_type),
-                _ => panic!(),
-            };
 
             let output_dir = compiler.sess.io.output_dir.clone().unwrap();
-            let haxmeta_path =
-                output_dir.join(format!("{crate_type}{crate_name}-{cg_metadata}.haxmeta",));
+            let haxmeta_path = output_dir.join(format!("{crate_name}-{cg_metadata}.haxmeta",));
 
             let mut file = BufWriter::new(File::create(&haxmeta_path).unwrap());
 
@@ -271,7 +266,6 @@ impl Callbacks for ExtractionCallbacks {
                         convert_thir(&self.clone().into(), self.macro_calls.clone(), tcx);
                     let haxmeta: HaxMeta<Body> = HaxMeta {
                         crate_name,
-                        crate_type,
                         cg_metadata,
                         externs,
                         impl_infos,

--- a/hax-types/src/driver_api.rs
+++ b/hax-types/src/driver_api.rs
@@ -19,7 +19,6 @@ pub enum HaxDriverMessage {
 #[derive(Debug, Clone)]
 pub struct HaxMeta<Body: hax_frontend_exporter::IsBody> {
     pub crate_name: String,
-    pub crate_type: String,
     pub cg_metadata: String,
     pub externs: Vec<PathBuf>,
     pub items: Vec<hax_frontend_exporter::Item<Body>>,


### PR DESCRIPTION
This commit removes the field `crate_type` in the struct `HaxMeta`, and changes the path of `haxmeta` files.

Originally, my intention was to name the `haxmeta` files very closely to `rmeta` files, but the `haxmeta` don't have anything to do with crate types.

Also, the code was assuming a crate would have only one type, which is false, as the type suggests... That was making the frontend panic on certain crates.