### PR TITLE
feat(engine/backend/F*): intro --line-width: control pretty printer

### DIFF
--- a/hax-types/Cargo.toml
+++ b/hax-types/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 readme.workspace = true
 
 [dependencies]
-clap.workspace = true
+clap = { workspace = true, features = ["env"] }
 hax-frontend-exporter.workspace = true
 hax-frontend-exporter-options.workspace = true
 itertools.workspace = true

--- a/hax-types/src/cli_options.rs
+++ b/hax-types/src/cli_options.rs
@@ -159,6 +159,9 @@ pub struct FStarOptions {
         allow_hyphen_values(true)
     )]
     interfaces: Vec<InclusionClause>,
+
+    #[arg(long, default_value = "100", env = "HAX_FSTAR_LINE_WIDTH")]
+    line_width: u16,
 }
 
 #[derive_group(Serializers)]


### PR DESCRIPTION
This PR introduces the option `--line-width` (and a corresponding env var) on the F* backend. This controls the max line width for the pretty-printer.