### PR TITLE
fix: precondition constraints should be of the shape `true => pred`

### DIFF
--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -1210,11 +1210,16 @@ struct
                 | TIFn ty ->
                     let weakest =
                       let h kind =
-                        Attrs.associated_fns kind i.ti_attrs |> List.hd
-                          |> Option.map ~f:(fun attr -> (attr, [%eq: Attr_payloads.AssocRole.t] kind Requires))
+                        Attrs.associated_fns kind i.ti_attrs
+                        |> List.hd
+                        |> Option.map ~f:(fun attr ->
+                               ( attr,
+                                 [%eq: Attr_payloads.AssocRole.t] kind Requires
+                               ))
                       in
                       Option.first_some (h Ensures) (h Requires)
-                      |> Option.map ~f:(fun ((generics, params, expr), is_req) ->
+                      |> Option.map
+                           ~f:(fun ((generics, params, expr), is_req) ->
                              let dummy_self =
                                List.find generics.params
                                  ~f:[%matches? { kind = GPType _; _ }]
@@ -1286,7 +1291,8 @@ struct
                         FStarBinder.of_named_typ p.pat.span name p.typ
                       in
                       weakest
-                      |> Option.map ~f:(fun (generics, binders, expr, is_req) -> (generics, List.map ~f binders, expr, is_req))
+                      |> Option.map ~f:(fun (generics, binders, expr, is_req) ->
+                             (generics, List.map ~f binders, expr, is_req))
                       |> Option.map
                            ~f:(fun (generics, binders, (expr : expr), is_req) ->
                              let result_ident = mk_fresh "pred" in
@@ -1305,7 +1311,8 @@ struct
                              let result =
                                F.AST.Refine
                                  ( FStarBinder.to_binder result_bd,
-                                   (if is_req then Fn.flip else Fn.id) F.implies result expr )
+                                   (if is_req then Fn.flip else Fn.id)
+                                     F.implies result expr )
                                |> F.term
                              in
                              F.AST.Product

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -1211,9 +1211,10 @@ struct
                     let weakest =
                       let h kind =
                         Attrs.associated_fns kind i.ti_attrs |> List.hd
+                          |> Option.map ~f:(fun attr -> (attr, [%eq: Attr_payloads.AssocRole.t] kind Requires))
                       in
                       Option.first_some (h Ensures) (h Requires)
-                      |> Option.map ~f:(fun (generics, params, expr) ->
+                      |> Option.map ~f:(fun ((generics, params, expr), is_req) ->
                              let dummy_self =
                                List.find generics.params
                                  ~f:[%matches? { kind = GPType _; _ }]
@@ -1244,7 +1245,7 @@ struct
                                List.map ~f:(renamer#visit_param ()) params
                              in
                              let expr = renamer#visit_expr () expr in
-                             (generics, params, expr))
+                             (generics, params, expr, is_req))
                     in
                     let ty = pty e.span ty in
                     let ty =
@@ -1252,7 +1253,7 @@ struct
                         let idents_visitor = U.Reducers.collect_local_idents in
                         idents_visitor#visit_trait_item () i
                         :: (Option.map
-                              ~f:(fun (generics, params, expr) ->
+                              ~f:(fun (generics, params, expr, _) ->
                                 [
                                   idents_visitor#visit_generics () generics;
                                   idents_visitor#visit_expr () expr;
@@ -1285,9 +1286,9 @@ struct
                         FStarBinder.of_named_typ p.pat.span name p.typ
                       in
                       weakest
-                      |> Option.map ~f:(List.map ~f |> map_snd3)
+                      |> Option.map ~f:(fun (generics, binders, expr, is_req) -> (generics, List.map ~f binders, expr, is_req))
                       |> Option.map
-                           ~f:(fun (generics, binders, (expr : expr)) ->
+                           ~f:(fun (generics, binders, (expr : expr), is_req) ->
                              let result_ident = mk_fresh "pred" in
                              let result_bd =
                                FStarBinder.of_named_typ expr.span result_ident
@@ -1304,7 +1305,7 @@ struct
                              let result =
                                F.AST.Refine
                                  ( FStarBinder.to_binder result_bd,
-                                   F.implies result expr )
+                                   (if is_req then Fn.flip else Fn.id) F.implies result expr )
                                |> F.term
                              in
                              F.AST.Product

--- a/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
@@ -90,9 +90,9 @@ class t_Operation (v_Self: Type0) = {
   f_double_pre:x: u8
     -> pred:
       bool
-        { pred ==>
-          (Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) <=
-          (127 <: Hax_lib.Int.t_Int) };
+        { (Rust_primitives.Hax.Int.from_machine x <: Hax_lib.Int.t_Int) <=
+          (127 <: Hax_lib.Int.t_Int) ==>
+          pred };
   f_double_post:x: u8 -> result: u8
     -> pred:
       bool
@@ -104,15 +104,18 @@ class t_Operation (v_Self: Type0) = {
   f_double:x0: u8 -> Prims.Pure u8 (f_double_pre x0) (fun result -> f_double_post x0 result)
 }
 
-class t_Identity (v_Self: Type0) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_8099741844003281729:Core.Cmp.t_Eq v_Self;
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_12632649257025169145:Core.Cmp.t_PartialEq v_Self
-    v_Self;
-  f_identity_pre:self___: v_Self -> pred: bool{pred ==> true};
-  f_identity_post:self___: v_Self -> result: v_Self -> pred: bool{pred ==> result =. self___};
-  f_identity:x0: v_Self
-    -> Prims.Pure v_Self (f_identity_pre x0) (fun result -> f_identity_post x0 result)
+class t_TraitWithRequiresAndEnsures (v_Self: Type0) = {
+  f_method_pre:self___: v_Self -> x: u8 -> pred: bool{x <. 100uy ==> pred};
+  f_method_post:self___: v_Self -> x: u8 -> r: u8 -> pred: bool{pred ==> r >. 88uy};
+  f_method:x0: v_Self -> x1: u8
+    -> Prims.Pure u8 (f_method_pre x0 x1) (fun result -> f_method_post x0 x1 result)
 }
+
+let test
+      (#v_T: Type0)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: t_TraitWithRequiresAndEnsures v_T)
+      (x: v_T)
+    : u8 = (f_method #v_T #FStar.Tactics.Typeclasses.solve x 99uy <: u8) -! 88uy
 
 type t_ViaAdd = | ViaAdd : t_ViaAdd
 

--- a/tests/attributes/src/lib.rs
+++ b/tests/attributes/src/lib.rs
@@ -190,10 +190,14 @@ mod pre_post_on_traits_and_impls {
     }
 
     #[hax_lib::attributes]
-    trait Identity: Eq + PartialEq {
-        #[ensures(|result| result == self)]
-        #[requires(true)]
-        fn identity(&self) -> Self;
+    trait TraitWithRequiresAndEnsures {
+        #[requires(x < 100)]
+        #[ensures(|r| r > 88)]
+        fn method(&self, x: u8) -> u8;
+    }
+
+    fn test<T: TraitWithRequiresAndEnsures>(x: T) -> u8 {
+        x.method(99) - 88
     }
 }
 


### PR DESCRIPTION
PR #790 was outputting `pre_instance => pre_trait` for precondition.
We need the opposite: the precondition of the instance should always be implied by the one defined on the trait.