### PR TITLE
Backend: Import unsafe code as a gated feature

### DIFF
--- a/engine/backends/coq/coq/coq_backend.ml
+++ b/engine/backends/coq/coq/coq_backend.ml
@@ -43,7 +43,8 @@ module SubtypeToInputLanguage
              and type state_passing_loop = Features.Off.state_passing_loop
              and type dyn = Features.Off.dyn
              and type match_guard = Features.Off.match_guard
-             and type trait_item_default = Features.Off.trait_item_default) =
+             and type trait_item_default = Features.Off.trait_item_default
+             and type unsafe = Features.Off.unsafe) =
 struct
   module FB = InputLanguage
 
@@ -701,7 +702,8 @@ open Phase_utils
 
 module TransformToInputLanguage =
   [%functor_application
-  Phases.Reject.RawOrMutPointer(Features.Rust)
+  Phases.Reject.Unsafe(Features.Rust)
+  |> Phases.Reject.RawOrMutPointer
   |> Phases.And_mut_defsite
   |> Phases.Reconstruct_asserts
   |> Phases.Reconstruct_for_loops

--- a/engine/backends/coq/ssprove/ssprove_backend.ml
+++ b/engine/backends/coq/ssprove/ssprove_backend.ml
@@ -43,7 +43,8 @@ module SubtypeToInputLanguage
              and type block = Features.Off.block
              and type dyn = Features.Off.dyn
              and type match_guard = Features.Off.match_guard
-             and type trait_item_default = Features.Off.trait_item_default) =
+             and type trait_item_default = Features.Off.trait_item_default
+             and type unsafe = Features.Off.unsafe) =
 struct
   module FB = InputLanguage
 
@@ -565,7 +566,8 @@ open Phase_utils
 
 module TransformToInputLanguage (* : PHASE *) =
   [%functor_application
-    Phases.Reject.RawOrMutPointer(Features.Rust)
+    Phases.Reject.Unsafe(Features.Rust)
+    |> Phases.Reject.RawOrMutPointer
     |> Phases.And_mut_defsite
     |> Phases.Reconstruct_asserts
     |> Phases.Reconstruct_for_loops

--- a/engine/backends/easycrypt/easycrypt_backend.ml
+++ b/engine/backends/easycrypt/easycrypt_backend.ml
@@ -61,6 +61,7 @@ module RejectNotEC (FA : Features.T) = struct
         let dyn = reject
         let match_guard = reject
         let trait_item_default = reject
+        let unsafe = reject
         let construct_base _ _ = Features.On.construct_base
         let for_index_loop _ _ = Features.On.for_index_loop
 
@@ -347,10 +348,10 @@ open Phase_utils
 
 module TransformToInputLanguage =
 [%functor_application
-Phases.Reject.RawOrMutPointer Features.Rust |> Phases.And_mut_defsite
-|> Phases.Reconstruct_asserts |> Phases.Reconstruct_for_loops
-|> Phases.Direct_and_mut |> Phases.Drop_blocks |> Phases.Reject.Continue
-|> Phases.Drop_references |> RejectNotEC]
+Phases.Reject.RawOrMutPointer Features.Rust |> Phases.Reject.Unsafe
+|> Phases.And_mut_defsite |> Phases.Reconstruct_asserts
+|> Phases.Reconstruct_for_loops |> Phases.Direct_and_mut |> Phases.Drop_blocks
+|> Phases.Reject.Continue |> Phases.Drop_references |> RejectNotEC]
 
 let apply_phases (_bo : BackendOptions.t) (items : Ast.Rust.item list) :
     AST.item list =

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -42,7 +42,8 @@ module SubtypeToInputLanguage
              and type for_index_loop = Features.Off.for_index_loop
              and type state_passing_loop = Features.Off.state_passing_loop
              and type match_guard = Features.Off.match_guard
-             and type trait_item_default = Features.Off.trait_item_default) =
+             and type trait_item_default = Features.Off.trait_item_default
+             and type unsafe = Features.Off.unsafe) =
 struct
   module FB = InputLanguage
 
