### PR TITLE
feat(book): fix checkboxes

### DIFF
--- a/book/default.nix
+++ b/book/default.nix
@@ -9,6 +9,7 @@ stdenv.mkDerivation {
   buildPhase = ''
             mdbook build
             mdbook build archive -d ../book/archive
+            bash ./postprocess.sh
           '';
   installPhase = "mv book $out";
 }

--- a/book/postprocess.sh
+++ b/book/postprocess.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env sh
+
+# This file replaces `<strong>user-checkable</strong>` with actual
+# checkboxes and adds CSS to the generated HTML.
+
+for file in $(find . -name '*.html'); do
+    sed -i 's|<strong>user-checkable</strong>|<input type="checkbox" class="user-checkable"/>|g' "$file"
+done
+
+for css in $(find . -name 'general.css'); do
+    cat >> "$css" <<-EOF
+input.user-checkable {
+    transform: scale(1.5);
+    margin-right: 8px;
+    margin-left: 8px;
+}
+
+ul:has(> li > .user-checkable) {
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+}
+li:has(> .user-checkable) {
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+}
+EOF
+done


### PR DESCRIPTION
The book uses custom checkboxes in the quickstart chapter. When we moved the book to this repo (see
https://github.com/hacspec/hax/pull/729), we dropped the theme.

mdbook documentation suggest (see
https://rust-lang.github.io/mdBook/format/theme/index.html) copying and patching the default theme.

Since here it's such a small change, I added a small script that post-process the HTML instead.