### PR TITLE
Fix incorrect line numbers in error messages

### DIFF
--- a/hax-types/src/diagnostics/report.rs
+++ b/hax-types/src/diagnostics/report.rs
@@ -74,20 +74,21 @@ impl Diagnostics {
                 let start = compute_offset(&source, span.lo.line, span.lo.col);
                 let end = compute_offset(&source, span.hi.line, span.hi.col);
                 let origin = format!("{}", path.display());
-                snippets_data.push((source, origin, span.lo.line, start..end));
+                snippets_data.push((source, origin, start..end));
             };
         }
 
         let title = format!("[{}] {self}", self.kind.code());
-        let message = level.title(&title).snippets(snippets_data.iter().map(
-            |(source, origin, line, range)| {
-                Snippet::source(source)
-                    .line_start(*line)
-                    .origin(&origin)
-                    .fold(true)
-                    .annotation(level.span(range.clone()))
-            },
-        ));
+        let message =
+            level
+                .title(&title)
+                .snippets(snippets_data.iter().map(|(source, origin, range)| {
+                    Snippet::source(source)
+                        .line_start(1)
+                        .origin(&origin)
+                        .fold(true)
+                        .annotation(level.span(range.clone()))
+                }));
 
         then(message)
     }


### PR DESCRIPTION
Fixes #879 

The crate `annotate-snippets` that we use for reporting error messages has a parameter `line_start` that corresponds to the line number of the first line that we pass (the source code is passed as a string in another parameter). In our case we always give the full source code so `line_start` should be 1 (and not the line number at which the error is located).