### PR TITLE
Bump rustc version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -110,11 +110,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719281921,
-        "narHash": "sha256-LIBMfhM9pMOlEvBI757GOK5l0R58SRi6YpwfYMbf4yc=",
+        "lastModified": 1723429325,
+        "narHash": "sha256-4x/32xTCd+xCwFoI/kKSiCr5LQA2ZlyTRYXKEni5HR8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b6032d3a404d8a52ecfc8571ff0c26dfbe221d07",
+        "rev": "65e3dc0fe079fe8df087cd38f1fe6836a0373aad",
         "type": "github"
       },
       "original": {

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -454,7 +454,7 @@ pub mod rustc {
         use rustc_infer::infer::TyCtxtInferExt;
         use rustc_middle::traits::CodegenObligationError;
         use rustc_middle::ty::{self, TyCtxt, TypeVisitableExt};
-        use rustc_trait_selection::traits::error_reporting::TypeErrCtxtExt;
+        use rustc_trait_selection::error_reporting::InferCtxtErrorExt;
         use rustc_trait_selection::traits::{
             Obligation, ObligationCause, ObligationCtxt, ScrubbedTraitError, SelectionContext,
             Unimplemented,

--- a/frontend/exporter/src/types/mir.rs
+++ b/frontend/exporter/src/types/mir.rs
@@ -153,7 +153,6 @@ pub struct MirBody<KIND> {
     pub spread_arg: Option<Local>,
     pub var_debug_info: Vec<VarDebugInfo>,
     pub span: Span,
-    pub required_consts: Vec<Constant>,
     pub is_polymorphic: bool,
     pub injection_phase: Option<MirPhase>,
     pub tainted_by_errors: Option<ErrorGuaranteed>,
@@ -569,6 +568,11 @@ pub enum TerminatorKind {
         fn_span: Span,
         trait_refs: Vec<ImplExpr>,
         trait_info: Option<ImplExpr>,
+    },
+    TailCall {
+        func: Operand,
+        args: Vec<Spanned<Operand>>,
+        fn_span: Span,
     },
     Assert {
         cond: Operand,

--- a/frontend/exporter/src/types/todo.rs
+++ b/frontend/exporter/src/types/todo.rs
@@ -15,6 +15,7 @@ sinto_todo!(rustc_hir, GenericArgs<'a> as HirGenericArgs);
 sinto_todo!(rustc_hir, InlineAsm<'a>);
 sinto_todo!(rustc_target::spec::abi, Abi);
 sinto_todo!(rustc_hir, MissingLifetimeKind);
+sinto_todo!(rustc_hir, QPath<'tcx>);
 sinto_todo!(rustc_hir, WhereRegionPredicate<'tcx>);
 sinto_todo!(rustc_hir, WhereEqPredicate<'tcx>);
 sinto_todo!(rustc_hir, OwnerId);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-06-25"
+channel = "nightly-2024-08-11"
 components = [ "rustc-dev", "llvm-tools-preview" , "rust-analysis" , "rust-src" , "rustfmt" ]

--- a/test-harness/src/snapshots/toolchain__traits into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__traits into-fstar.snap
@@ -329,11 +329,11 @@ let impl (#v_TypeArg: Type0) (v_ConstArg: usize) : t_Trait Prims.unit v_TypeArg 
   }
 
 class t_SubTrait (v_Self: Type0) (v_TypeArg: Type0) (v_ConstArg: usize) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]_super_9139092951006237722:t_Trait v_Self
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_2645671271498264788:t_Trait v_Self
     v_TypeArg
     v_ConstArg;
   f_AssocType:Type0;
-  f_AssocType_11599353381930848827:t_Trait f_AssocType v_TypeArg v_ConstArg
+  f_AssocType_1171953828677564027:t_Trait f_AssocType v_TypeArg v_ConstArg
 }
 
 let associated_function_caller


### PR DESCRIPTION
Bump the version of rustc by 7 weeks, to get the benefits of https://github.com/rust-lang/rust/pull/127028 and https://github.com/rust-lang/rust/pull/128815.