### PR TITLE
feat(hax-lib): allow requires & ensures on `&mut` inputs functions

### DIFF
--- a/hax-lib-macros/src/lib.rs
+++ b/hax-lib-macros/src/lib.rs
@@ -4,10 +4,12 @@ mod syn_ext;
 mod utils;
 
 mod prelude {
+    pub use crate::syn_ext::*;
     pub use proc_macro as pm;
     pub use proc_macro2::*;
     pub use proc_macro_error::*;
     pub use quote::*;
+    pub use std::collections::HashSet;
     pub use syn::spanned::Spanned;
     pub use syn::{visit_mut::VisitMut, *};
 
@@ -17,7 +19,6 @@ mod prelude {
 }
 
 use prelude::*;
-use syn_ext::*;
 use utils::*;
 
 /// Include this item in the Hax translation.
@@ -188,6 +189,9 @@ pub fn decreases(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStrea
 
 /// Add a logical precondition to a function.
 // Note you can use the `forall` and `exists` operators. (TODO: commented out for now, see #297)
+/// In the case of a function that has one or more `&mut` inputs, in
+/// the `ensures` clause, you can refer to such an `&mut` input `x` as
+/// `x` for its "past" value and `future(x)` for its "future" value.
 ///
 /// # Example
 ///

--- a/hax-lib-macros/src/utils.rs
+++ b/hax-lib-macros/src/utils.rs
@@ -88,9 +88,10 @@ fn merge_generics(x: Generics, y: Generics) -> Generics {
     }
 }
 
-/// Transform every `x: &mut T` input into `x: &T` in a signature
-fn unmut_references_in_inputs(sig: &mut Signature) -> bool {
-    let mut any_mut_ref = false;
+/// Transform every `x: &mut T` input into `x: &T` in a signature, and
+/// returns a list of such transformed `x: &T` inputs
+fn unmut_references_in_inputs(sig: &mut Signature) -> Vec<FnArg> {
+    let mut mutable_inputs = vec![];
     for input in &mut sig.inputs {
         if let Some(mutability) = match input {
             FnArg::Receiver(syn::Receiver {
@@ -109,11 +110,73 @@ fn unmut_references_in_inputs(sig: &mut Signature) -> bool {
             }
             _ => None,
         } {
-            any_mut_ref |= mutability.is_some();
-            *mutability = None;
+            if mutability.is_some() {
+                *mutability = None;
+                mutable_inputs.push(input.clone());
+            }
         }
     }
-    any_mut_ref
+    mutable_inputs
+}
+
+/// Expects a `FnArg` to be a simple variable pattern
+fn expect_fn_arg_var_pat(arg: &FnArg) -> Option<(String, syn::Type)> {
+    match arg {
+        FnArg::Receiver(recv) => Some(("self".into(), *recv.ty.clone())),
+        FnArg::Typed(pat_type) => match &*pat_type.pat {
+            syn::Pat::Wild(_) => Some(("".into(), *pat_type.ty.clone())),
+            syn::Pat::Ident(pat_ident) => {
+                Some((format!("{}", pat_ident.ident), *pat_type.ty.clone()))
+            }
+            _ => None,
+        },
+    }
+}
+
+/// Rewrites `future(x)` nodes in an expression when (1) `x` is an
+/// ident and (2) the ident `x` is contained in the HashSet.
+struct RewriteFuture(HashSet<String>);
+impl VisitMut for RewriteFuture {
+    fn visit_expr_mut(&mut self, e: &mut Expr) {
+        syn::visit_mut::visit_expr_mut(self, e);
+        if let Expr::Call(call) = e {
+            if call.func.is_ident("future") {
+                let help_message = || match self.0.iter().next() {
+                    None => format!(" In the context, there is no `&mut` input."),
+                    Some(var) => {
+                        format!(" For example, in the context you can write `future({var})`.")
+                    }
+                };
+                let error = match call.args.iter().collect::<Vec<_>>().as_slice() {
+                    [arg] => {
+                        if let Some(arg) = arg.expect_ident() {
+                            let arg = format!("{}", arg);
+                            if self.0.contains(&arg) {
+                                let arg = create_future_ident(&arg);
+                                *e = parse_quote! {#arg};
+                                return;
+                            }
+                            format!("Cannot find an input `{arg}` of type `&mut _`. In the context, `future` can be called on the following inputs: {:?}.", self.0)
+                        } else {
+                            format!(
+                                "`future` can only be called with an `&mut` input name.{}",
+                                help_message()
+                            )
+                        }
+                    }
+                    _ => format!(
+                        "`future` can only be called with one argument: a `&mut` input name.{}",
+                        help_message()
+                    ),
+                };
+                *e = parse_quote! {::std::compile_error!(#error)};
+            }
+        }
+    }
+}
+
+fn create_future_ident(name: &str) -> syn::Ident {
+    proc_macro2::Ident::new(&format!("{name}_future"), proc_macro2::Span::call_site())
 }
 
 /// Common logic when generating a function decoration
@@ -125,11 +188,7 @@ pub fn make_fn_decoration(
     self_type: Option<Type>,
 ) -> (TokenStream, AttrPayload) {
     let uid = ItemUid::fresh();
-    let any_mut_ref = unmut_references_in_inputs(&mut signature);
-    if any_mut_ref && matches!(kind, FnDecorationKind::Ensures { .. }) {
-        panic!("For now, ensures clause don't work on function that have `&mut` inputs (see https://github.com/hacspec/hax/issues/290)")
-    }
-
+    let mut_ref_inputs = unmut_references_in_inputs(&mut signature);
     let self_ident: Ident = syn::parse_quote! {self_};
     let mut rewriter = RewriteSelf::new(self_ident, self_type);
     rewriter.visit_expr_mut(&mut phi);
@@ -143,7 +202,28 @@ pub fn make_fn_decoration(
                     syn::ReturnType::Default => quote! {()},
                     syn::ReturnType::Type(_, t) => quote! {#t},
                 };
-                sig.inputs.push(syn::parse_quote! {#ret_binder: #output});
+                let mut_ref_inputs = mut_ref_inputs
+                    .iter()
+                    .map(|mut_ref_input| {
+                        expect_fn_arg_var_pat(mut_ref_input).expect(
+                            "Every `&mut` input of a function annotated with a `ensures` clause is expected to be a simple variable pattern.",
+                        )
+                    });
+                let mut rewrite_future =
+                    RewriteFuture(mut_ref_inputs.clone().map(|x| x.0).collect());
+                rewrite_future.visit_expr_mut(&mut phi);
+                let (pats, tys): (Vec<_>, Vec<_>) = mut_ref_inputs
+                    .map(|(name, ty)| {
+                        (
+                            create_future_ident(&name).to_token_stream(),
+                            ty.to_token_stream(),
+                        )
+                    })
+                    .chain([(ret_binder.to_token_stream(), output)].into_iter())
+                    .unzip();
+
+                sig.inputs
+                    .push(syn::parse_quote! {(#(#pats),*): (#(#tys),*)});
             }
             if let Some(generics) = generics {
                 sig.generics = merge_generics(generics, sig.generics);

--- a/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
@@ -237,6 +237,19 @@ let add3 (x y z: u32)
                 let _:Prims.unit = temp_0_ in
                 result >. 32ul <: bool)) = (x +! y <: u32) +! z
 
+let swap_and_mut_req_ens (x y: u32)
+    : Prims.Pure (u32 & u32 & u32)
+      (requires x <. 40ul && y <. 300ul)
+      (ensures
+        fun temp_0_ ->
+          let x_future, y_future, result:(u32 & u32 & u32) = temp_0_ in
+          x_future =. y && y_future =. x && result =. (x +! y <: u32)) =
+  let x0:u32 = x in
+  let x:u32 = y in
+  let y:u32 = x0 in
+  let hax_temp_output:u32 = x +! y in
+  x, y, hax_temp_output <: (u32 & u32 & u32)
+
 type t_Foo = {
   f_x:u32;
   f_y:f_y: u32{f_y >. 3ul};

--- a/tests/attributes/src/lib.rs
+++ b/tests/attributes/src/lib.rs
@@ -11,6 +11,15 @@ fn add3(x: u32, y: u32, z: u32) -> u32 {
     x + y + z
 }
 
+#[hax::requires(*x < 40 && *y < 300)]
+#[hax::ensures(|result| *future(x) == *y && *future(y) == *x && result == *x + *y)]
+fn swap_and_mut_req_ens(x: &mut u32, y: &mut u32) -> u32 {
+    let x0 = *x;
+    *x = *y;
+    *y = x0;
+    *x + *y
+}
+
 #[hax::lemma]
 fn add3_lemma(x: u32) -> Proof<{ x <= 10 || x >= u32_max / 3 || add3(x, x, x) == x * 3 }> {}
 


### PR DESCRIPTION
Fixes #755 and fixes #290.

This allows this kind of post-conditions:
```rust
#[hax::requires(*x < 40 && *y < 300)]
#[hax::ensures(|result| *future(x) == *y && *future(y) == *x && result == *x + *y)]
fn swap_and_mut_req_ens(x: &mut u32, y: &mut u32) -> u32 {
    let x0 = *x;
    *x = *y;
    *y = x0;
    *x + *y
}
```