### PR TITLE
Remove unsize for certain types

### DIFF
--- a/test-harness/src/snapshots/toolchain__literals into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__literals into-fstar.snap
@@ -157,9 +157,11 @@ let panic_with_msg (_: Prims.unit) : Prims.unit =
 
 let empty_array (_: Prims.unit) : Prims.unit =
   let (_: t_Slice u8):t_Slice u8 =
-    Rust_primitives.unsize (let list:Prims.list u8 = [] in
-        FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 0);
-        Rust_primitives.Hax.array_of_list 0 list)
+    (let list:Prims.list u8 = [] in
+      FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 0);
+      Rust_primitives.Hax.array_of_list 0 list)
+    <:
+    t_Slice u8
   in
   ()
 

--- a/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
@@ -127,9 +127,9 @@ let index_mutation_unsize (x: t_Array u8 (sz 12)) : u8 =
               Core.Ops.Range.t_Range usize ]
             <:
             t_Slice u8)
-          (Rust_primitives.unsize (let list = [1uy; 2uy] in
-                FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
-                Rust_primitives.Hax.array_of_list 2 list)
+          ((let list = [1uy; 2uy] in
+              FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
+              Rust_primitives.Hax.array_of_list 2 list)
             <:
             t_Slice u8)
         <:

--- a/test-harness/src/snapshots/toolchain__slices into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__slices into-fstar.snap
@@ -34,16 +34,18 @@ open Core
 open FStar.Mul
 
 let v_VERSION: t_Slice u8 =
-  Rust_primitives.unsize (let list = [118uy; 49uy] in
-      FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
-      Rust_primitives.Hax.array_of_list 2 list)
+  (let list = [118uy; 49uy] in
+    FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
+    Rust_primitives.Hax.array_of_list 2 list)
+  <:
+  t_Slice u8
 
 let do_something (_: t_Slice u8) : Prims.unit = ()
 
 let r#unsized (_: t_Array (t_Slice u8) (sz 1)) : Prims.unit = ()
 
 let sized (x: t_Array (t_Array u8 (sz 4)) (sz 1)) : Prims.unit =
-  r#unsized (let list = [Rust_primitives.unsize (x.[ sz 0 ] <: t_Array u8 (sz 4)) <: t_Slice u8] in
+  r#unsized (let list = [x.[ sz 0 ] <: t_Slice u8] in
       FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 1);
       Rust_primitives.Hax.array_of_list 1 list)
 '''


### PR DESCRIPTION
Subsumes #854: this PR removes entirely `unsize` calls whenever it is called on arrays, in the F* backend.

The advantages are:
 - no unsize calls at all
 - easy to support other kinds of unsize which might not be identity, just by adding F* instances (or go the full way and hardcode something in the engine) 