@@ -1683,7 +1684,8 @@ module DepGraphR = Dependencies.Make (Features.Rust)
 
 module TransformToInputLanguage =
   [%functor_application
-  Phases.Reject.RawOrMutPointer(Features.Rust)
+  Phases.Reject.Unsafe(Features.Rust)
+  |> Phases.Reject.RawOrMutPointer
   |> Phases.Transform_hax_lib_inline
   |> Phases.Specialize
   |> Phases.Drop_sized_trait

--- a/engine/backends/proverif/proverif_backend.ml
+++ b/engine/backends/proverif/proverif_backend.ml
@@ -79,6 +79,7 @@ struct
         let dyn = reject
         let match_guard = reject
         let trait_item_default = reject
+        let unsafe = reject
         let metadata = Phase_reject.make_metadata (NotInBackendLang ProVerif)
       end)
 
@@ -888,11 +889,12 @@ module DepGraphR = Dependencies.Make (Features.Rust)
 
 module TransformToInputLanguage =
   [%functor_application
-    Phases.Reject.RawOrMutPointer(Features.Rust)
-    |> Phases.Transform_hax_lib_inline
-    |> Phases.Simplify_question_marks
-    |> Phases.And_mut_defsite
-    |> Phases.Reconstruct_for_loops
+  Phases.Reject.Unsafe(Features.Rust)
+  |> Phases.Reject.RawOrMutPointer
+  |> Phases.Transform_hax_lib_inline
+  |> Phases.Simplify_question_marks
+  |> Phases.And_mut_defsite
+  |> Phases.Reconstruct_for_loops
   |> Phases.Direct_and_mut
   |> Phases.Reject.Arbitrary_lhs
   |> Phases.Drop_blocks

--- a/engine/lib/ast.ml
+++ b/engine/lib/ast.ml
@@ -105,6 +105,9 @@ functor
   (F : Features.T)
   ->
   struct
+    type safety_kind = Safe | Unsafe of F.unsafe
+    [@@deriving show, yojson, hash, eq]
+
     type borrow_kind = Shared | Unique | Mut of F.mutable_reference
     [@@deriving show, yojson, hash, eq]
 
@@ -240,7 +243,7 @@ functor
           rhs : expr;
           body : expr;
         }
-      | Block of (expr * F.block)
+      | Block of { e : expr; safety_mode : safety_kind; witness : F.block }
         (* Corresponds to `{e}`: this is important for places *)
       | LocalVar of local_ident
       | GlobalVar of global_ident
@@ -391,6 +394,7 @@ functor
           generics : generics;
           body : expr;
           params : param list;
+          safety : safety_kind;
         }
       | TyAlias of { name : concrete_ident; generics : generics; ty : ty }
       | Type of {
@@ -409,6 +413,7 @@ functor
           name : concrete_ident;
           generics : generics;
           items : trait_item list;
+          safety : safety_kind;
         }
       | Impl of {
           generics : generics;
@@ -416,6 +421,7 @@ functor
           of_trait : global_ident * generic_value list;
           items : impl_item list;
           parent_bounds : (impl_expr * impl_ident) list;
+          safety : safety_kind;
         }
       | Alias of { name : concrete_ident; item : concrete_ident }
           (** `Alias {name; item}` is basically a `use

--- a/engine/lib/ast_utils.ml
+++ b/engine/lib/ast_utils.ml
@@ -58,7 +58,7 @@ module Make (F : Features.T) = struct
       match e.e with Borrow { e; _ } -> Some e | _ -> None
 
     let block (e : expr) : expr option =
-      match e.e with Block (e, _) -> Some e | _ -> None
+      match e.e with Block { e; _ } -> Some e | _ -> None
 
     let deref (e : expr) : expr option =
       match e.e with
@@ -173,7 +173,8 @@ module Make (F : Features.T) = struct
 
   let functions_of_item (x : item) : (concrete_ident * expr) list =
     match x.v with
-    | Fn { name; generics = _; body; params = _ } -> [ (name, body) ]
+    | Fn { name; generics = _; body; params = _; safety = _ } ->
+        [ (name, body) ]
     | Impl { items; _ } ->
         List.filter_map
           ~f:(fun w ->
@@ -252,13 +253,14 @@ module Make (F : Features.T) = struct
 
         method! visit_item' () item' =
           match item' with
-          | Fn { name; generics; body; params } ->
+          | Fn { name; generics; body; params; safety } ->
               Fn
                 {
                   name;
                   generics;
                   body = { body with e = GlobalVar (`TupleCons 0) };
                   params;
