### PR TITLE
Add infos impl

### DIFF
--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -306,7 +306,7 @@ struct
     | TArray { typ; length } ->
         F.mk_e_app (F.term_of_lid [ "t_Array" ]) [ pty span typ; pexpr length ]
     | TParam i -> F.term @@ F.AST.Var (F.lid_of_id @@ plocal_ident i)
-    | TAssociatedType { impl = Self; item } ->
+    | TAssociatedType { impl = { kind = Self; _ }; item } ->
         F.term
         @@ F.AST.Var (F.lid [ U.Concrete_ident_view.to_definition_name item ])
     | TAssociatedType { impl; item } -> (
@@ -342,7 +342,7 @@ struct
   and pimpl_expr span (ie : impl_expr) =
     let some = Option.some in
     let hax_unstable_impl_exprs = false in
-    match ie with
+    match ie.kind with
     | Concrete tr -> c_trait_goal span tr |> some
     | LocalBound { id } ->
         let local_ident =

--- a/engine/lib/ast.ml
+++ b/engine/lib/ast.ml
@@ -1,7 +1,7 @@
 open! Prelude
 
-type todo = string [@@deriving show, yojson, hash, eq]
-type span = Span.t [@@deriving show, yojson, hash, compare, sexp, eq]
+type todo = string [@@deriving show, yojson, hash, compare, sexp, hash, eq]
+type span = Span.t [@@deriving show, yojson, hash, compare, sexp, hash, eq]
 
 type concrete_ident = Concrete_ident.t
 [@@deriving show, yojson, hash, compare, sexp, hash, eq]
@@ -9,7 +9,7 @@ type concrete_ident = Concrete_ident.t
 type logical_op = And | Or
 
 and primitive_ident = Deref | Cast | LogicalOp of logical_op
-[@@deriving show, yojson, hash, compare, sexp, eq]
+[@@deriving show, yojson, hash, compare, sexp, hash, eq]
 
 module Global_ident = struct
   module T = struct
@@ -21,7 +21,7 @@ module Global_ident = struct
       | `TupleField of int * int
       | `Projector of [ `Concrete of concrete_ident | `TupleField of int * int ]
       ]
-    [@@deriving show, yojson, compare, hash, sexp, eq]
+    [@@deriving show, yojson, hash, compare, sexp, hash, eq]
   end
 
   module M = struct
@@ -40,7 +40,8 @@ module Global_ident = struct
   let to_string : t -> string = [%show: t]
 end
 
-type global_ident = Global_ident.t [@@deriving show, yojson, hash, eq]
+type global_ident = Global_ident.t
+[@@deriving show, yojson, hash, compare, sexp, hash, eq]
 
 type attr_kind =
   | Tool of { path : string; tokens : string }
@@ -48,13 +49,13 @@ type attr_kind =
 
 and attr = { kind : attr_kind; span : span }
 and doc_comment_kind = DCKLine | DCKBlock
-and attrs = attr list [@@deriving show, yojson, hash, eq]
+and attrs = attr list [@@deriving show, yojson, hash, compare, sexp, hash, eq]
 
 type local_ident = Local_ident.t
-[@@deriving show, yojson, hash, compare, sexp, eq]
+[@@deriving show, yojson, hash, compare, sexp, hash, eq]
 
 type size = S8 | S16 | S32 | S64 | S128 | SSize
-[@@deriving show, yojson, hash, compare, eq]
+[@@deriving show, yojson, hash, compare, sexp, hash, eq]
 
 let int_of_size = function
   | S8 -> Some 8
@@ -67,10 +68,10 @@ let int_of_size = function
 let string_of_size = int_of_size >> Option.map ~f:Int.to_string
 
 type signedness = Signed | Unsigned
-[@@deriving show, yojson, hash, compare, eq]
+[@@deriving show, yojson, hash, compare, sexp, hash, eq]
 
 type int_kind = { size : size; signedness : signedness }
