### PR TITLE
Loop invariants

### DIFF
--- a/.utils/list-names.sh
+++ b/.utils/list-names.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+function pager() {
+    if command -v bat &> /dev/null; then
+        bat -l ml
+    else
+        less
+    fi
+}
+
+hax-engine-names-extract | sed '/include .val/,$d' | pager

--- a/engine/lib/ast_utils.ml
+++ b/engine/lib/ast_utils.ml
@@ -905,6 +905,13 @@ module Make (F : Features.T) = struct
       (`Concrete (Concrete_ident.of_name kind f_name))
       args span ret_typ
 
+  let make_closure (params : pat list) (body : expr) (span : span) : expr =
+    let params =
+      match params with [] -> [ make_wild_pat unit_typ span ] | _ -> params
+    in
+    let e = Closure { params; body; captures = [] } in
+    { e; typ = TArrow (List.map ~f:(fun p -> p.typ) params, body.typ); span }
+
   let string_lit span (s : string) : expr =
     { span; typ = TStr; e = Literal (String s) }
 

--- a/engine/lib/phases/phase_functionalize_loops.ml
+++ b/engine/lib/phases/phase_functionalize_loops.ml
@@ -33,6 +33,95 @@ struct
       include Features.SUBTYPE.Id
     end
 
+    type body_and_invariant = { body : B.expr; invariant : B.expr option }
+
+    let extract_loop_invariant (body : B.expr) : body_and_invariant =
+      match body.e with
+      | Let
+          {
+            monadic = None;
+            lhs = { p = PWild; _ };
+            rhs =
+              {
+                e = App { f = { e = GlobalVar f; _ }; args = [ invariant ]; _ };
+                _;
+              };
+            body;
+          }
+        when Global_ident.eq_name Hax_lib__loop_invariant f ->
+          { body; invariant = Some invariant }
+      | _ -> { body; invariant = None }
+
+    type iterator =
+      | Range of { start : B.expr; end_ : B.expr }
+      | Slice of B.expr
+      | ChunksExact of { size : B.expr; slice : B.expr }
+      | Enumerate of iterator
+      | StepBy of { n : B.expr; it : iterator }
+    [@@deriving show]
+
+    let rec as_iterator (e : B.expr) : iterator option =
+      match e.e with
+      | Construct
+          {
+            constructor = `Concrete range_ctor;
+            is_record = true;
+            is_struct = true;
+            fields =
+              [ (`Concrete start_field, start); (`Concrete end_field, end_) ];
+            base = None;
+          }
+        when Concrete_ident.eq_name Core__ops__range__Range__start start_field
+             && Concrete_ident.eq_name Core__ops__range__Range range_ctor
+             && Concrete_ident.eq_name Core__ops__range__Range__end end_field ->
+          Some (Range { start; end_ })
+      | _ -> meth_as_iterator e
+
+    and meth_as_iterator (e : B.expr) : iterator option =
+      let* f, args =
+        match e.e with
+        | App { f = { e = GlobalVar f; _ }; args; _ } -> Some (f, args)
+        | _ -> None
+      in
+      let f_eq n = Global_ident.eq_name n f in
+      let one_arg () = match args with [ x ] -> Some x | _ -> None in
+      let two_args () = match args with [ x; y ] -> Some (x, y) | _ -> None in
+      if f_eq Core__iter__traits__iterator__Iterator__step_by then
+        let* it, n = two_args () in
+        let* it = as_iterator it in
+        Some (StepBy { n; it })
+      else if
+        f_eq Core__iter__traits__collect__IntoIterator__into_iter
+        || f_eq Core__slice__Impl__iter
+      then
+        let* iterable = one_arg () in
+        match iterable.typ with
+        | TSlice _ -> Some (Slice iterable)
+        | _ -> as_iterator iterable
+      else if f_eq Core__iter__traits__iterator__Iterator__enumerate then
+        let* iterable = one_arg () in
+        let* iterator = as_iterator iterable in
+        Some (Enumerate iterator)
+      else if f_eq Core__slice__Impl__chunks_exact then
+        let* slice, size = two_args () in
+        Some (ChunksExact { size; slice })
+      else None
+
+    let fn_args_of_iterator (it : iterator) :
+        (Concrete_ident.name * B.expr list) option =
+      let open Concrete_ident_generated in
+      match it with
+      | Enumerate (ChunksExact { size; slice }) ->
+          Some
+            ( Rust_primitives__hax__folds__fold_enumerated_chunked_slice,
+              [ size; slice ] )
+      | Enumerate (Slice slice) ->
+          Some (Rust_primitives__hax__folds__fold_enumerated_slice, [ slice ])
+      | StepBy { n; it = Range { start; end_ } } ->
+          Some
+            (Rust_primitives__hax__folds__fold_range_step_by, [ start; end_; n ])
+      | _ -> None
+
     [%%inline_defs dmutability]
 
     let rec dexpr_unwrapped (expr : A.expr) : B.expr =
@@ -46,23 +135,32 @@ struct
             _;
           } ->
           let body = dexpr body in
+          let { body; invariant } = extract_loop_invariant body in
           let it = dexpr it in
           let pat = dpat pat in
           let bpat = dpat bpat in
-          let fn : B.expr' =
-            Closure { params = [ bpat; pat ]; body; captures = [] }
-          in
-          let fn : B.expr =
+          let as_lhs_closure e : B.expr =
             {
-              e = fn;
-              typ = TArrow ([ bpat.typ; pat.typ ], body.typ);
-              span = body.span;
+              e = Closure { params = [ bpat; pat ]; body = e; captures = [] };
+              typ = TArrow ([ bpat.typ; pat.typ ], e.typ);
+              span = e.span;
             }
           in