+                  safety;
                 }
           | _ -> super#visit_item' () item'
       end

--- a/engine/lib/dependencies.ml
+++ b/engine/lib/dependencies.ml
@@ -39,7 +39,7 @@ module Make (F : Features.T) = struct
       in
       let set =
         match i.v with
-        | Fn { name = _; generics; body; params } ->
+        | Fn { name = _; generics; body; params; _ } ->
             v#visit_generics () generics
             @ v#visit_expr () body
             @ concat_map (v#visit_param ()) params
@@ -51,10 +51,11 @@ module Make (F : Features.T) = struct
         | IMacroInvokation { macro; argument = (_ : string); span; witness = _ }
           ->
             v#visit_concrete_ident () macro @ v#visit_span () span
-        | Trait { name = _; generics; items } ->
+        | Trait { name = _; generics; items; safety = _ } ->
             v#visit_generics () generics
             @ concat_map (v#visit_trait_item ()) items
-        | Impl { generics; self_ty; of_trait; items; parent_bounds } ->
+        | Impl { generics; self_ty; of_trait; items; parent_bounds; safety = _ }
+          ->
             v#visit_generics () generics
             @ v#visit_ty () self_ty
             @ v#visit_global_ident () (fst of_trait)

--- a/engine/lib/diagnostics.ml
+++ b/engine/lib/diagnostics.ml
@@ -17,6 +17,7 @@ module Phase = struct
       | AsPattern
       | Dyn
       | TraitItemDefault
+      | Unsafe
     [@@deriving show { with_path = false }, eq, yojson, compare, hash, sexp]
 
     let display = function

--- a/engine/lib/features.ml
+++ b/engine/lib/features.ml
@@ -26,7 +26,8 @@ loop,
   block,
   dyn,
   match_guard,
-  trait_item_default]
+  trait_item_default,
+  unsafe]
 
 module Full = On
 

--- a/engine/lib/generic_printer/generic_printer.ml
+++ b/engine/lib/generic_printer/generic_printer.ml
@@ -399,7 +399,7 @@ module Make (F : Features.T) (View : Concrete_ident.VIEW_API) = struct
               in
               let generics = print#generic_params generics.params in
               let safety =
-                optional Stdlib.Fun.id
+                optional Base.Fn.id
                   (match safety with
                   | Safe -> None
                   | Unsafe _ -> Some !^"unsafe ")

--- a/engine/lib/generic_printer/generic_printer.ml
+++ b/engine/lib/generic_printer/generic_printer.ml
@@ -186,7 +186,11 @@ module Make (F : Features.T) (View : Concrete_ident.VIEW_API) = struct
                   ~lhs ~rhs body
                 |> wrap_parens
             | Literal l -> print#literal Expr l