-[@@deriving show, yojson, hash, compare, eq]
+[@@deriving show, yojson, hash, compare, sexp, hash, eq]
 
 let show_int_kind { size; signedness } =
   (match signedness with Signed -> "i" | Unsigned -> "u")
@@ -79,7 +80,7 @@ let show_int_kind { size; signedness } =
     |> Option.value ~default:"size")
 
 type float_kind = F16 | F32 | F64 | F128
-[@@deriving show, yojson, hash, compare, eq]
+[@@deriving show, yojson, hash, compare, sexp, hash, eq]
 
 let show_float_kind = function
   | F16 -> "f16"
@@ -93,12 +94,10 @@ type literal =
   | Int of { value : string; negative : bool; kind : int_kind }
   | Float of { value : string; negative : bool; kind : float_kind }
   | Bool of bool
-[@@deriving show, yojson, hash, eq]
-
-(* type 't spanned = { v : 't; span : span } [@@deriving show, yojson, hash, eq] *)
+[@@deriving show, yojson, hash, compare, sexp, hash, eq]
 
 type 'mut_witness mutability = Mutable of 'mut_witness | Immutable
-[@@deriving show, yojson, hash, eq]
+[@@deriving show, yojson, hash, compare, sexp, hash, eq]
 
 module Make =
 functor
@@ -109,10 +108,10 @@ functor
     [@@deriving show, yojson, hash, eq]
 
     type borrow_kind = Shared | Unique | Mut of F.mutable_reference
-    [@@deriving show, yojson, hash, eq]
+    [@@deriving show, yojson, hash, compare, sexp, hash, eq]
 
     type binding_mode = ByValue | ByRef of (borrow_kind * F.reference)
-    [@@deriving show, yojson, hash, eq]
+    [@@deriving show, yojson, hash, compare, sexp, hash, eq]
 
     type ty =
       | TBool
@@ -353,7 +352,8 @@ functor
 
     (* OCaml + visitors is not happy with `pat`... hence `arm_pat`... *)
     and arm' = { arm_pat : pat; body : expr; guard : guard option }
