### PR TITLE
fix: fstar: default trait

### DIFF
--- a/proof-libs/fstar/core/Core.Default.fsti
+++ b/proof-libs/fstar/core/Core.Default.fsti
@@ -1,5 +1,7 @@
 module Core.Default
 
 class t_Default (t: Type0) = {
-  v_default: unit -> t;
+  f_default_pre: unit -> Type0;
+  f_default_post: unit -> out:t -> Type0;
+  f_default: unit -> t;
 }


### PR DESCRIPTION
Fixes the definition of the `default` trait in the F* core lib.
The previous definition was incorrect: names were wrong, and pre/post fields were missing.

Fixes #585.