-            | Block (e, _) -> print#expr ctx e
+            | Block { e; safety_mode; _ } -> (
+                let e = lbrace ^/^ nest 2 (print#expr ctx e) ^/^ rbrace in
+                match safety_mode with
+                | Safe -> e
+                | Unsafe _ -> !^"unsafe " ^^ e)
             | Array l ->
                 separate_map comma (print#expr_at Expr_Array) l
                 |> group |> brackets
@@ -388,13 +392,19 @@ module Make (F : Features.T) (View : Concrete_ident.VIEW_API) = struct
 
         method item' : item' fn =
           function
-          | Fn { name; generics; body; params } ->
+          | Fn { name; generics; body; params; safety } ->
               let params =
                 iblock parens
                   (separate_map (comma ^^ break 1) print#param params)
               in
               let generics = print#generic_params generics.params in
-              string "fn" ^^ space ^^ print#concrete_ident name ^^ generics
+              let safety =
+                optional Stdlib.Fun.id
+                  (match safety with
+                  | Safe -> None
+                  | Unsafe _ -> Some !^"unsafe ")
+              in
+              safety ^^ !^"fn" ^^ space ^^ print#concrete_ident name ^^ generics
               ^^ params
               ^^ iblock braces (print#expr_at Item_Fn_body body)
           | Quote quote -> print#quote quote

--- a/engine/lib/phases/phase_and_mut_defsite.ml
+++ b/engine/lib/phases/phase_and_mut_defsite.ml
@@ -309,9 +309,9 @@ struct
 
           method! visit_item' () item' =
             (match item' with
-            | Fn { name; generics; body; params } ->
+            | Fn { name; generics; body; params; safety } ->
                 let* params, body = rewrite_function params body in
-                Some (B.Fn { name; generics; body; params })
+                Some (B.Fn { name; generics; body; params; safety })
             | _ -> None)
             |> Option.value_or_thunk ~default:(Fn.flip super#visit_item' item')
         end

--- a/engine/lib/phases/phase_cf_into_monads.ml
+++ b/engine/lib/phases/phase_cf_into_monads.ml
@@ -37,7 +37,7 @@ struct
       let monadic_binding _ = Features.On.monadic_binding
     end
 
-    [%%inline_defs dmutability]
+    [%%inline_defs dmutability + dsafety_kind]
 
     module KnownMonads = struct
       type t = { monad : B.supported_monads option; typ : B.ty }

--- a/engine/lib/phases/phase_direct_and_mut.ml
+++ b/engine/lib/phases/phase_direct_and_mut.ml
@@ -59,7 +59,7 @@ struct
       | Some place -> Either.First place
       | None -> Second e
 
-    [%%inline_defs dmutability]
+    [%%inline_defs dmutability + dsafety_kind]
 
     let rec dty (span : span) (ty : A.ty) : B.ty =
       match ty with

--- a/engine/lib/phases/phase_drop_blocks.ml
+++ b/engine/lib/phases/phase_drop_blocks.ml
@@ -24,12 +24,12 @@ module%inlined_contents Make (F : Features.T) = struct
       include Features.SUBTYPE.Id
     end
 
-    [%%inline_defs dmutability]
+    [%%inline_defs dmutability + dsafety_kind]
 
     let rec dexpr' (span : span) (e : A.expr') : B.expr' =
       match (UA.unbox_underef_expr { e; span; typ = UA.never_typ }).e with
       | [%inline_arms "dexpr'.*" - Block] -> auto
-      | Block (inner, _) -> (dexpr inner).e
+      | Block { e; _ } -> (dexpr e).e
       [@@inline_ands bindings_of dexpr - dexpr']
 
     [%%inline_defs "Item.*"]

--- a/engine/lib/phases/phase_drop_blocks.mli
+++ b/engine/lib/phases/phase_drop_blocks.mli
@@ -1,5 +1,6 @@
 open! Prelude
 
+(** Only use this phase if you are also rejecting [unsafe] *)
 module Make (F : Features.T) : sig
   include module type of struct
     module FA = F

--- a/engine/lib/phases/phase_drop_match_guards.ml
+++ b/engine/lib/phases/phase_drop_match_guards.ml
@@ -58,7 +58,7 @@ module%inlined_contents Make (F : Features.T) = struct
       include Features.SUBTYPE.Id
     end
 
-    [%%inline_defs dmutability]
+    [%%inline_defs dmutability + dsafety_kind]
 
     let maybe_simplified_match scrutinee ?(original_arms : A.arm list = [])
         (arms : B.arm list) : B.expr' =

--- a/engine/lib/phases/phase_drop_references.ml
+++ b/engine/lib/phases/phase_drop_references.ml
@@ -30,6 +30,8 @@ struct
       include Features.SUBTYPE.Id
     end
 
+    [%%inline_defs dsafety_kind]
+
     let rec dty (span : span) (t : A.ty) : B.ty =
       match t with
       | [%inline_arms "dty.*" - TApp - TRef] -> auto
@@ -180,6 +182,7 @@ struct
             of_trait = of_trait_id, of_trait_generics;
             items;
             parent_bounds;
+            safety;
           } ->
           B.Impl
             {
@@ -191,6 +194,7 @@ struct
               items = List.map ~f:dimpl_item items;
               parent_bounds =
                 List.map ~f:(dimpl_expr span *** dimpl_ident span) parent_bounds;
+              safety = dsafety_kind span safety;
             }
 
     [%%inline_defs ditems]

--- a/engine/lib/phases/phase_functionalize_loops.ml
+++ b/engine/lib/phases/phase_functionalize_loops.ml
@@ -154,7 +154,7 @@ struct
             (Rust_primitives__hax__folds__fold_range, [ start; end_ ], start.typ)
       | _ -> None
 
-    [%%inline_defs dmutability]
+    [%%inline_defs dmutability + dsafety_kind]
 
     let rec dexpr_unwrapped (expr : A.expr) : B.expr =
       let span = expr.span in

--- a/engine/lib/phases/phase_local_mutation.ml
+++ b/engine/lib/phases/phase_local_mutation.ml
@@ -56,7 +56,7 @@ struct
     let free_assigned_variables =
       UA.Reducers.free_assigned_variables (function _ -> .)
 
-    [%%inline_defs dmutability]
+    [%%inline_defs dmutability + dsafety_kind]
 
     let rec dpat' (span : span) (p : A.pat') : B.pat' =
       match p with

--- a/engine/lib/phases/phase_reconstruct_asserts.ml
+++ b/engine/lib/phases/phase_reconstruct_asserts.ml
@@ -41,22 +41,25 @@ module Make (F : Features.T) =
                                              {
                                                e =
                                                  Block
-                                                   ( {
-                                                       e =
-                                                         App
-                                                           {
-                                                             f =
-                                                               {
-                                                                 e =
-                                                                   GlobalVar
-                                                                     panic;
-                                                                 _;
-                                                               };
-                                                             _;
-                                                           };
-                                                       _;
-                                                     },
-                                                     _ );
+                                                   {
+                                                     e =
+                                                       {
+                                                         e =
+                                                           App
+                                                             {
+                                                               f =
+                                                                 {
+                                                                   e =
+                                                                     GlobalVar
+                                                                       panic;
+                                                                   _;
+                                                                 };
+                                                               _;
+                                                             };
+                                                         _;
+                                                       };
+                                                     _;
+                                                   };
                                                _;
                                              };
                                            _;
@@ -67,29 +70,35 @@ module Make (F : Features.T) =
                                _;
                              }
                          | Block
-                             ( {
-                                 e =
-                                   App
-                                     {
-                                       f = { e = GlobalVar nta; _ };
-                                       args =
-                                         [
-                                           {
-                                             e =
-                                               App
-                                                 {
-                                                   f =
-                                                     { e = GlobalVar panic; _ };
-                                                   _;
-                                                 };
-                                             _;
-                                           };
-                                         ];
-                                       _;
-                                     };
-                                 _;
-                               },
-                               _ ) );
+                             {
+                               e =
+                                 {
+                                   e =
+                                     App
+                                       {
+                                         f = { e = GlobalVar nta; _ };
+                                         args =
+                                           [
+                                             {
+                                               e =
+                                                 App
+                                                   {
+                                                     f =
+                                                       {
+                                                         e = GlobalVar panic;
+                                                         _;
+                                                       };
+                                                     _;
+                                                   };
+                                               _;
+                                             };
+                                           ];
+                                         _;
+                                       };
+                                   _;
+                                 };
+                               _;
+                             } );
                        _;
                      };
                    _;