-          UB.call ~kind:(AssociatedItem Value)
-            Core__iter__traits__iterator__Iterator__fold
-            [ it; dexpr init; fn ]
-            span (dty span expr.typ)
+          let fn : B.expr = as_lhs_closure body in
+          let invariant : B.expr =
+            let default : B.expr =
+              { e = Literal (Bool true); typ = TBool; span = expr.span }
+            in
+            Option.value ~default invariant |> as_lhs_closure
+          in
+          let init = dexpr init in
+          let f, args =
+            match as_iterator it |> Option.bind ~f:fn_args_of_iterator with
+            | Some (f, args) -> (f, args @ [ init; invariant; fn ])
+            | None ->
+                (Core__iter__traits__iterator__Iterator__fold, [ it; init; fn ])
+          in
+          UB.call ~kind:(AssociatedItem Value) f args span (dty span expr.typ)
       | Loop
           {
             body;

--- a/engine/lib/phases/phase_functionalize_loops.ml
+++ b/engine/lib/phases/phase_functionalize_loops.ml
@@ -154,13 +154,13 @@ struct
             Option.value ~default invariant |> as_lhs_closure
           in
           let init = dexpr init in
-          let f, args =
+          let f, kind, args =
             match as_iterator it |> Option.bind ~f:fn_args_of_iterator with
-            | Some (f, args) -> (f, args @ [ init; invariant; fn ])
+            | Some (f, args) -> (f, Concrete_ident.Kind.Value, args @ [ init; invariant; fn ])
             | None ->
-                (Core__iter__traits__iterator__Iterator__fold, [ it; init; fn ])
+                (Core__iter__traits__iterator__Iterator__fold, AssociatedItem Value, [ it; init; fn ])
           in
-          UB.call ~kind:(AssociatedItem Value) f args span (dty span expr.typ)
+          UB.call ~kind f args span (dty span expr.typ)
       | Loop
           {
             body;

--- a/engine/lib/phases/phase_functionalize_loops.ml
+++ b/engine/lib/phases/phase_functionalize_loops.ml
@@ -48,7 +48,7 @@ struct
               };
             body;
           }
-        when Global_ident.eq_name Hax_lib__loop_invariant f ->
+        when Global_ident.eq_name Hax_lib___internal_loop_invariant f ->
           { body; invariant = Some invariant }
       | _ -> { body; invariant = None }
 

