### PR TITLE
feat(hax-lib/f*): add `verif_status` and `options`

### DIFF
--- a/hax-lib-macros/src/lib.rs
+++ b/hax-lib-macros/src/lib.rs
@@ -45,7 +45,7 @@ pub fn fstar_options(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenS
 /// `panic_free`.
 #[proc_macro_error]
 #[proc_macro_attribute]
-pub fn fstar_verif_status(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
+pub fn fstar_verification_status(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream {
     let action = format!("{}", parse_macro_input!(attr as Ident));
     match action.as_str() {
         "lax" => {

--- a/hax-lib/src/proc_macros.rs
+++ b/hax-lib/src/proc_macros.rs
@@ -34,7 +34,7 @@ macro_rules! export_quoting_proc_macros {
 export_quoting_proc_macros!(
     fstar(fstar_expr, fstar_unsafe_expr, fstar_before, fstar_after, fstar_replace, hax_backend_fstar, {
         pub use hax_lib_macros::fstar_options as options;
-        pub use hax_lib_macros::fstar_verif_status as verif_status;
+        pub use hax_lib_macros::fstar_verification_status as verification_status;
     })
 
     coq(coq_expr, coq_unsafe_expr, coq_before, coq_after, coq_replace, hax_backend_coq)

--- a/hax-lib/src/proc_macros.rs
+++ b/hax-lib/src/proc_macros.rs
@@ -11,7 +11,7 @@ pub use hax_lib_macros::{
 };
 
 macro_rules! export_quoting_proc_macros {
-    ($backend:ident($expr_name:ident, $expr_unsafe_name:ident, $before_name:ident, $after_name:ident, $replace_name:ident, $cfg_name:ident)) => {
+    ($backend:ident($expr_name:ident, $expr_unsafe_name:ident, $before_name:ident, $after_name:ident, $replace_name:ident, $cfg_name:ident $(, {$($extra:tt)+})?)) => {
         pub use hax_lib_macros::$expr_name as $backend;
         #[doc(hidden)]
         pub use hax_lib_macros::$expr_unsafe_name;
@@ -21,6 +21,7 @@ macro_rules! export_quoting_proc_macros {
             pub use hax_lib_macros::$after_name as after;
             pub use hax_lib_macros::$before_name as before;
             pub use hax_lib_macros::$replace_name as replace;
+            $($($extra)*)?
         }
     };
 
@@ -30,6 +31,12 @@ macro_rules! export_quoting_proc_macros {
     }
 }
 
-export_quoting_proc_macros!(fstar(fstar_expr, fstar_unsafe_expr, fstar_before, fstar_after, fstar_replace, hax_backend_fstar)
-                         coq(coq_expr, coq_unsafe_expr, coq_before, coq_after, coq_replace, hax_backend_coq)
-                         proverif(proverif_expr, proverif_unsafe_expr, proverif_before, proverif_after, proverif_replace, hax_backend_proverif));
+export_quoting_proc_macros!(
+    fstar(fstar_expr, fstar_unsafe_expr, fstar_before, fstar_after, fstar_replace, hax_backend_fstar, {
+        pub use hax_lib_macros::fstar_options as options;
+        pub use hax_lib_macros::fstar_verif_status as verif_status;
+    })
+
+    coq(coq_expr, coq_unsafe_expr, coq_before, coq_after, coq_replace, hax_backend_coq)
+
+    proverif(proverif_expr, proverif_unsafe_expr, proverif_before, proverif_after, proverif_replace, hax_backend_proverif));


### PR DESCRIPTION
@karthikbhargavan @mamonet that's what we discussed:

```rust
#[hax_lib::fstar::verification_status(panic_free)]
#[hax_lib::requires(x < 30)]
#[hax_lib::ensures(|_|
    /*something hard to prove, symbolized by false here*/
    false
)]
fn f(x: u8) -> u8 {
    x + x
}

#[hax_lib::fstar::verification_status(lax)]
fn g(x: u8) -> u8 {
    x + x
}

#[hax_lib::fstar::options("--z3rlimit 1234")]
fn h(x: u8) -> u8 {
    x + x
}


```
<sup>&nbsp;&nbsp;&nbsp;[Open this code snippet in the playground](https://hax-playground.cryspen.com/#fstar/526fc073dc/gist=09e66ea206ccaca45ff4021b553515fa)</sup>