--- a/engine/lib/phases/phase_reconstruct_for_index_loops.ml
+++ b/engine/lib/phases/phase_reconstruct_for_index_loops.ml
@@ -25,7 +25,7 @@ module%inlined_contents Make (FA : Features.T) = struct
       include Features.SUBTYPE.On.For_index_loop
     end
 
-    [%%inline_defs dmutability]
+    [%%inline_defs dmutability + dsafety_kind]
 
     let rec dloop_kind (span : span) (k : A.loop_kind) : B.loop_kind =
       match k with

--- a/engine/lib/phases/phase_reconstruct_for_loops.ml
+++ b/engine/lib/phases/phase_reconstruct_for_loops.ml
@@ -234,7 +234,7 @@ struct
                [@ocamlformat "disable"]
     end
 
-    [%%inline_defs dmutability]
+    [%%inline_defs dmutability + dsafety_kind]
 
     let rec dexpr_unwrapped (expr : A.expr) : B.expr =
       let h = [%inline_body dexpr_unwrapped] in

--- a/engine/lib/phases/phase_reconstruct_question_marks.ml
+++ b/engine/lib/phases/phase_reconstruct_question_marks.ml
@@ -201,7 +201,7 @@ module%inlined_contents Make (FA : Features.T) = struct
         | _ -> None
     end
 