--- a/engine/lib/utils.ml
+++ b/engine/lib/utils.ml
@@ -93,3 +93,17 @@ module MyInt64 = struct
 
   let yojson_of_t (int64 : t) : Yojson.Safe.t = `Intlit (to_string int64)
 end
+
+include (
+  struct
+    let id = ref 0
+
+    let tempfile_path ~suffix =
+      id := !id + 1;
+      Core.Filename.(
+        concat temp_dir_name ("hax-debug-" ^ Int.to_string !id ^ suffix))
+  end :
+    sig
+      val tempfile_path : suffix:string -> string
+      (** Generates a temporary file path that ends with `suffix` *)
+    end)

--- a/engine/names/src/lib.rs
+++ b/engine/names/src/lib.rs
@@ -29,7 +29,7 @@ fn dummy_hax_concrete_ident_wrapper<I: core::iter::Iterator<Item = u8>>(x: I, mu
     assert!(true);
     assert_eq!(1, 1);
     hax_lib::assert!(true);
-    hax_lib::loop_invariant(true);
+    hax_lib::_internal_loop_invariant(true);
 
     let _ = [()].into_iter();
     let _: u16 = 6u8.into();

--- a/engine/names/src/lib.rs
+++ b/engine/names/src/lib.rs
@@ -29,7 +29,7 @@ fn dummy_hax_concrete_ident_wrapper<I: core::iter::Iterator<Item = u8>>(x: I, mu
     assert!(true);
     assert_eq!(1, 1);
     hax_lib::assert!(true);
-    hax_lib::_internal_loop_invariant(true);
+    hax_lib::_internal_loop_invariant(|_: usize| true);
 
     let _ = [()].into_iter();
     let _: u16 = 6u8.into();

--- a/engine/names/src/lib.rs
+++ b/engine/names/src/lib.rs
@@ -29,6 +29,7 @@ fn dummy_hax_concrete_ident_wrapper<I: core::iter::Iterator<Item = u8>>(x: I, mu
     assert!(true);
     assert_eq!(1, 1);
     hax_lib::assert!(true);
+    hax_lib::loop_invariant(true);
 
     let _ = [()].into_iter();
     let _: u16 = 6u8.into();
@@ -36,6 +37,14 @@ fn dummy_hax_concrete_ident_wrapper<I: core::iter::Iterator<Item = u8>>(x: I, mu
     let _ = 1..;
     let _ = ..;
     let _ = ..1;
+
+    fn iterator_functions<It: Iterator + Clone>(it: It) {
+        let _ = it.clone().step_by(2);
+        let _ = it.clone().enumerate();
+        let _ = [()].chunks_exact(2);
+        let _ = [()].iter();
+        let _ = (&[()] as &[()]).iter();
+    }
 
     {
         use hax_lib::int::*;
@@ -162,6 +171,13 @@ mod hax {
     // TODO: Should that live here? (this is F* specific)
     fn array_of_list() {}
     fn never_to_any() {}
+
+    mod folds {
+        fn fold_range() {}
+        fn fold_range_step_by() {}
+        fn fold_enumerated_slice() {}
+        fn fold_enumerated_chunked_slice() {}
+    }
 
     /// The engine uses this `dropped_body` symbol as a marker value
     /// to signal that a item was extracted without body.

--- a/flake.nix
+++ b/flake.nix
@@ -152,6 +152,15 @@
             })
           ];
         in let
+          utils = pkgs.stdenv.mkDerivation {
+            name = "hax-dev-scripts";
+            phases = ["installPhase"];
+            installPhase = ''
+                mkdir -p $out/bin
+                cp ${./.utils/rebuild.sh} $out/bin/rebuild
+                cp ${./.utils/list-names.sh} $out/bin/list-names
+              '';
+          };
           packages = [
             ocamlformat
             pkgs.ocamlPackages.ocaml-lsp
@@ -168,14 +177,7 @@
             rustfmt
             rustc
 
-            (pkgs.stdenv.mkDerivation {
-              name = "rebuild-script";
-              phases = ["installPhase"];
-              installPhase = ''
-                mkdir -p $out/bin
-                cp ${./.utils/rebuild.sh} $out/bin/rebuild
-              '';
-            })
+            utils
           ];
           LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
         in {
@@ -191,6 +193,7 @@
           };
           default = pkgs.mkShell {
             inherit packages inputsFrom LIBCLANG_PATH;
+            shellHook = ''echo "Commands available: $(ls ${utils}/bin | tr '\n' ' ')"'';
           };
         };
       }

--- a/hax-lib-macros/src/lib.rs
+++ b/hax-lib-macros/src/lib.rs
@@ -40,6 +40,25 @@ pub fn fstar_options(attr: pm::TokenStream, item: pm::TokenStream) -> pm::TokenS
     .into()
 }
 
+/// Add an invariant to a loop. This function must be called on the
+/// first line of a loop body to be effective. Note that in the
+/// invariant expression, `forall`, `exists`, and `BACKEND!`
+/// (`BACKEND` can be `fstar`, `proverif`, `coq`...) are in scope.
+#[proc_macro]
+pub fn loop_invariant(predicate: pm::TokenStream) -> pm::TokenStream {
+    let predicate: TokenStream = predicate.into();
+    quote! {
+        #[cfg(#HaxCfgOptionName)]
+        {
+            hax_lib::_internal_loop_invariant({
+                #HaxQuantifiers
+                #predicate
+            })
+        }
+    }
+    .into()
+}
+
 /// When extracting to F*, inform about what is the current
 /// verification status for an item. It can either be `lax` or
 /// `panic_free`.

--- a/hax-lib/src/lib.rs
+++ b/hax-lib/src/lib.rs
@@ -147,8 +147,9 @@ pub fn inline_unsafe<T>(_: &str) -> T {
     unreachable!()
 }
 
+/// A dummy function that holds a loop invariant.
 #[doc(hidden)]
-pub fn loop_invariant(_: bool) {}
+pub fn _internal_loop_invariant(_: bool) {}
 
 /// A type that implements `Refinement` should be a newtype for a
 /// type `T`. The field holding the value of type `T` should be

--- a/hax-lib/src/lib.rs
+++ b/hax-lib/src/lib.rs
@@ -149,7 +149,7 @@ pub fn inline_unsafe<T>(_: &str) -> T {
 
 /// A dummy function that holds a loop invariant.
 #[doc(hidden)]
-pub fn _internal_loop_invariant(_: bool) {}
+pub fn _internal_loop_invariant<T, P: FnOnce(T) -> bool>(_: P) {}
 
 /// A type that implements `Refinement` should be a newtype for a
 /// type `T`. The field holding the value of type `T` should be

--- a/hax-lib/src/lib.rs
+++ b/hax-lib/src/lib.rs
@@ -147,6 +147,9 @@ pub fn inline_unsafe<T>(_: &str) -> T {
     unreachable!()
 }
 
+#[doc(hidden)]
+pub fn loop_invariant(_: bool) {}
+
 /// A type that implements `Refinement` should be a newtype for a
 /// type `T`. The field holding the value of type `T` should be
 /// private, and `Refinement` should be the only interface to the

--- a/hax-lib/src/proc_macros.rs
+++ b/hax-lib/src/proc_macros.rs
@@ -2,8 +2,8 @@
 //! proc-macro crate cannot export anything but procedural macros.
 
 pub use hax_lib_macros::{
-    attributes, ensures, exclude, impl_fn_decoration, include, lemma, opaque_type, refinement_type,
-    requires, trait_fn_decoration,
+    attributes, ensures, exclude, impl_fn_decoration, include, lemma, loop_invariant, opaque_type,
+    refinement_type, requires, trait_fn_decoration,
 };
 
 pub use hax_lib_macros::{

--- a/proof-libs/fstar/rust_primitives/Rust_primitives.Hax.Folds.fsti
+++ b/proof-libs/fstar/rust_primitives/Rust_primitives.Hax.Folds.fsti
@@ -20,22 +20,22 @@ val fold_enumerated_chunked_slice
   (#t: Type0) (#acc_t: Type0)
   (chunk_size: usize {v chunk_size > 0})
   (s: t_Slice t)
-  (inv: acc_t -> (i:usize{v i <= v (length s)}) -> Type0)
+  (inv: acc_t -> (i:usize{v i <= Seq.length s / v chunk_size}) -> Type0)
   (init: acc_t {inv init (sz 0)})
   (f: ( acc:acc_t
-      -> item:(usize & t_Array t chunk_size) {
+      -> item:(usize & t_Slice t) {
         let (i, s_chunk) = item in
           v i < Seq.length s / v chunk_size
+        /\ length s_chunk == chunk_size
         /\ nth_chunk_of s s_chunk (v i)
-        /\ v i < v (length s) 
         /\ inv acc i
       }
       -> acc':acc_t {
-        v (fst item) < v (length s) /\ inv acc' (fst item)
+        inv acc' (fst item +! sz 1)
       }
       )
   )
-  : result: acc_t {inv result (length s)}
+  : result: acc_t {inv result (mk_int (Seq.length s / v chunk_size))}
 
 (**** `s.enumerate()` *)
 /// Fold function that is generated for `for` loops iterating on

--- a/proof-libs/fstar/rust_primitives/Rust_primitives.Hax.Folds.fsti
+++ b/proof-libs/fstar/rust_primitives/Rust_primitives.Hax.Folds.fsti
@@ -1,0 +1,103 @@
+module Rust_primitives.Hax.Folds
+
+open Rust_primitives
+open Core.Ops.Range
+open FStar.Mul
+
+(**** `s.chunks_exact(chunk_size).enumerate()` *)
+/// Predicate that asserts a slice `s_chunk` is exactly the nth chunk
+/// of the sequence `s`
+let nth_chunk_of #t
+  (s: Seq.seq t)
+  (s_chunk: Seq.seq t {Seq.length s_chunk > 0})
+  (chunk_nth: nat {chunk_nth < Seq.length s / Seq.length s_chunk})
+  =  Seq.slice s (Seq.length s_chunk * chunk_nth) (Seq.length s_chunk * (chunk_nth + 1))
+  == s_chunk
+
+/// Fold function that is generated for `for` loops iterating on
+/// `s.chunks_exact(chunk_size).enumerate()`-like iterators
+val fold_enumerated_chunked_slice
+  (#t: eqtype) (#acc_t: eqtype)
+  (chunk_size: usize {v chunk_size > 0})
+  (s: t_Slice t)
+  (inv: acc_t -> (i:usize{v i <= v (length s)}) -> Type0)
+  (init: acc_t {inv init (sz 0)})
+  (f: ( acc:acc_t
+      -> item:(usize & t_Array t chunk_size) {
+        let (i, s_chunk) = item in
+          v i < Seq.length s / v chunk_size
+        /\ nth_chunk_of s s_chunk (v i)
+        /\ v i < v (length s) 
+        /\ inv acc i
+      }
+      -> acc':acc_t {
+        v (fst item) < v (length s) /\ inv acc' (fst item)
+      }
+      )
+  )
+  : result: acc_t {inv result (length s)}
+
+(**** `s.enumerate()` *)
+/// Fold function that is generated for `for` loops iterating on
+/// `s.enumerate()`-like iterators
+val fold_enumerated_slice
+  (#t: eqtype) (#acc_t: eqtype)
+  (s: t_Slice t)
+  (inv: acc_t -> (i:usize{v i <= v (length s)}) -> Type0)
+  (init: acc_t {inv init (sz 0)})
+  (f: (acc:acc_t -> i:(usize & t) {v (fst i) < v (length s) /\ inv acc  (fst i)}
+                 -> acc':acc_t    {v (fst i) < v (length s) /\ inv acc' (fst i)}))
+  : result: acc_t {inv result (length s)}
+
+(**** `(start..end_).step_by(step)` *)
+unfold let fold_range_step_by_wf_index (#u: Lib.IntTypes.inttype)
+  (start: int_t u) (end_: int_t u {v start <= v end_})
+  (step: usize {v step > 0}) (strict: bool) (i: int)
+  = i >= v start 
+  /\ (if strict then i < v end_ else i <= v end_ + v step)
+  // /\ i % v step == v start % v step
+
+#push-options "--z3rlimit 80"
+unfold let fold_range_step_by_upper_bound (#u: Lib.IntTypes.inttype)
+  (start: int_t u) (end_: int_t u {v start <= v end_})
+  (step: usize {v step > 0})
+  : end':int {fold_range_step_by_wf_index start end_ step false end'}
+  = if end_ = start 
+    then v end_
+    else
+      let range: nat = v end_ - v start in
+      let k: nat = range / v step in
+      let end' = v start + k * v step in
+      FStar.Math.Lemmas.division_propriety range (v step);
+      end'
+#pop-options
+
+/// Fold function that is generated for `for` loops iterating on
+/// `s.enumerate()`-like iterators
+val fold_range_step_by
+  (#acc_t: eqtype) (#u: Lib.IntTypes.inttype)
+  (start: int_t u)
+  (end_: int_t u {v start <= v end_})
+  (step: usize {v step > 0 /\ range (v end_ + v step) u})
+  (inv: acc_t -> (i:int_t u{fold_range_step_by_wf_index start end_ step false (v i)}) -> Type0)
+  (init: acc_t {inv init start})
+  (f: (acc:acc_t -> i:int_t u  {fold_range_step_by_wf_index start end_ step true (v i) /\ inv acc i}
+                 -> acc':acc_t {(inv acc (mk_int (v i + v step)))}))
+  : result: acc_t {inv result (mk_int (fold_range_step_by_upper_bound start end_ step))}
+
+(**** `start..end_` *)
+unfold let fold_range_wf_index (#u: Lib.IntTypes.inttype)
+  (start: int_t u) (end_: int_t u {v start <= v end_})
+  (strict: bool) (i: int)
+  = i >= v start 
+  /\ (if strict then i < v end_ else i <= v end_)
+
+val fold_range
+  (#acc_t: eqtype) (#u: Lib.IntTypes.inttype)
+  (start: int_t u)
+  (end_: int_t u {v start <= v end_})
+  (inv: acc_t -> (i:int_t u{fold_range_wf_index start end_ false (v i)}) -> Type0)
+  (init: acc_t {inv init start})
+  (f: (acc:acc_t -> i:int_t u  {fold_range_wf_index start end_ true (v i) /\ inv acc i}
+                 -> acc':acc_t {(inv acc (mk_int (v i + 1)))}))
+  : result: acc_t {inv result end_}

--- a/proof-libs/fstar/rust_primitives/Rust_primitives.Hax.Folds.fsti
+++ b/proof-libs/fstar/rust_primitives/Rust_primitives.Hax.Folds.fsti
@@ -17,7 +17,7 @@ let nth_chunk_of #t
 /// Fold function that is generated for `for` loops iterating on
 /// `s.chunks_exact(chunk_size).enumerate()`-like iterators
 val fold_enumerated_chunked_slice
-  (#t: eqtype) (#acc_t: eqtype)
+  (#t: Type0) (#acc_t: Type0)
   (chunk_size: usize {v chunk_size > 0})
   (s: t_Slice t)
   (inv: acc_t -> (i:usize{v i <= v (length s)}) -> Type0)
@@ -41,7 +41,7 @@ val fold_enumerated_chunked_slice
 /// Fold function that is generated for `for` loops iterating on
 /// `s.enumerate()`-like iterators
 val fold_enumerated_slice
-  (#t: eqtype) (#acc_t: eqtype)
+  (#t: Type0) (#acc_t: Type0)
   (s: t_Slice t)
   (inv: acc_t -> (i:usize{v i <= v (length s)}) -> Type0)
   (init: acc_t {inv init (sz 0)})
@@ -75,14 +75,14 @@ unfold let fold_range_step_by_upper_bound (#u: Lib.IntTypes.inttype)
 /// Fold function that is generated for `for` loops iterating on
 /// `s.enumerate()`-like iterators
 val fold_range_step_by
-  (#acc_t: eqtype) (#u: Lib.IntTypes.inttype)
+  (#acc_t: Type0) (#u: Lib.IntTypes.inttype)
   (start: int_t u)
   (end_: int_t u)
   (step: usize {v step > 0 /\ range (v end_ + v step) u})
   (inv: acc_t -> (i:int_t u{fold_range_step_by_wf_index start end_ step false (v i)}) -> Type0)
   (init: acc_t {inv init start})
   (f: (acc:acc_t -> i:int_t u  {v i < v end_ /\ fold_range_step_by_wf_index start end_ step true (v i) /\ inv acc i}
-                 -> acc':acc_t {(inv acc (mk_int (v i + v step)))}))
+                 -> acc':acc_t {(inv acc' (mk_int (v i + v step)))}))
   : result: acc_t {inv result (mk_int (fold_range_step_by_upper_bound start end_ step))}
 
 (**** `start..end_` *)
@@ -94,11 +94,11 @@ unfold let fold_range_wf_index (#u: Lib.IntTypes.inttype)
      /\ (if strict then i < v end_ else i <= v end_))
 
 val fold_range
-  (#acc_t: eqtype) (#u: Lib.IntTypes.inttype)
+  (#acc_t: Type0) (#u: Lib.IntTypes.inttype)
   (start: int_t u)
   (end_: int_t u)
   (inv: acc_t -> (i:int_t u{fold_range_wf_index start end_ false (v i)}) -> Type0)
   (init: acc_t {inv init start})
   (f: (acc:acc_t -> i:int_t u  {v i <= v end_ /\ fold_range_wf_index start end_ true (v i) /\ inv acc i}
-                 -> acc':acc_t {(inv acc (mk_int (v i + 1)))}))
+                 -> acc':acc_t {(inv acc' (mk_int (v i + 1)))}))
   : result: acc_t {inv result end_}

--- a/test-harness/src/snapshots/toolchain__generics into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__generics into-fstar.snap
@@ -111,14 +111,12 @@ let call_g (_: Prims.unit) : usize =
 let foo (v_LEN: usize) (arr: t_Array usize v_LEN) : usize =
   let acc:usize = v_LEN +! sz 9 in
   let acc:usize =
-    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter #(Core.Ops.Range.t_Range
-            usize)
-          #FStar.Tactics.Typeclasses.solve
-          ({ Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = v_LEN }
-            <:
-            Core.Ops.Range.t_Range usize)
-        <:
-        Core.Ops.Range.t_Range usize)
+    Rust_primitives.Hax.Folds.fold_range (sz 0)
+      v_LEN
+      (fun acc temp_1_ ->
+          let acc:usize = acc in
+          let _:usize = temp_1_ in
+          true)
       acc
       (fun acc i ->
           let acc:usize = acc in

--- a/test-harness/src/snapshots/toolchain__loops into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__loops into-fstar.snap
@@ -148,7 +148,7 @@ let enumerate_chunks (arr: Alloc.Vec.t_Vec usize Alloc.Alloc.t_Global) : usize =
       (fun acc temp_1_ ->
           let acc:usize = acc in
           let i, chunk:(usize & t_Slice usize) = temp_1_ in
-          Rust_primitives.Hax.f_fold_enumerated_slice chunk
+          Rust_primitives.Hax.Folds.fold_enumerated_slice chunk
             acc
             (fun acc temp_1_ ->
                 let acc:usize = acc in
@@ -359,21 +359,22 @@ open FStar.Mul
 
 let enumerated_chunked_slice (#v_T: Type0) (slice: t_Slice v_T) : u64 =
   let count:u64 = 0uL in
-  Rust_primitives.Hax.f_fold_enumerated_chunked_slice (sz 3)
+  Rust_primitives.Hax.Folds.fold_enumerated_chunked_slice (sz 3)
     slice
     count
     (fun count i ->
         let count:u64 = count in
         let i:(usize & t_Slice v_T) = i in
-        true)
+        forall (x: nat). x >= 0)
     (fun count i ->
         let count:u64 = count in
         let i:(usize & t_Slice v_T) = i in
-        count +! 3uL <: u64)
+        let count:u64 = count +! 3uL in
+        count)
 
 let enumerated_slice (#v_T: Type0) (slice: t_Slice v_T) : u64 =
   let count:u64 = 0uL in
-  Rust_primitives.Hax.f_fold_enumerated_slice slice
+  Rust_primitives.Hax.Folds.fold_enumerated_slice slice
     count
     (fun count i ->
         let count:u64 = count in
@@ -387,7 +388,7 @@ let enumerated_slice (#v_T: Type0) (slice: t_Slice v_T) : u64 =
 
 let range_step_by (_: Prims.unit) : u64 =
   let count:u64 = 0uL in
-  Rust_primitives.Hax.f_fold_range_step_by 0l
+  Rust_primitives.Hax.Folds.fold_range_step_by 0l
     10l
     (sz 2)
     count

--- a/test-harness/src/snapshots/toolchain__loops into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__loops into-fstar.snap
@@ -148,17 +148,12 @@ let enumerate_chunks (arr: Alloc.Vec.t_Vec usize Alloc.Alloc.t_Global) : usize =
       (fun acc temp_1_ ->
           let acc:usize = acc in
           let i, chunk:(usize & t_Slice usize) = temp_1_ in
-          Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter #(Core.Iter.Adapters.Enumerate.t_Enumerate
-                  (Core.Slice.Iter.t_Iter usize))
-                #FStar.Tactics.Typeclasses.solve
-                (Core.Iter.Traits.Iterator.f_enumerate #(Core.Slice.Iter.t_Iter usize)
-                    #FStar.Tactics.Typeclasses.solve
-                    (Core.Slice.impl__iter #usize chunk <: Core.Slice.Iter.t_Iter usize)
-                  <:
-                  Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_Iter usize))
-              <:
-              Core.Iter.Adapters.Enumerate.t_Enumerate (Core.Slice.Iter.t_Iter usize))
+          Rust_primitives.Hax.f_fold_enumerated_slice chunk
             acc
+            (fun acc temp_1_ ->
+                let acc:usize = acc in
+                let j, x:(usize & usize) = temp_1_ in
+                true)
             (fun acc temp_1_ ->
                 let acc:usize = acc in
                 let j, x:(usize & usize) = temp_1_ in
@@ -355,6 +350,56 @@ let rev_range (n: usize) : usize =
           (acc +! i <: usize) +! sz 1 <: usize)
   in
   acc
+'''
+"Loops.Recognized_loops.fst" = '''
+module Loops.Recognized_loops
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+let enumerated_chunked_slice (#v_T: Type0) (slice: t_Slice v_T) : u64 =
+  let count:u64 = 0uL in
+  Rust_primitives.Hax.f_fold_enumerated_chunked_slice (sz 3)
+    slice
+    count
+    (fun count i ->
+        let count:u64 = count in
+        let i:(usize & t_Slice v_T) = i in
+        true)
+    (fun count i ->
+        let count:u64 = count in
+        let i:(usize & t_Slice v_T) = i in
+        count +! 3uL <: u64)
+
+let enumerated_slice (#v_T: Type0) (slice: t_Slice v_T) : u64 =
+  let count:u64 = 0uL in
+  Rust_primitives.Hax.f_fold_enumerated_slice slice
+    count
+    (fun count i ->
+        let count:u64 = count in
+        let i:(usize & v_T) = i in
+        false)
+    (fun count i ->
+        let count:u64 = count in
+        let i:(usize & v_T) = i in
+        let count:u64 = count +! 2uL in
+        count)
+
+let range_step_by (_: Prims.unit) : u64 =
+  let count:u64 = 0uL in
+  Rust_primitives.Hax.f_fold_range_step_by 0l
+    10l
+    (sz 2)
+    count
+    (fun count i ->
+        let count:u64 = count in
+        let i:i32 = i in
+        i <. 20l <: bool)
+    (fun count i ->
+        let count:u64 = count in
+        let i:i32 = i in
+        let count:u64 = count +! 1uL in
+        count)
 '''
 "Loops.While_loops.fst" = '''
 module Loops.While_loops

--- a/test-harness/src/snapshots/toolchain__loops into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__loops into-fstar.snap
@@ -21,22 +21,7 @@ info:
     backend_options: ~
 ---
 exit = 0
-stderr = '''
-warning: unnecessary parentheses around `for` iterator expression
- --> loops/src/lib.rs:4:18
-  |
-4 |         for i in (0u8..10u8) {
-  |                  ^         ^
-  |
-  = note: `#[warn(unused_parens)]` on by default
-help: remove these parentheses
-  |
-4 -         for i in (0u8..10u8) {
-4 +         for i in 0u8..10u8 {
-  |
-
-warning: `loops` (lib) generated 1 warning (run `cargo fix --lib -p loops` to apply 1 suggestion)
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in XXs'''
+stderr = 'Finished `dev` profile [unoptimized + debuginfo] target(s) in XXs'
 
 [stdout]
 diagnostics = []

--- a/test-harness/src/snapshots/toolchain__loops into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__loops into-fstar.snap
@@ -21,7 +21,22 @@ info:
     backend_options: ~
 ---
 exit = 0
-stderr = 'Finished `dev` profile [unoptimized + debuginfo] target(s) in XXs'
+stderr = '''
+warning: unnecessary parentheses around `for` iterator expression
+ --> loops/src/lib.rs:4:18
+  |
+4 |         for i in (0u8..10u8) {
+  |                  ^         ^
+  |
+  = note: `#[warn(unused_parens)]` on by default
+help: remove these parentheses
+  |
+4 -         for i in (0u8..10u8) {
+4 +         for i in 0u8..10u8 {
+  |
+
+warning: `loops` (lib) generated 1 warning (run `cargo fix --lib -p loops` to apply 1 suggestion)
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in XXs'''
 
 [stdout]
 diagnostics = []
@@ -149,11 +164,11 @@ let enumerate_chunks (arr: Alloc.Vec.t_Vec usize Alloc.Alloc.t_Global) : usize =
           let acc:usize = acc in
           let i, chunk:(usize & t_Slice usize) = temp_1_ in
           Rust_primitives.Hax.Folds.fold_enumerated_slice chunk
-            acc
             (fun acc temp_1_ ->
                 let acc:usize = acc in
-                let j, x:(usize & usize) = temp_1_ in
+                let _:usize = temp_1_ in
                 true)
+            acc
             (fun acc temp_1_ ->
                 let acc:usize = acc in
                 let j, x:(usize & usize) = temp_1_ in
@@ -165,12 +180,12 @@ let enumerate_chunks (arr: Alloc.Vec.t_Vec usize Alloc.Alloc.t_Global) : usize =
 
 let f (_: Prims.unit) : u8 =
   let acc:u8 = 0uy in
-  Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter #(Core.Ops.Range.t_Range u8
-        )
-        #FStar.Tactics.Typeclasses.solve
-        ({ Core.Ops.Range.f_start = 1uy; Core.Ops.Range.f_end = 10uy } <: Core.Ops.Range.t_Range u8)
-      <:
-      Core.Ops.Range.t_Range u8)
+  Rust_primitives.Hax.Folds.fold_range 1uy
+    10uy
+    (fun acc temp_1_ ->
+        let acc:u8 = acc in
+        let _:u8 = temp_1_ in
+        true)
     acc
     (fun acc i ->
         let acc:u8 = acc in
@@ -293,14 +308,12 @@ let pattern (arr: Alloc.Vec.t_Vec (usize & usize) Alloc.Alloc.t_Global) : usize 
 let range1 (_: Prims.unit) : usize =
   let acc:usize = sz 0 in
   let acc:usize =
-    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter #(Core.Ops.Range.t_Range
-            usize)
-          #FStar.Tactics.Typeclasses.solve
-          ({ Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = sz 15 }
-            <:
-            Core.Ops.Range.t_Range usize)
-        <:
-        Core.Ops.Range.t_Range usize)
+    Rust_primitives.Hax.Folds.fold_range (sz 0)
+      (sz 15)
+      (fun acc temp_1_ ->
+          let acc:usize = acc in
+          let _:usize = temp_1_ in
+          true)
       acc
       (fun acc i ->
           let acc:usize = acc in
@@ -312,14 +325,12 @@ let range1 (_: Prims.unit) : usize =
 let range2 (n: usize) : usize =
   let acc:usize = sz 0 in
   let acc:usize =
-    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter #(Core.Ops.Range.t_Range
-            usize)
-          #FStar.Tactics.Typeclasses.solve
-          ({ Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = n +! sz 10 <: usize }
-            <:
-            Core.Ops.Range.t_Range usize)
-        <:
-        Core.Ops.Range.t_Range usize)
+    Rust_primitives.Hax.Folds.fold_range (sz 0)
+      (n +! sz 10 <: usize)
+      (fun acc temp_1_ ->
+          let acc:usize = acc in
+          let _:usize = temp_1_ in
+          true)
       acc
       (fun acc i ->
           let acc:usize = acc in
@@ -361,11 +372,11 @@ let enumerated_chunked_slice (#v_T: Type0) (slice: t_Slice v_T) : u64 =
   let count:u64 = 0uL in
   Rust_primitives.Hax.Folds.fold_enumerated_chunked_slice (sz 3)
     slice
-    count
     (fun count i ->
         let count:u64 = count in
-        let i:(usize & t_Slice v_T) = i in
-        forall (x: nat). x >= 0)
+        let i:usize = i in
+        i <= Core.Slice.impl__len #v_T slice)
+    count
     (fun count i ->
         let count:u64 = count in
         let i:(usize & t_Slice v_T) = i in
@@ -375,30 +386,45 @@ let enumerated_chunked_slice (#v_T: Type0) (slice: t_Slice v_T) : u64 =
 let enumerated_slice (#v_T: Type0) (slice: t_Slice v_T) : u64 =
   let count:u64 = 0uL in
   Rust_primitives.Hax.Folds.fold_enumerated_slice slice
-    count
     (fun count i ->
         let count:u64 = count in
-        let i:(usize & v_T) = i in
-        false)
+        let i:usize = i in
+        i <=. sz 10 <: bool)
+    count
     (fun count i ->
         let count:u64 = count in
         let i:(usize & v_T) = i in
         let count:u64 = count +! 2uL in
         count)
 
-let range_step_by (_: Prims.unit) : u64 =
+let range (_: Prims.unit) : u64 =
   let count:u64 = 0uL in
-  Rust_primitives.Hax.Folds.fold_range_step_by 0l
-    10l
-    (sz 2)
+  Rust_primitives.Hax.Folds.fold_range 0uy
+    10uy
+    (fun count i ->
+        let count:u64 = count in
+        let i:u8 = i in
+        i <=. 10uy <: bool)
     count
     (fun count i ->
         let count:u64 = count in
-        let i:i32 = i in
-        i <. 20l <: bool)
+        let i:u8 = i in
+        let count:u64 = count +! 1uL in
+        count)
+
+let range_step_by (_: Prims.unit) : u64 =
+  let count:u64 = 0uL in
+  Rust_primitives.Hax.Folds.fold_range_step_by 0uy
+    10uy
+    (sz 2)
     (fun count i ->
         let count:u64 = count in
-        let i:i32 = i in
+        let i:u8 = i in
+        i <=. 10uy <: bool)
+    count
+    (fun count i ->
+        let count:u64 = count in
+        let i:u8 = i in
         let count:u64 = count +! 1uL in
         count)
 '''

--- a/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__mut-ref-functionalization into-fstar.snap
@@ -195,14 +195,12 @@ let impl__S__update (self: t_S) (x: u8) : t_S =
 
 let foo (lhs rhs: t_S) : t_S =
   let lhs:t_S =
-    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter #(Core.Ops.Range.t_Range
-            usize)
-          #FStar.Tactics.Typeclasses.solve
-          ({ Core.Ops.Range.f_start = sz 0; Core.Ops.Range.f_end = sz 1 }
-            <:
-            Core.Ops.Range.t_Range usize)
-        <:
-        Core.Ops.Range.t_Range usize)
+    Rust_primitives.Hax.Folds.fold_range (sz 0)
+      (sz 1)
+      (fun lhs temp_1_ ->
+          let lhs:t_S = lhs in
+          let _:usize = temp_1_ in
+          true)
       lhs
       (fun lhs i ->
           let lhs:t_S = lhs in
@@ -244,14 +242,12 @@ let g (x: t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global))
     : Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global =
   let x:t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) = x in
   let x:t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) =
-    Core.Iter.Traits.Iterator.f_fold (Core.Iter.Traits.Collect.f_into_iter #(Core.Ops.Range.t_Range
-            u8)
-          #FStar.Tactics.Typeclasses.solve
-          ({ Core.Ops.Range.f_start = 1uy; Core.Ops.Range.f_end = 10uy }
-            <:
-            Core.Ops.Range.t_Range u8)
-        <:
-        Core.Ops.Range.t_Range u8)
+    Rust_primitives.Hax.Folds.fold_range 1uy
+      10uy
+      (fun x temp_1_ ->
+          let x:t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) = x in
+          let _:u8 = temp_1_ in
+          true)
       x
       (fun x i ->
           let x:t_Pair (Alloc.Vec.t_Vec u8 Alloc.Alloc.t_Global) = x in

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -499,6 +499,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 [[package]]
 name = "loops"
 version = "0.1.0"
+dependencies = [
+ "hax-lib",
+]
 
 [[package]]
 name = "memchr"

--- a/tests/loops/Cargo.toml
+++ b/tests/loops/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+hax-lib = { path = "../../hax-lib" }
 
 [package.metadata.hax-tests]
 into."fstar" = { }

--- a/tests/loops/src/lib.rs
+++ b/tests/loops/src/lib.rs
@@ -1,3 +1,26 @@
+mod recognized_loops {
+    fn range_step_by() {
+        let mut count = 0u64;
+        for i in (0..10).step_by(2) {
+            hax_lib::loop_invariant(i < 20);
+            count += 1;
+        }
+    }
+    fn enumerated_slice<T>(slice: &[T]) {
+        let mut count = 0u64;
+        for i in slice.into_iter().enumerate() {
+            hax_lib::loop_invariant(false);
+            count += 2;
+        }
+    }
+    fn enumerated_chunked_slice<T>(slice: &[T]) {
+        let mut count = 0u64;
+        for i in slice.chunks_exact(3).enumerate() {
+            count += 3;
+        }
+    }
+}
+
 mod for_loops {
     fn range1() -> usize {
         let mut acc = 0;

--- a/tests/loops/src/lib.rs
+++ b/tests/loops/src/lib.rs
@@ -2,20 +2,21 @@ mod recognized_loops {
     fn range_step_by() {
         let mut count = 0u64;
         for i in (0..10).step_by(2) {
-            hax_lib::loop_invariant(i < 20);
+            hax_lib::loop_invariant!(i < 20);
             count += 1;
         }
     }
     fn enumerated_slice<T>(slice: &[T]) {
         let mut count = 0u64;
         for i in slice.into_iter().enumerate() {
-            hax_lib::loop_invariant(false);
+            hax_lib::loop_invariant!(false);
             count += 2;
         }
     }
     fn enumerated_chunked_slice<T>(slice: &[T]) {
         let mut count = 0u64;
         for i in slice.chunks_exact(3).enumerate() {
+            hax_lib::loop_invariant!(fstar!("forall (x: nat). x >= 0"));
             count += 3;
         }
     }

--- a/tests/loops/src/lib.rs
+++ b/tests/loops/src/lib.rs
@@ -1,22 +1,29 @@
 mod recognized_loops {
+    fn range() {
+        let mut count = 0u64;
+        for i in 0u8..10u8 {
+            hax_lib::loop_invariant!(|i: u8| i <= 10);
+            count += 1;
+        }
+    }
     fn range_step_by() {
         let mut count = 0u64;
-        for i in (0..10).step_by(2) {
-            hax_lib::loop_invariant!(i < 20);
+        for i in (0u8..10u8).step_by(2) {
+            hax_lib::loop_invariant!(|i: u8| i <= 10);
             count += 1;
         }
     }
     fn enumerated_slice<T>(slice: &[T]) {
         let mut count = 0u64;
         for i in slice.into_iter().enumerate() {
-            hax_lib::loop_invariant!(false);
+            hax_lib::loop_invariant!(|i: usize| i <= 10);
             count += 2;
         }
     }
     fn enumerated_chunked_slice<T>(slice: &[T]) {
         let mut count = 0u64;
         for i in slice.chunks_exact(3).enumerate() {
-            hax_lib::loop_invariant!(fstar!("forall (x: nat). x >= 0"));
+            hax_lib::loop_invariant!(|i: usize| { fstar!("$i <= ${slice.len()}") });
             count += 3;
         }
     }


### PR DESCRIPTION
This PR recognizes and transforms in a particular way the following loops. It also injects invariants.

```rust
fn range() {
    let mut count = 0u64;
    for i in 0u8..10u8 {
        hax_lib::loop_invariant!(|i: u8| i <= 10);
        count += 1;
    }
}
fn range_step_by() {
    let mut count = 0u64;
    for i in (0u8..10u8).step_by(2) {
        hax_lib::loop_invariant!(|i: u8| i <= 10);
        count += 1;
    }
}
fn enumerated_slice<T>(slice: &[T]) {
    let mut count = 0u64;
    for i in slice.into_iter().enumerate() {
        hax_lib::loop_invariant!(|i: usize| i <= 10);
        count += 2;
    }
}
fn enumerated_chunked_slice<T>(slice: &[T]) {
    let mut count = 0u64;
    for i in slice.chunks_exact(3).enumerate() {
        hax_lib::loop_invariant!(|i: usize| { fstar!("$i <= ${slice.len()}") });
        count += 3;
    }
}

```
[Open this code snippet in the playground](https://hax-playground.cryspen.com/#fstar/c27e57e453/gist=d122ede5a56ea8d3468ece70edcd532f)


The design is not great, I copy paste here the documentation of  `loop_invariant`:
```rust
/// Add an invariant to a loop which deals with an index. The
/// invariant cannot refer to any variable introduced within the
/// loop. An invariant is a closure that takes one argument, the
/// index, and returns a boolean.
///
/// Note that loop invariants are unstable (this will be handled in a
/// better way in the future, see
/// https://github.com/hacspec/hax/issues/858) and only supported on
/// specific `for` loops with specific iterators:
///
///  - `for i in start..end {...}`
///  - `for i in (start..end).step_by(n) {...}`
///  - `for i in slice.enumerate() {...}`
///  - `for i in slice.chunks_exact(n).enumerate() {...}`
///
/// This function must be called on the first line of a loop body to
/// be effective. Note that in the invariant expression, `forall`,
/// `exists`, and `BACKEND!` (`BACKEND` can be `fstar`, `proverif`,
/// `coq`...) are in scope.
``` 

This fixes #605.

Things left to do:
 - [x] add F* definitions