### PR TITLE
Support other variants of MIR

### DIFF
--- a/frontend/exporter/src/body.rs
+++ b/frontend/exporter/src/body.rs
@@ -104,7 +104,7 @@ mod module {
                         did.to_def_id(),
                     ))
                 });
-                mir.unwrap()
+                mir.s_unwrap(s)
             }
         }
     }

--- a/frontend/exporter/src/body.rs
+++ b/frontend/exporter/src/body.rs
@@ -95,8 +95,16 @@ mod module {
         impl<MirKind: IsMirKind + Clone + 'static> IsBody for MirBody<MirKind> {
             fn body<'tcx, S: UnderOwnerState<'tcx>>(did: RLocalDefId, s: &S) -> Self {
                 let (thir, _) = get_thir(did, s);
-                let mir = Rc::new(s.base().tcx.mir_built(did).borrow().clone());
-                mir.sinto(&with_owner_id(s.base(), thir, mir.clone(), did.to_def_id()))
+                let mir = MirKind::get_mir(s.base().tcx, did, |body| {
+                    let body = Rc::new(body.clone());
+                    body.sinto(&with_owner_id(
+                        s.base(),
+                        thir,
+                        body.clone(),
+                        did.to_def_id(),
+                    ))
+                });
+                mir.unwrap()
             }
         }
     }

--- a/frontend/exporter/src/types/mir.rs
+++ b/frontend/exporter/src/types/mir.rs
@@ -121,7 +121,7 @@ pub mod mir_kinds {
         use rustc_middle::ty::TyCtxt;
         use rustc_span::def_id::LocalDefId;
 
-        pub trait IsMirKind: Clone {
+        pub trait IsMirKind: Clone + std::fmt::Debug {
             // CPS to deal with stealable bodies cleanly.
             fn get_mir<'tcx, T>(
                 tcx: TyCtxt<'tcx>,


### PR DESCRIPTION
Intermediate variants of MIR involve promoted constants, which are normal expressions turned into anonymous constants, which is a necessary step for cases like:
```rust
fn static_lifetime() -> &'static u32 {
    let x = &0;
    x
}
```
Hax crashes on them today (the call to `ucv.shrink()` panics); this PR fixes that.