### PR TITLE
Add unsafe versions of inlining macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,7 @@ version = "0.1.0-pre.1"
 dependencies = [
  "hax-lib",
  "hax-lib-macros-types",
+ "paste",
  "proc-macro-error",
  "proc-macro2",
  "quote",

--- a/engine/lib/phases/phase_transform_hax_lib_inline.ml
+++ b/engine/lib/phases/phase_transform_hax_lib_inline.ml
@@ -80,7 +80,8 @@ module%inlined_contents Make (F : Features.T) = struct
     and quote_of_expr' span (expr : A.expr') =
       match expr with
       | App { f = { e = GlobalVar f; _ }; args = [ payload ]; _ }
-        when Global_ident.eq_name Hax_lib__inline f ->
+        when Global_ident.eq_name Hax_lib__inline f
+             || Global_ident.eq_name Hax_lib__inline_unsafe f ->
           let bindings, str = dexpr payload |> UB.collect_let_bindings in
           let str =
             match

--- a/engine/names/src/lib.rs
+++ b/engine/names/src/lib.rs
@@ -51,6 +51,7 @@ fn dummy_hax_concrete_ident_wrapper<I: core::iter::Iterator<Item = u8>>(x: I, mu
     }
 
     let _ = hax_lib::inline("");
+    let _: () = hax_lib::inline_unsafe("");
     use hax_lib::{RefineAs, Refinement};
 
     fn refinements<T: Refinement + Clone, U: RefineAs<T>>(x: T, y: U) -> T {

--- a/hax-lib-macros/Cargo.toml
+++ b/hax-lib-macros/Cargo.toml
@@ -23,6 +23,7 @@ syn = { version = "2.0", features = [
     "parsing",
 ] }
 hax-lib-macros-types.workspace = true
+paste = "1.0.15"
 
 [dev-dependencies]
 hax-lib = { path = "../hax-lib" }

--- a/hax-lib-macros/Cargo.toml
+++ b/hax-lib-macros/Cargo.toml
@@ -19,6 +19,7 @@ quote.workspace = true
 syn = { version = "2.0", features = [
     "full",
     "visit-mut",
+    "visit",
     "extra-traits",
     "parsing",
 ] }

--- a/hax-lib-macros/src/lib.rs
+++ b/hax-lib-macros/src/lib.rs
@@ -195,6 +195,10 @@ pub fn decreases(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStrea
 /// the `ensures` clause, you can refer to such an `&mut` input `x` as
 /// `x` for its "past" value and `future(x)` for its "future" value.
 ///
+/// You can use the (unqualified) macro `fstar!` (`BACKEND!` for any
+/// backend `BACKEND`) to inline F* (or Coq, ProVerif, etc.) code in
+/// the precondition, e.g. `fstar!("true")`.
+///
 /// # Example
 ///
 /// ```
@@ -238,6 +242,10 @@ pub fn requires(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenStream
 
 /// Add a logical postcondition to a function. Note you can use the
 /// `forall` and `exists` operators.
+///
+/// You can use the (unqualified) macro `fstar!` (`BACKEND!` for any
+/// backend `BACKEND`) to inline F* (or Coq, ProVerif, etc.) code in
+/// the postcondition, e.g. `fstar!("true")`.
 ///
 /// # Example
 ///
@@ -693,6 +701,19 @@ macro_rules! make_quoting_proc_macro {
             #[proc_macro]
             pub fn [<$backend _expr>](payload: pm::TokenStream) -> pm::TokenStream {
                 let ts: TokenStream = quote::expression(true, payload).into();
+                quote!{
+                    #[cfg([< hax_backend_ $backend >])]
+                    {
+                        #ts
+                    }
+                }.into()
+            }
+
+            #[doc = concat!("The unsafe (because polymorphic: even computationally relevant code can be inlined!) version of `", stringify!($backend), "_expr`.")]
+            #[proc_macro]
+            #[doc(hidden)]
+            pub fn [<$backend _unsafe_expr>](payload: pm::TokenStream) -> pm::TokenStream {
+                let ts: TokenStream = quote::expression(false, payload).into();
                 quote!{
                     #[cfg([< hax_backend_ $backend >])]
                     {

--- a/hax-lib-macros/src/lib.rs
+++ b/hax-lib-macros/src/lib.rs
@@ -691,7 +691,7 @@ macro_rules! make_quoting_proc_macro {
         /// Types can be refered to with the syntax `$:{TYPE}`.
         #[proc_macro]
         pub fn $expr_name(payload: pm::TokenStream) -> pm::TokenStream {
-            let ts: TokenStream = quote::expression(payload).into();
+            let ts: TokenStream = quote::expression(true, payload).into();
             quote!{
                 #[cfg($cfg_name)]
                 {

--- a/hax-lib-macros/src/quote.rs
+++ b/hax-lib-macros/src/quote.rs
@@ -134,7 +134,7 @@ pub(super) fn item(
     payload: pm::TokenStream,
     item: pm::TokenStream,
 ) -> pm::TokenStream {
-    let expr = TokenStream::from(expression(payload));
+    let expr = TokenStream::from(expression(true, payload));
     let item = TokenStream::from(item);
     let uid = ItemUid::fresh();
     let uid_attr = AttrPayload::Uid(uid.clone());
@@ -162,7 +162,7 @@ pub(super) fn item(
     .into()
 }
 
-pub(super) fn expression(payload: pm::TokenStream) -> pm::TokenStream {
+pub(super) fn expression(force_unit: bool, payload: pm::TokenStream) -> pm::TokenStream {
     let (mut backend_code, antiquotes) = {
         let payload = parse_macro_input!(payload as LitStr).value();
         if payload.find(SPLIT_MARK).is_some() {
@@ -187,5 +187,11 @@ pub(super) fn expression(payload: pm::TokenStream) -> pm::TokenStream {
         };
     }
 
-    quote! {::hax_lib::inline(#[allow(unused_variables)]{#backend_code})}.into()
+    let function = if force_unit {
+        quote! {inline}
+    } else {
+        quote! {inline_unsafe}
+    };
+
+    quote! {::hax_lib::#function(#[allow(unused_variables)]{#backend_code})}.into()
 }

--- a/hax-lib-macros/src/utils.rs
+++ b/hax-lib-macros/src/utils.rs
@@ -17,6 +17,10 @@ impl ToTokens for HaxQuantifiers {
             fn exists<T, F: Fn(T) -> bool>(f: F) -> bool {
                 true
             }
+
+            use ::hax_lib::fstar_unsafe_expr as fstar;
+            use ::hax_lib::coq_unsafe_expr as coq;
+            use ::hax_lib::proverif_unsafe_expr as proverif;
         }
         .to_tokens(tokens)
     }

--- a/hax-lib/src/lib.rs
+++ b/hax-lib/src/lib.rs
@@ -143,7 +143,6 @@ pub fn inline(_: &str) {}
 
 /// Similar to `inline`, but allows for any type. Do not use directly.
 #[doc(hidden)]
-#[cfg(hax)]
 pub fn inline_unsafe<T>(_: &str) -> T {
     unreachable!()
 }

--- a/hax-lib/src/lib.rs
+++ b/hax-lib/src/lib.rs
@@ -141,6 +141,12 @@ pub fn implies(lhs: bool, rhs: impl Fn() -> bool) -> bool {
 #[doc(hidden)]
 pub fn inline(_: &str) {}
 
+/// Similar to `inline`, but allows for any type. Do not use directly.
+#[doc(hidden)]
+pub fn inline_unsafe<T>(_: &str) -> T {
+    unreachable!()
+}
+
 /// A type that implements `Refinement` should be a newtype for a
 /// type `T`. The field holding the value of type `T` should be
 /// private, and `Refinement` should be the only interface to the

--- a/hax-lib/src/lib.rs
+++ b/hax-lib/src/lib.rs
@@ -143,6 +143,7 @@ pub fn inline(_: &str) {}
 
 /// Similar to `inline`, but allows for any type. Do not use directly.
 #[doc(hidden)]
+#[cfg(hax)]
 pub fn inline_unsafe<T>(_: &str) -> T {
     unreachable!()
 }

--- a/hax-lib/src/proc_macros.rs
+++ b/hax-lib/src/proc_macros.rs
@@ -11,8 +11,10 @@ pub use hax_lib_macros::{
 };
 
 macro_rules! export_quoting_proc_macros {
-    ($backend:ident($expr_name:ident, $before_name:ident, $after_name:ident, $replace_name:ident, $cfg_name:ident)) => {
+    ($backend:ident($expr_name:ident, $expr_unsafe_name:ident, $before_name:ident, $after_name:ident, $replace_name:ident, $cfg_name:ident)) => {
         pub use hax_lib_macros::$expr_name as $backend;
+        #[doc(hidden)]
+        pub use hax_lib_macros::$expr_unsafe_name;
 
         #[doc=concat!("Procedural macros for ", stringify!($backend))]
         pub mod $backend {
@@ -28,6 +30,6 @@ macro_rules! export_quoting_proc_macros {
     }
 }
 
-export_quoting_proc_macros!(fstar(fstar_expr, fstar_before, fstar_after, fstar_replace, hax_backend_fstar)
-                         coq(coq_expr, coq_before, coq_after, coq_replace, hax_backend_coq)
-                         proverif(proverif_expr, proverif_before, proverif_after, proverif_replace, hax_backend_proverif));
+export_quoting_proc_macros!(fstar(fstar_expr, fstar_unsafe_expr, fstar_before, fstar_after, fstar_replace, hax_backend_fstar)
+                         coq(coq_expr, coq_unsafe_expr, coq_before, coq_after, coq_replace, hax_backend_coq)
+                         proverif(proverif_expr, proverif_unsafe_expr, proverif_before, proverif_after, proverif_replace, hax_backend_proverif));

--- a/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__attributes into-fstar.snap
@@ -26,6 +26,42 @@ exit = 0
 diagnostics = []
 
 [stdout.files]
+"Attributes.Inlined_code_ensures_requires.fst" = '''
+module Attributes.Inlined_code_ensures_requires
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let increment_array (v: t_Array u8 (sz 4))
+    : Prims.Pure (t_Array u8 (sz 4))
+      (requires forall i. FStar.Seq.index v i <. 254uy)
+      (ensures
+        fun temp_0_ ->
+          let vv_future, ():(t_Array u8 (sz 4) & Prims.unit) = temp_0_ in
+          let future_v:t_Array u8 (sz 4) = vv_future in
+          forall i. FStar.Seq.index future_v i >. 0uy) =
+  let v:t_Array u8 (sz 4) =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
+      (sz 0)
+      ((v.[ sz 0 ] <: u8) +! 1uy <: u8)
+  in
+  let v:t_Array u8 (sz 4) =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
+      (sz 1)
+      ((v.[ sz 1 ] <: u8) +! 1uy <: u8)
+  in
+  let v:t_Array u8 (sz 4) =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
+      (sz 2)
+      ((v.[ sz 2 ] <: u8) +! 1uy <: u8)
+  in
+  let v:t_Array u8 (sz 4) =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize v
+      (sz 3)
+      ((v.[ sz 3 ] <: u8) +! 1uy <: u8)
+  in
+  v
+'''
 "Attributes.Int_model.fst" = '''
 module Attributes.Int_model
 #set-options "--fuel 0 --ifuel 1 --z3rlimit 15"

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -322,6 +322,7 @@ name = "hax-lib-macros"
 version = "0.1.0-pre.1"
 dependencies = [
  "hax-lib-macros-types",
+ "paste",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -640,6 +641,12 @@ name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pattern-or"

--- a/tests/attributes/src/lib.rs
+++ b/tests/attributes/src/lib.rs
@@ -285,3 +285,18 @@ mod nested_refinement_elim {
         (DummyRefinement::new(x.get())).get()
     }
 }
+
+/// `ensures` and `requires` with inlined code (issue #825)
+mod inlined_code_ensures_requires {
+    #[hax_lib::requires(fstar!("forall i. FStar.Seq.index $v i <. ${254u8}"))]
+    #[hax_lib::ensures(|()| {
+        let future_v = future(v);
+        fstar!("forall i. FStar.Seq.index ${future_v} i >. ${0u8}")
+    })]
+    fn increment_array(v: &mut [u8; 4]) {
+        v[0] += 1;
+        v[1] += 1;
+        v[2] += 1;
+        v[3] += 1;
+    }
+}


### PR DESCRIPTION
Closes #825.

(note: replace BACKEND by `fstar`, `coq`, etc. in the text of this PR)

This PR:
 - adds `hax_lib::inline_unsafe` function, hidden in documentation, that allows to inline BACKEND code of any type directly as an expression. This is an internal function, it not supposed to be used directly. ~It exists only when compiling through hax~ (see my last reverted commit). The body of this function is an `unreachable!`.
 - adds a `hax_lib_macro:BACKEND_unsafe_expr` macro (exposed as `hax_lib::BACKEND_unsafe_expr`, hidden in doc) which leverages `inline_unsafe` to produce inlined BACKEND code of any type.
 - exposes `hax_lib_macro:BACKEND_unsafe_expr` locally as `BACKEND` in pre and post conditions. Thus we can use e.g. `fstar!("forall x. ...")` in ensures and requires clauses.
 - Disallow `future(...)` within a quote (e.g. `fstar!("... ${future(arg)} ...")`): due to the way macros expand in a fixed sequence (the `fstar!("...")` expands after `requires` expands, so the `requires` macro cannot rewrite future nodes in `"..."` -- note that will be the same thing, but with `old` instead of `future`, when #773 will be fixed)
 - adds tests

Example of what you can do:
```rust
/// `ensures` and `requires` with inlined code (issue #825)
mod inlined_code_ensures_requires {
    #[hax_lib::requires(fstar!("forall i. FStar.Seq.index $v i <. ${254u8}"))]
    #[hax_lib::ensures(|()| {
        let future_v = future(v);
        fstar!("forall i. FStar.Seq.index ${future_v} i >. ${0u8}")
    })]
    fn increment_array(v: &mut [u8; 4]) {
        v[0] += 1;
        v[1] += 1;
        v[2] += 1;
        v[3] += 1;
    }
}
```
https://hax-playground.cryspen.com/#fstar/88b4821690/gist=49d80be217020e9fd41f9e0a6a23714e