### PR TITLE
Add json format option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,7 @@ dependencies = [
  "cargo_metadata",
  "clap",
  "colored",
+ "extension-traits",
  "hax-frontend-exporter",
  "hax-frontend-exporter-options",
  "hax-lib-macros-types",

--- a/cli/subcommands/Cargo.toml
+++ b/cli/subcommands/Cargo.toml
@@ -42,6 +42,7 @@ serde-jsonlines = "0.5.0"
 prettyplease = "0.2.20"
 syn = { version = "2.*", features = ["full"] }
 cargo_metadata.workspace = true
+extension-traits = "1.0.1"
 
 [build-dependencies]
 serde.workspace = true

--- a/cli/subcommands/src/cargo_hax.rs
+++ b/cli/subcommands/src/cargo_hax.rs
@@ -365,6 +365,11 @@ fn compute_haxmeta_files(options: &Options) -> (Vec<EmitHaxMetaMessage>, i32) {
         if !explicit_color_flag && std::io::stderr().is_terminal() {
             cmd.args([COLOR_FLAG, "always"]);
         }
+        const MSG_FMT_FLAG: &str = "--message-format";
+        let explicit_msg_fmt_flag = options.cargo_flags.iter().any(|flag| flag == MSG_FMT_FLAG);
+        if !explicit_msg_fmt_flag && options.message_format == MessageFormat::Json {
+            cmd.args([MSG_FMT_FLAG, "json"]);
+        }
         cmd.stderr(std::process::Stdio::piped());
         if !options.no_custom_target_directory {
             cmd.env("CARGO_TARGET_DIR", target_dir("hax"));

--- a/cli/subcommands/src/cargo_hax.rs
+++ b/cli/subcommands/src/cargo_hax.rs
@@ -131,7 +131,7 @@ use hax_types::diagnostics::report::ReportCtx;
 impl HaxMessage {
     fn report(self, message_format: MessageFormat, rctx: Option<&mut ReportCtx>) {
         match message_format {
-            MessageFormat::Json => eprintln!("{}", serde_json::to_string(&self).unwrap()),
+            MessageFormat::Json => println!("{}", serde_json::to_string(&self).unwrap()),
             MessageFormat::Human => self.report_styled(rctx),
         }
     }

--- a/cli/subcommands/src/cargo_hax.rs
+++ b/cli/subcommands/src/cargo_hax.rs
@@ -82,7 +82,7 @@ const ENGINE_BINARY_NOT_FOUND: &str = "The binary [hax-engine] was not found in 
 /// found, detect whether nodejs is available, download the JS-compiled
 /// engine and use it.
 #[allow(unused_variables, unreachable_code)]
-fn find_hax_engine() -> process::Command {
+fn find_hax_engine(message_format: MessageFormat) -> process::Command {
     use which::which;
 
     std::env::var("HAX_ENGINE_BINARY")
@@ -119,7 +119,7 @@ fn find_hax_engine() -> process::Command {
             HaxMessage::EngineNotFound {
                 is_opam_setup_correctly: is_opam_setup_correctly(),
             }
-            .report_styled(None);
+            .report(message_format, None);
             std::process::exit(2);
         })
 }
@@ -129,6 +129,12 @@ use hax_types::diagnostics::report::ReportCtx;
 
 #[extension_traits::extension(trait ExtHaxMessage)]
 impl HaxMessage {
+    fn report(self, message_format: MessageFormat, rctx: Option<&mut ReportCtx>) {
+        match message_format {
+            MessageFormat::Json => eprintln!("{}", serde_json::to_string(&self).unwrap()),
+            MessageFormat::Human => self.report_styled(rctx),
+        }
+    }
     fn report_styled(self, rctx: Option<&mut ReportCtx>) {
         let renderer = Renderer::styled();
         match self {
@@ -188,13 +194,14 @@ fn run_engine(
     working_dir: PathBuf,
     manifest_dir: PathBuf,
     backend: &BackendOptions,
+    message_format: MessageFormat,
 ) -> bool {
     let engine_options = EngineOptions {
         backend: backend.clone(),
         input: haxmeta.items,
         impl_infos: haxmeta.impl_infos,
     };
-    let mut engine_subprocess = find_hax_engine()
+    let mut engine_subprocess = find_hax_engine(message_format)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .spawn()
@@ -264,7 +271,7 @@ fn run_engine(
                         diagnostic,
                         working_dir: working_dir.clone(),
                     }
-                    .report_styled(Some(&mut rctx));
+                    .report(message_format, Some(&mut rctx));
                 }
                 FromEngine::File(file) => {
                     if backend.dry_run {
@@ -273,7 +280,7 @@ fn run_engine(
                         let path = out_dir.join(&file.path);
                         std::fs::create_dir_all(&path.parent().unwrap()).unwrap();
                         std::fs::write(&path, file.contents).unwrap();
-                        HaxMessage::WroteFile { path }.report_styled(None)
+                        HaxMessage::WroteFile { path }.report(message_format, None)
                     }
                 }
                 FromEngine::DebugString(debug) => {
@@ -403,7 +410,7 @@ fn compute_haxmeta_files(options: &Options) -> (Vec<EmitHaxMetaMessage>, i32) {
         .expect("`driver-hax-frontend-exporter`: could not start?");
 
     let exit_code = if !status.success() {
-        HaxMessage::CargoBuildFailure.report_styled(None);
+        HaxMessage::CargoBuildFailure.report(options.message_format, None);
         status.code().unwrap_or(254)
     } else {
         0
@@ -449,7 +456,7 @@ fn run_command(options: &Options, haxmeta_files: Vec<EmitHaxMetaMessage>) -> boo
                 HaxMessage::WarnExperimentalBackend {
                     backend: backend.backend.clone(),
                 }
-                .report_styled(None);
+                .report(options.message_format, None);
             }
 
             let mut error = false;
@@ -461,7 +468,14 @@ fn run_command(options: &Options, haxmeta_files: Vec<EmitHaxMetaMessage>) -> boo
             {
                 let haxmeta: HaxMeta<Body> = HaxMeta::read(fs::File::open(&path).unwrap());
 
-                error = error || run_engine(haxmeta, working_dir, manifest_dir, &backend);
+                error = error
+                    || run_engine(
+                        haxmeta,
+                        working_dir,
+                        manifest_dir,
+                        &backend,
+                        options.message_format,
+                    );
             }
             error
         }

--- a/engine/utils/ocaml_of_json_schema/ocaml_of_json_schema.js
+++ b/engine/utils/ocaml_of_json_schema/ocaml_of_json_schema.js
@@ -76,7 +76,16 @@ let variantNameOf = s => {
 };
 let typeNameOf = s => s.replace(/[A-Z]/g, (l, i) => `${i?'_':''}${l.toLowerCase()}`);
 let fieldNameOf = s => {
-    if (['then', 'if', 'end', 'open', 'include', 'begin', 'fun', 'initializer'].includes(s))
+    let ocaml_keywords = [ "and", "as", "assert", "asr", "begin", "class", "constraint",
+                           "do", "done", "downto", "else", "end", "exception", "external",
+                           "false", "for", "fun", "function", "functor", "if", "in",
+                           "include", "inherit", "initializer", "land", "lazy", "let",
+                           "lor", "lsl", "lsr", "lxor", "match", "method", "mod", "module",
+                           "mutable", "new", "nonrec", "object", "of", "open", "or",
+                           "private", "rec", "sig", "struct", "then", "to", "true", "try",
+                           "type", "val", "virtual", "when", "while", "with"
+                         ];
+    if (ocaml_keywords.includes(s))
         return s + "'";
     return s;
 };

--- a/hax-types/src/cli_options.rs
+++ b/hax-types/src/cli_options.rs
@@ -439,6 +439,17 @@ pub struct Options {
     /// this behavior.
     #[arg(long)]
     pub no_custom_target_directory: bool,
+
+    /// Diagnostic format.
+    #[arg(long, default_value = "human")]
+    pub message_format: MessageFormat,
+}
+
+#[derive_group(Serializers)]
+#[derive(JsonSchema, ValueEnum, Debug, Clone, Copy)]
+pub enum MessageFormat {
+    Human,
+    Json,
 }
 
 impl NormalizePaths for Command {

--- a/hax-types/src/cli_options.rs
+++ b/hax-types/src/cli_options.rs
@@ -433,7 +433,7 @@ pub struct Options {
     #[arg(long = "deps")]
     pub deps: bool,
 
-    /// By default, hax use `$CARGO_TARGET_DIR/hax` as target folder,
+    /// By default, hax uses `$CARGO_TARGET_DIR/hax` as target folder,
     /// to avoid recompilation when working both with `cargo hax` and
     /// `cargo build` (or, e.g. `rust-analyzer`). This option disables
     /// this behavior.

--- a/hax-types/src/cli_options.rs
+++ b/hax-types/src/cli_options.rs
@@ -440,13 +440,14 @@ pub struct Options {
     #[arg(long)]
     pub no_custom_target_directory: bool,
 
-    /// Diagnostic format.
+    /// Diagnostic format. Sets `cargo`'s `--message-format` as well,
+    /// if not present.
     #[arg(long, default_value = "human")]
     pub message_format: MessageFormat,
 }
 
 #[derive_group(Serializers)]
-#[derive(JsonSchema, ValueEnum, Debug, Clone, Copy)]
+#[derive(JsonSchema, ValueEnum, Debug, Clone, Copy, Eq, PartialEq)]
 pub enum MessageFormat {
     Human,
     Json,

--- a/hax-types/src/diagnostics/message.rs
+++ b/hax-types/src/diagnostics/message.rs
@@ -3,22 +3,37 @@ use crate::prelude::*;
 
 #[derive_group(Serializers)]
 #[derive(Debug, Clone, JsonSchema)]
+#[repr(u8)]
 pub enum HaxMessage {
     Diagnostic {
         diagnostic: super::Diagnostics,
         working_dir: PathBuf,
-    },
+    } = 254,
     EngineNotFound {
         is_opam_setup_correctly: bool,
-    },
+    } = 0,
     WroteFile {
         path: PathBuf,
-    },
+    } = 1,
     HaxEngineFailure {
         exit_code: i32,
-    },
-    CargoBuildFailure,
+    } = 2,
+    CargoBuildFailure = 3,
     WarnExperimentalBackend {
         backend: Backend,
-    },
+    } = 4,
+}
+
+impl HaxMessage {
+    // https://doc.rust-lang.org/reference/items/enumerations.html#pointer-casting
+    pub fn discriminant(&self) -> u16 {
+        unsafe { *(self as *const Self as *const u16) }
+    }
+
+    pub fn code(&self) -> String {
+        match self {
+            HaxMessage::Diagnostic { diagnostic, .. } => diagnostic.kind.code(),
+            _ => format!("CARGOHAX{:0>4}", self.discriminant()),
+        }
+    }
 }

--- a/hax-types/src/diagnostics/message.rs
+++ b/hax-types/src/diagnostics/message.rs
@@ -1,0 +1,24 @@
+use crate::cli_options::Backend;
+use crate::prelude::*;
+
+#[derive_group(Serializers)]
+#[derive(Debug, Clone, JsonSchema)]
+pub enum HaxMessage {
+    Diagnostic {
+        diagnostic: super::Diagnostics,
+        working_dir: PathBuf,
+    },
+    EngineNotFound {
+        is_opam_setup_correctly: bool,
+    },
+    WroteFile {
+        path: PathBuf,
+    },
+    HaxEngineFailure {
+        exit_code: i32,
+    },
+    CargoBuildFailure,
+    WarnExperimentalBackend {
+        backend: Backend,
+    },
+}

--- a/hax-types/src/diagnostics/mod.rs
+++ b/hax-types/src/diagnostics/mod.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 use colored::Colorize;
 
+pub mod message;
 pub mod report;
 
 #[derive_group(Serializers)]

--- a/hax-types/src/diagnostics/report.rs
+++ b/hax-types/src/diagnostics/report.rs
@@ -10,7 +10,7 @@ pub struct ReportCtx {
     files: HashMap<PathBuf, Rc<String>>,
 }
 
-/// Translates ae line and column position into an absolute offset
+/// Translates a line and column position into an absolute offset
 fn compute_offset(src: &str, mut line: usize, col: usize) -> usize {
     let mut chars = src.chars().enumerate();
     while line > 1 {


### PR DESCRIPTION
This PR adds an option `--message-format` to output hax messages as JSON, just as `cargo` does.
`--message-format` can be set either to `human` (the default), or `json`.

When `--message-format` is set to `json`, `cargo` commands will be run with `--message-format json` as well, unless Cargo's own `--message-format` flag is explicitly set (e.g. via `cargo hax -C --message-format human ; ...`).

This feature is useful for external programs that might want to consume machine-readable output from hax.