-    and arm = { arm : arm'; span : span } [@@deriving show, yojson, hash, eq]
+    and arm = { arm : arm'; span : span }
+    [@@deriving show, yojson, hash, compare, sexp, hash, eq]
 
     type generic_param = {
       ident : local_ident;
@@ -373,7 +373,7 @@ functor
       | GCProjection of projection_predicate
           (** Trait or lifetime constraints. For instance, `A` and `B` in
     `fn f<T: A + B>()`. *)
-    [@@deriving show, yojson, hash, eq]
+    [@@deriving show, yojson, hash, compare, sexp, hash, eq]
 
     type param = { pat : pat; typ : ty; typ_span : span option; attrs : attrs }
 
@@ -468,7 +468,7 @@ functor
       ti_ident : concrete_ident;
       ti_attrs : attrs;
     }
-    [@@deriving show, yojson, hash, eq]
+    [@@deriving show, yojson, hash, compare, sexp, hash, eq]
 
     type modul = item list
 
@@ -480,8 +480,8 @@ functor
   end
 
 module type T = sig
-  type expr [@@deriving show, yojson]
-  type item' [@@deriving show, yojson]
+  type expr [@@deriving show, compare, yojson]
+  type item' [@@deriving show, compare, yojson]
 
   type item = {
     v : item';
@@ -489,7 +489,7 @@ module type T = sig
     ident : Concrete_ident.t;
     attrs : attrs;
   }
-  [@@deriving show, yojson]
+  [@@deriving show, compare, yojson]
 
   val make_hax_error_item : span -> Concrete_ident.t -> string -> item
 end

--- a/engine/lib/ast.ml
+++ b/engine/lib/ast.ml
@@ -141,7 +141,9 @@ functor
       | GType of ty
       | GConst of expr
 
-    and impl_expr =
+    and impl_expr = { kind : impl_expr_kind; goal : trait_goal }
+
+    and impl_expr_kind =
       | Self
       | Concrete of trait_goal
       | LocalBound of { id : string }

--- a/engine/lib/ast.ml
+++ b/engine/lib/ast.ml
@@ -105,7 +105,7 @@ functor
   ->
   struct
     type safety_kind = Safe | Unsafe of F.unsafe
-    [@@deriving show, yojson, hash, eq]
+    [@@deriving show, yojson, hash, compare, sexp, hash, eq]
 
     type borrow_kind = Shared | Unique | Mut of F.mutable_reference
     [@@deriving show, yojson, hash, compare, sexp, hash, eq]
@@ -352,6 +352,7 @@ functor
 
     (* OCaml + visitors is not happy with `pat`... hence `arm_pat`... *)
     and arm' = { arm_pat : pat; body : expr; guard : guard option }
+
     and arm = { arm : arm'; span : span }
     [@@deriving show, yojson, hash, compare, sexp, hash, eq]
 

--- a/engine/lib/ast_utils.ml
+++ b/engine/lib/ast_utils.ml
@@ -239,12 +239,12 @@ module Make (F : Features.T) = struct
           in
           super#visit_item' (enabled, s) item
 
-        method! visit_impl_expr s ie =
+        method! visit_impl_expr_kind s ie =
           match ie with
           | LocalBound { id } ->
               LocalBound
                 { id = Hashtbl.find (snd s) id |> Option.value ~default:id }
-          | _ -> super#visit_impl_expr s ie
+          | _ -> super#visit_impl_expr_kind s ie
       end
 
     let drop_bodies =

--- a/engine/lib/ast_utils.ml
+++ b/engine/lib/ast_utils.ml
@@ -933,6 +933,7 @@ module Make (F : Features.T) = struct
 
   module LiftToFullAst = struct
     let expr : AST.expr -> Ast.Full.expr = Stdlib.Obj.magic
+    let ty : AST.ty -> Ast.Full.ty = Stdlib.Obj.magic
     let item : AST.item -> Ast.Full.item = Stdlib.Obj.magic
   end
 

--- a/engine/lib/features.ml
+++ b/engine/lib/features.ml
@@ -43,8 +43,6 @@ module Rust = struct
   include Off.Quote
 end
 
-let _ = Enumeration.all
-
 module _ = struct
   module _ : T = Full
   module _ : T = Rust

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -1029,21 +1029,23 @@ end) : EXPR = struct
   (* fun _ -> Ok Bool *)
 
   and c_impl_expr (span : Thir.span) (ie : Thir.impl_expr) : impl_expr =
-    let impl = c_impl_expr_atom span ie.impl in
+    let goal = c_trait_ref span ie.trait in
+    let impl = { kind = c_impl_expr_atom span ie.impl; goal } in
     match ie.args with
     | [] -> impl
     | args ->
         let args = List.map ~f:(c_impl_expr span) args in
-        ImplApp { impl; args }
+        { kind = ImplApp { impl; args }; goal }
 
   and c_trait_ref span (tr : Thir.trait_ref) : trait_goal =
     let trait = Concrete_ident.of_def_id Trait tr.def_id in
     let args = List.map ~f:(c_generic_value span) tr.generic_args in
     { trait; args }
 
-  and c_impl_expr_atom (span : Thir.span) (ie : Thir.impl_expr_atom) : impl_expr
-      =
-    let browse_path (impl : impl_expr) (chunk : Thir.impl_expr_path_chunk) =
+  and c_impl_expr_atom (span : Thir.span) (ie : Thir.impl_expr_atom) :
+      impl_expr_kind =
+    let browse_path (item_kind : impl_expr_kind)
+        (chunk : Thir.impl_expr_path_chunk) =
       match chunk with
       | AssocItem
           { item; predicate = { value = { trait_ref; _ }; _ }; predicate_id; _ }
@@ -1055,13 +1057,16 @@ end) : EXPR = struct
             match item.kind with Const | Fn -> Value | Type -> Type
           in
           let item = Concrete_ident.of_def_id kind item.def_id in
-          Projection { impl; ident; item }
+          let trait_ref = c_trait_ref span trait_ref in
+          Projection
+            { impl = { kind = item_kind; goal = trait_ref }; ident; item }
       | Parent { predicate = { value = { trait_ref; _ }; _ }; predicate_id; _ }
         ->
           let ident =
             { goal = c_trait_ref span trait_ref; name = predicate_id }
           in
-          Parent { impl; ident }
+          let trait_ref = c_trait_ref span trait_ref in
+          Parent { impl = { kind = item_kind; goal = trait_ref }; ident }
     in
     match ie with
     | Concrete { id; generics } ->

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -1029,7 +1029,7 @@ end) : EXPR = struct
   (* fun _ -> Ok Bool *)
 
   and c_impl_expr (span : Thir.span) (ie : Thir.impl_expr) : impl_expr =
