### PR TITLE
fix(cli): when we generate a file that exists and has the same content, skip writing

### DIFF
--- a/hax-types/src/diagnostics/message.rs
+++ b/hax-types/src/diagnostics/message.rs
@@ -12,8 +12,9 @@ pub enum HaxMessage {
     EngineNotFound {
         is_opam_setup_correctly: bool,
     } = 0,
-    WroteFile {
+    ProducedFile {
         path: PathBuf,
+        wrote: bool,
     } = 1,
     HaxEngineFailure {
         exit_code: i32,


### PR DESCRIPTION
This PR:
 - prints relative paths instead of absolute ones in hax note messages
 - write files only when a file doesn't exists or has a different content as what we were about to write
 - prints the notice message `hax: unchanged file <path>` instead of `hax: wrote file <path>` in those cases

This is useful not to invalidate checked files in caches while typechecking F*