-    [%%inline_defs dmutability]
+    [%%inline_defs dmutability + dsafety_kind]
 
     let rec dexpr_unwrapped (expr : A.expr) : B.expr =
       let h = [%inline_body dexpr_unwrapped] in

--- a/engine/lib/phases/phase_reconstruct_while_loops.ml
+++ b/engine/lib/phases/phase_reconstruct_while_loops.ml
@@ -52,7 +52,7 @@ module%inlined_contents Make (FA : Features.T) = struct
         | _ -> None
 
       let strip_block (e : expr) : expr =
-        match e.e with Block (e, _) -> e | _ -> e
+        match e.e with Block { e; safety_mode = Safe; _ } -> e | _ -> e
 
       let expect_ite (e : expr) : (expr * expr * expr option) option =
         match e.e with
@@ -75,7 +75,7 @@ module%inlined_contents Make (FA : Features.T) = struct
         | _ -> None
     end
 
-    [%%inline_defs dmutability]
+    [%%inline_defs dmutability + dsafety_kind]
 
     let rec dexpr_unwrapped (expr : A.expr) : B.expr =
       let h = [%inline_body dexpr_unwrapped] in

--- a/engine/lib/phases/phase_reject.ml
+++ b/engine/lib/phases/phase_reject.ml
@@ -134,3 +134,21 @@ module Trait_item_default (FA : Features.T) = struct
         let metadata = make_metadata TraitItemDefault
       end)
 end
+
+module Unsafe (FA : Features.T) = struct
+  module FB = struct
+    include FA
+    include Features.Off.Unsafe
+  end
+
+  include
+    Feature_gate.Make (FA) (FB)
+      (struct
+        module A = FA
+        module B = FB
+        include Feature_gate.DefaultSubtype
+
+        let unsafe = reject
+        let metadata = make_metadata Unsafe
+      end)
+end

--- a/engine/lib/phases/phase_simplify_question_marks.ml
+++ b/engine/lib/phases/phase_simplify_question_marks.ml
@@ -286,7 +286,7 @@ module%inlined_contents Make (FA : Features.T) = struct
         | _ -> None
     end
 
-    [%%inline_defs dmutability]
+    [%%inline_defs dmutability + dsafety_kind]
 
     let rec dexpr_unwrapped (expr : A.expr) : B.expr =
       QuestionMarks.extract expr |> Option.value ~default:expr

--- a/engine/lib/phases/phase_traits_specs.ml
+++ b/engine/lib/phases/phase_traits_specs.ml
@@ -27,7 +27,7 @@ module Make (F : Features.T) =
         let f' (item : item) : item =
           let v =
             match item.v with
-            | Trait { name; generics; items } ->
+            | Trait { name; generics; items; safety } ->
                 let f attrs (item : trait_item) =
                   let mk role kind =
                     let ti_ident = mk_name item.ti_ident kind in
@@ -82,8 +82,9 @@ module Make (F : Features.T) =
                       f attrs item @ [ { item with ti_attrs } ])
                     items
                 in
-                Trait { name; generics; items }
-            | Impl { generics; self_ty; of_trait; items; parent_bounds } ->
+                Trait { name; generics; items; safety }
+            | Impl { generics; self_ty; of_trait; items; parent_bounds; safety }
+              ->
                 let f (item : impl_item) =
                   let mk kind =
                     let ii_ident = mk_name item.ii_ident kind in