-    let goal = c_trait_ref span ie.trait in
+    let goal = c_trait_ref span ie.trait.value in
     let impl = { kind = c_impl_expr_atom span ie.impl; goal } in
     match ie.args with
     | [] -> impl

--- a/engine/lib/phases/phase_reconstruct_question_marks.ml
+++ b/engine/lib/phases/phase_reconstruct_question_marks.ml
@@ -51,9 +51,12 @@ module%inlined_contents Make (FA : Features.T) = struct
       `std::ops::FromResidual` for the type [Result<_, _>], and
       extract its parent [From] impl expr *)
       let expect_residual_impl_result (impl : impl_expr) : impl_expr option =
-        match impl with
+        match impl.kind with
         | ImplApp
-            { impl = Concrete { trait; _ }; args = [ _; _; _; from_impl ] }
+            {
+              impl = { kind = Concrete { trait; _ }; _ };
+              args = [ _; _; _; from_impl ];
+            }
           when Concrete_ident.eq_name Core__result__Impl_27 trait ->
             Some from_impl
         | _ -> None

--- a/engine/lib/phases/phase_simplify_question_marks.ml
+++ b/engine/lib/phases/phase_simplify_question_marks.ml
@@ -51,9 +51,12 @@ module%inlined_contents Make (FA : Features.T) = struct
       `std::ops::FromResidual` for the type [Result<_, _>], and
       extract its parent [From] impl expr *)
       let expect_residual_impl_result (impl : impl_expr) : impl_expr option =
-        match impl with
+        match impl.kind with
         | ImplApp
-            { impl = Concrete { trait; _ }; args = [ _; _; _; from_impl ] }
+            {
+              impl = { kind = Concrete { trait; _ }; _ };
+              args = [ _; _; _; from_impl ];
+            }
           when Concrete_ident.eq_name Core__result__Impl_27 trait ->
             Some from_impl
         | _ -> None

--- a/engine/lib/print_rust.ml
+++ b/engine/lib/print_rust.ml
@@ -89,7 +89,9 @@ module Raw = struct
   let rec pglobal_ident' prefix span (e : global_ident) : AnnotatedString.t =
     let ( ! ) s = pure span (prefix ^ s) in
     match e with
