### PR TITLE
fix(fstar-core): add support for `Option::map`

### DIFF
--- a/proof-libs/fstar/core/Core.Option.fst
+++ b/proof-libs/fstar/core/Core.Option.fst
@@ -7,6 +7,11 @@ let impl__and_then #t_Self #t (self: t_Option t_Self) (f: t_Self -> t_Option t):
   | Option_Some x -> f x
   | Option_None -> Option_None
 
+let impl__map #t_Self #t (self: t_Option t_Self) (f: t_Self -> t): t_Option t =
+  match self with
+  | Option_Some x -> Option_Some (f x)
+  | Option_None -> Option_None
+
 let impl__unwrap #t (x: t_Option t {Option_Some? x}): t = Option_Some?._0 x
 
 let impl__is_some #t_Self (self: t_Option t_Self): bool =  Option_Some? self


### PR DESCRIPTION
This is an attempt at adding support for `Option::map` in the F* model of the Rust core library.
The model is copied from the existing one of `Option::and_then`, with the return type of the closure being adapted.

Is there any additional integration/unit tests to write for these models?