@@ -143,7 +144,8 @@ module Make (F : Features.T) =
                 let items =
                   List.concat_map ~f:(fun item -> f item @ [ item ]) items
                 in
-                Impl { generics; self_ty; of_trait; items; parent_bounds }
+                Impl
+                  { generics; self_ty; of_trait; items; parent_bounds; safety }
             | v -> v
           in
           { item with v }

--- a/engine/lib/phases/phase_transform_hax_lib_inline.ml
+++ b/engine/lib/phases/phase_transform_hax_lib_inline.ml
@@ -32,7 +32,7 @@ module%inlined_contents Make (F : Features.T) = struct
       let quote _ _ = Features.On.quote
     end
 
-    [%%inline_defs dmutability]
+    [%%inline_defs dmutability + dsafety_kind]
 
     (** Patterns are "stored" in a
         [match None { Some <PAT> => (), _ => () }]
@@ -40,28 +40,31 @@ module%inlined_contents Make (F : Features.T) = struct
     let extract_pattern (e : B.expr) : B.pat option =
       match e.e with
       | Block
-          ( {
-              e =
-                Match
-                  {
-                    arms =
-                      [
-                        {
-                          arm =
-                            {
-                              arm_pat =
-                                { p = PConstruct { args = [ arg ]; _ }; _ };
-                              _;
-                            };
+          {
+            e =
+              {
+                e =
+                  Match
+                    {
+                      arms =
+                        [
+                          {
+                            arm =
+                              {
+                                arm_pat =
+                                  { p = PConstruct { args = [ arg ]; _ }; _ };
+                                _;
+                              };
+                            _;
+                          };
                           _;
-                        };
-                        _;
-                      ];
-                    _;
-                  };
-              _;
-            },
-            _ ) ->
+                        ];
+                      _;
+                    };
+                _;
+              };
+            _;
+          } ->
           Some arg.pat
       | _ -> None
 

--- a/engine/lib/phases/phase_trivialize_assign_lhs.ml
+++ b/engine/lib/phases/phase_trivialize_assign_lhs.ml
@@ -27,7 +27,7 @@ module%inlined_contents Make (F : Features.T) = struct
     module UA = Ast_utils.Make (F)
     module UB = Ast_utils.Make (FB)
 
-    [%%inline_defs dmutability]
+    [%%inline_defs dmutability + dsafety_kind]
 
     let rec updater_of_lhs (lhs : A.lhs) (rhs : B.expr) (span : span) :
         (Local_ident.t * B.ty) * B.expr =

--- a/engine/lib/side_effect_utils.ml
+++ b/engine/lib/side_effect_utils.ml
@@ -362,9 +362,9 @@ struct
                     },
                     effects ))
           | Literal _ -> (e, m#zero)
-          | Block (inner, witness) ->
-              HoistSeq.one env (self#visit_expr env inner) (fun inner effects ->
-                  ({ e with e = Block (inner, witness) }, effects))
+          | Block { e; safety_mode; witness } ->
+              HoistSeq.one env (self#visit_expr env e) (fun e effects ->
+                  ({ e with e = Block { e; safety_mode; witness } }, effects))
           | Array l ->
               HoistSeq.many env
                 (List.map ~f:(self#visit_expr env) l)
@@ -523,7 +523,7 @@ struct
 
   open MakeSI (F)
 
-  [%%inline_defs dmutability]
+  [%%inline_defs dmutability + dsafety_kind]
 
   module ID = struct
     (* OCaml is not able to understand A.expr is the same as B.expr........... *)


### PR DESCRIPTION
This was discussed on [zulip](https://hacspec.zulipchat.com/#narrow/stream/269544-general/topic/Loosen.20Backend's.20Infrastructure.20on.20Unsafe.20Code) before.

We introduce `unsafe` as a new feature. And the following AST nodes are affected

- `Block`
- `Fn`
- `Trait`
- `Impl`

Current backends are unaffected besides adding a new phase that rejects `unsafe`.