-    | `Concrete c -> !(Concrete_ident_view.show c)
+    | `Concrete c ->
+        !(let s = Concrete_ident_view.show c in
+          if String.equal "_" s then "_anon" else s)
     | `Primitive p -> pprimitive_ident span p
     | `TupleType n -> ![%string "tuple%{Int.to_string n}"]
     | `TupleCons n -> ![%string "Tuple%{Int.to_string n}"]
@@ -111,6 +113,7 @@ module Raw = struct
               name
       | _ -> e.name
     in
+    let name = if String.equal name "_" then "_anon" else name in
     pure span name
 
   let dmutability span : _ -> AnnotatedString.t =
@@ -416,15 +419,24 @@ module Raw = struct
     !(Concrete_ident_view.show trait)
     & if List.is_empty args then empty else !"<" & args & !">"
 
+  let pprojection_predicate span (pp : projection_predicate) =
+    let ( ! ) = pure span in
+    (pp.impl.goal.args
+     |> List.find_map ~f:(function GType ty -> Some ty | _ -> None)
+     |> Option.map ~f:(pty span)
+     |> Option.value ~default:!"unknown_self")
+    & !" :"
+    & !(Concrete_ident_view.show pp.impl.goal.trait)
+    & !"<"
+    & !(Concrete_ident_view.to_definition_name pp.assoc_item)
+    & !" = " & pty span pp.typ & !">"
+
   let pgeneric_constraint span (p : generic_constraint) =
     let ( ! ) = pure span in
     match p with
     | GCLifetime _ -> !"'unk: 'unk"
-    | GCType { goal; _ } -> !"_:" & ptrait_goal span goal
-    | GCProjection { assoc_item; typ; _ } ->
-        !"_:_<_>::"
-        & !(Concrete_ident_view.show assoc_item)
-        & !"==" & pty span typ
+    | GCType { goal; _ } -> !"_: " & ptrait_goal span goal
+    | GCProjection pp -> pprojection_predicate span pp
 
   let pgeneric_constraints span (constraints : generic_constraint list) =
     if List.is_empty constraints then empty
@@ -658,6 +670,19 @@ let pitems : item list -> AnnotatedString.Output.t =
   >> rustfmt_annotated >> AnnotatedString.Output.convert
 
 let pitem_str : item -> string = pitem >> AnnotatedString.Output.raw_string
+
+let pty_str (e : ty) : string =
+  let e = Raw.pty (Span.dummy ()) e in
+  let ( ! ) = AnnotatedString.pure @@ Span.dummy () in
+  let ( & ) = AnnotatedString.( & ) in
+  let prefix = "type TypeWrapper = " in
+  let suffix = ";" in
+  let item = !prefix & e & !suffix in
+  rustfmt_annotated item |> AnnotatedString.Output.convert
+  |> AnnotatedString.Output.raw_string |> Stdlib.String.trim
+  |> String.chop_suffix_if_exists ~suffix
+  |> String.chop_prefix_if_exists ~prefix
+  |> Stdlib.String.trim
 
 let pexpr_str (e : expr) : string =
   let e = Raw.pexpr e in

--- a/engine/lib/print_rust.ml
+++ b/engine/lib/print_rust.ml
@@ -421,10 +421,10 @@ module Raw = struct
 
   let pprojection_predicate span (pp : projection_predicate) =
     let ( ! ) = pure span in
-    (pp.impl.goal.args
-     |> List.find_map ~f:(function GType ty -> Some ty | _ -> None)
-     |> Option.map ~f:(pty span)
-     |> Option.value ~default:!"unknown_self")
+    pp.impl.goal.args
+    |> List.find_map ~f:(function GType ty -> Some ty | _ -> None)
+    |> Option.map ~f:(pty span)
+    |> Option.value ~default:!"unknown_self"
     & !" :"
     & !(Concrete_ident_view.show pp.impl.goal.trait)
     & !"<"

--- a/engine/lib/print_rust.mli
+++ b/engine/lib/print_rust.mli
@@ -12,3 +12,4 @@ val pitem : item -> AnnotatedString.Output.t
 val pitems : item list -> AnnotatedString.Output.t
 val pitem_str : item -> string
 val pexpr_str : expr -> string
+val pty_str : ty -> string

--- a/engine/lib/subtype.ml
+++ b/engine/lib/subtype.ml
@@ -78,6 +78,9 @@ struct
     }
 
   and dimpl_expr (span : span) (i : A.impl_expr) : B.impl_expr =
+    { kind = dimpl_expr_kind span i.kind; goal = dtrait_goal span i.goal }
+
+  and dimpl_expr_kind (span : span) (i : A.impl_expr_kind) : B.impl_expr_kind =
     match i with
     | Self -> Self
     | Concrete tr -> Concrete (dtrait_goal span tr)

--- a/engine/utils/ppx_generate_features/ppx_generate_features.ml
+++ b/engine/utils/ppx_generate_features/ppx_generate_features.ml
@@ -39,7 +39,7 @@ let expand ~(ctxt : Expansion_context.Extension.t) (features : string list) :
         List.map
           ~f:(fun txt ->
             (rename [ ("placeholder", txt) ])#signature_item
-              [%sigi: type placeholder [@@deriving show, yojson, hash, eq]])
+              [%sigi: type placeholder [@@deriving show, yojson, hash, compare, sexp, hash, eq]])
           features
         |> B.pmty_signature]
       end
@@ -71,10 +71,7 @@ let expand ~(ctxt : Expansion_context.Extension.t) (features : string list) :
                       (PStr
                          [%str
                            show { with_path = false },
-                             yojson,
-                             hash,
-                             eq,
-                             enumerate]);
+                             yojson, hash, compare, sexp, hash, eq]);
                 ];
             };
           ]]
@@ -125,12 +122,12 @@ let expand ~(ctxt : Expansion_context.Extension.t) (features : string list) :
             #structure
             [%str
               module Placeholder : sig
-                type placeholder [@@deriving show, yojson, hash, eq]
+                type placeholder [@@deriving show, yojson, hash, compare, sexp, hash, eq]
 
                 val placeholder : placeholder
               end = struct
                 type placeholder = Placeholder
-                [@@deriving show, yojson, hash, eq]
+                [@@deriving show, yojson, hash, compare, sexp, hash, eq]
 
                 let placeholder = Placeholder
               end
@@ -159,7 +156,7 @@ let expand ~(ctxt : Expansion_context.Extension.t) (features : string list) :
             #structure
             [%str
               module Placeholder = struct
-                type placeholder = | [@@deriving show, yojson, hash, eq]
+                type placeholder = | [@@deriving show, yojson, hash, compare, sexp, hash, eq]
               end
 
               include Placeholder])

--- a/engine/utils/ppx_generate_features/ppx_generate_features.ml
+++ b/engine/utils/ppx_generate_features/ppx_generate_features.ml
@@ -39,7 +39,9 @@ let expand ~(ctxt : Expansion_context.Extension.t) (features : string list) :
         List.map
           ~f:(fun txt ->
             (rename [ ("placeholder", txt) ])#signature_item
-              [%sigi: type placeholder [@@deriving show, yojson, hash, compare, sexp, hash, eq]])
+              [%sigi:
+                type placeholder
+                [@@deriving show, yojson, hash, compare, sexp, hash, eq]])
           features
         |> B.pmty_signature]
       end
@@ -71,7 +73,12 @@ let expand ~(ctxt : Expansion_context.Extension.t) (features : string list) :
                       (PStr
                          [%str
                            show { with_path = false },
-                             yojson, hash, compare, sexp, hash, eq]);
+                             yojson,
+                             hash,
+                             compare,
+                             sexp,
+                             hash,
+                             eq]);
                 ];
             };
           ]]
@@ -122,7 +129,8 @@ let expand ~(ctxt : Expansion_context.Extension.t) (features : string list) :
             #structure
             [%str
               module Placeholder : sig
-                type placeholder [@@deriving show, yojson, hash, compare, sexp, hash, eq]
+                type placeholder
+                [@@deriving show, yojson, hash, compare, sexp, hash, eq]
 
                 val placeholder : placeholder
               end = struct
@@ -156,7 +164,8 @@ let expand ~(ctxt : Expansion_context.Extension.t) (features : string list) :
             #structure
             [%str
               module Placeholder = struct
-                type placeholder = | [@@deriving show, yojson, hash, compare, sexp, hash, eq]
+                type placeholder = |
+                [@@deriving show, yojson, hash, compare, sexp, hash, eq]
               end
 
               include Placeholder])

--- a/test-harness/src/snapshots/toolchain__traits into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__traits into-fstar.snap
@@ -195,6 +195,7 @@ let _ =
   (* This module has implicit dependencies, here we make them explicit. *)
   (* The implicit dependencies arise from typeclasses instances. *)
   let open Traits.Implicit_dependencies_issue_667_.Impl_type in
+  let open Traits.Implicit_dependencies_issue_667_.Trait_definition in
   ()
 
 let some_function (x: Traits.Implicit_dependencies_issue_667_.Define_type.t_MyType) : Prims.unit =
@@ -328,14 +329,6 @@ let impl (#v_TypeArg: Type0) (v_ConstArg: usize) : t_Trait Prims.unit v_TypeArg 
       ()
   }
 
-class t_SubTrait (v_Self: Type0) (v_TypeArg: Type0) (v_ConstArg: usize) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_8779313392680198588:t_Trait v_Self
-    v_TypeArg
-    v_ConstArg;
-  f_AssocType:Type0;
-  f_AssocType_6369404467997533198:t_Trait f_AssocType v_TypeArg v_ConstArg
-}
-
 let associated_function_caller
       (#v_MethodTypeArg #v_TypeArg: Type0)
       (v_ConstArg v_MethodConstArg: usize)
@@ -379,6 +372,14 @@ let method_caller
       value_Type
   in
   ()
+
+class t_SubTrait (v_Self: Type0) (v_TypeArg: Type0) (v_ConstArg: usize) = {
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_8779313392680198588:t_Trait v_Self
+    v_TypeArg
+    v_ConstArg;
+  f_AssocType:Type0;
+  f_AssocType_6369404467997533198:t_Trait f_AssocType v_TypeArg v_ConstArg
+}
 '''
 "Traits.Interlaced_consts_types.fst" = '''
 module Traits.Interlaced_consts_types
@@ -532,14 +533,6 @@ let impl__Error__for_application_callback (_: Prims.unit) :  Prims.unit -> t_Err
 
 let t_Error_cast_to_repr (x: t_Error) : isize = match x with | Error_Fail  -> isz 0
 
-class t_Lang (v_Self: Type0) = {
-  f_Var:Type0;
-  f_s_pre:v_Self -> i32 -> Type0;
-  f_s_post:v_Self -> i32 -> (v_Self & f_Var) -> Type0;
-  f_s:x0: v_Self -> x1: i32
-    -> Prims.Pure (v_Self & f_Var) (f_s_pre x0 x1) (fun result -> f_s_post x0 x1 result)
-}
-
 class t_SuperTrait (v_Self: Type0) = {
   [@@@ FStar.Tactics.Typeclasses.no_method]_super_9442900250278684536:Core.Clone.t_Clone v_Self;
   f_function_of_super_trait_pre:v_Self -> Type0;
@@ -558,27 +551,6 @@ let impl_SuperTrait_for_i32: t_SuperTrait i32 =
     f_function_of_super_trait_post = (fun (self: i32) (out: u32) -> true);
     f_function_of_super_trait = fun (self: i32) -> cast (Core.Num.impl__i32__abs self <: i32) <: u32
   }
-
-class t_Foo (v_Self: Type0) = {
-  f_AssocType:Type0;
-  f_AssocType_15525962639250476383:t_SuperTrait f_AssocType;
-  f_AssocType_17265963849229885182:Core.Clone.t_Clone f_AssocType;
-  f_N:usize;
-  f_assoc_f_pre:Prims.unit -> Type0;
-  f_assoc_f_post:Prims.unit -> Prims.unit -> Type0;
-  f_assoc_f:x0: Prims.unit
-    -> Prims.Pure Prims.unit (f_assoc_f_pre x0) (fun result -> f_assoc_f_post x0 result);
-  f_method_f_pre:v_Self -> Type0;
-  f_method_f_post:v_Self -> Prims.unit -> Type0;
-  f_method_f:x0: v_Self
-    -> Prims.Pure Prims.unit (f_method_f_pre x0) (fun result -> f_method_f_post x0 result);
-  f_assoc_type_pre:{| i3: Core.Marker.t_Copy f_AssocType |} -> f_AssocType -> Type0;
-  f_assoc_type_post:{| i3: Core.Marker.t_Copy f_AssocType |} -> f_AssocType -> Prims.unit -> Type0;
-  f_assoc_type:{| i3: Core.Marker.t_Copy f_AssocType |} -> x0: f_AssocType
-    -> Prims.Pure Prims.unit
-        (f_assoc_type_pre #i3 x0)
-        (fun result -> f_assoc_type_post #i3 x0 result)
-}
 
 let closure_impl_expr
       (#v_I: Type0)
@@ -610,6 +582,37 @@ let closure_impl_expr_fngen
       <:
       Core.Iter.Adapters.Map.t_Map v_I v_F)
 
+class t_Foo (v_Self: Type0) = {
+  f_AssocType:Type0;
+  f_AssocType_15525962639250476383:t_SuperTrait f_AssocType;
+  f_AssocType_17265963849229885182:Core.Clone.t_Clone f_AssocType;
+  f_N:usize;
+  f_assoc_f_pre:Prims.unit -> Type0;
+  f_assoc_f_post:Prims.unit -> Prims.unit -> Type0;
+  f_assoc_f:x0: Prims.unit
+    -> Prims.Pure Prims.unit (f_assoc_f_pre x0) (fun result -> f_assoc_f_post x0 result);
+  f_method_f_pre:v_Self -> Type0;
+  f_method_f_post:v_Self -> Prims.unit -> Type0;
+  f_method_f:x0: v_Self
+    -> Prims.Pure Prims.unit (f_method_f_pre x0) (fun result -> f_method_f_post x0 result);
+  f_assoc_type_pre:{| i3: Core.Marker.t_Copy f_AssocType |} -> f_AssocType -> Type0;
+  f_assoc_type_post:{| i3: Core.Marker.t_Copy f_AssocType |} -> f_AssocType -> Prims.unit -> Type0;
+  f_assoc_type:{| i3: Core.Marker.t_Copy f_AssocType |} -> x0: f_AssocType
+    -> Prims.Pure Prims.unit
+        (f_assoc_type_pre #i3 x0)
+        (fun result -> f_assoc_type_post #i3 x0 result)
+}
+
+class t_Lang (v_Self: Type0) = {
+  f_Var:Type0;
+  f_s_pre:v_Self -> i32 -> Type0;
+  f_s_post:v_Self -> i32 -> (v_Self & f_Var) -> Type0;
+  f_s:x0: v_Self -> x1: i32
+    -> Prims.Pure (v_Self & f_Var) (f_s_pre x0 x1) (fun result -> f_s_post x0 x1 result)
+}
+
+type t_Struct = | Struct : t_Struct
+
 let f (#v_T: Type0) (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: t_Foo v_T) (x: v_T) : Prims.unit =
   let _:Prims.unit = f_assoc_f #v_T #FStar.Tactics.Typeclasses.solve () in
   f_method_f #v_T #FStar.Tactics.Typeclasses.solve x
@@ -635,6 +638,4 @@ let impl_Foo_for_tuple_: t_Foo Prims.unit =
     f_assoc_type_post = (fun (_: i32) (out: Prims.unit) -> true);
     f_assoc_type = fun (_: i32) -> ()
   }
-
-type t_Struct = | Struct : t_Struct
 '''


### PR DESCRIPTION
I had leftover work while working on iterators.
Those were required for iterators at the time, and are good generally.

This PR:
 - fixes the rust printer for projection predicates;
 - derive compare and sexp for every type of the AST;
 - add trait information on impl exprs 