### PR TITLE
Detangle trait solving from `SInto`

### DIFF
--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -1074,7 +1074,6 @@ end) : EXPR = struct
     | Dyn -> Dyn
     | SelfImpl { path; _ } -> List.fold ~init:Self ~f:browse_path path
     | Builtin { trait } -> Builtin (c_trait_ref span trait.value)
-    | Todo str -> failwith @@ "impl_expr_atom: Todo " ^ str
 
   and c_generic_value (span : Thir.span) (ty : Thir.generic_arg) : generic_value
       =

--- a/frontend/exporter/src/constant_utils.rs
+++ b/frontend/exporter/src/constant_utils.rs
@@ -430,8 +430,7 @@ mod rustc {
 
                         // Solve the trait obligations
                         let parent_def_id = tcx.parent(ucv.def);
-                        let trait_refs =
-                            solve_item_traits(s, param_env, parent_def_id, ucv.args, None);
+                        let trait_refs = solve_item_traits(s, parent_def_id, ucv.args, None);
 
                         // Convert
                         let id = ucv.def.sinto(s);

--- a/frontend/exporter/src/rustc_utils.rs
+++ b/frontend/exporter/src/rustc_utils.rs
@@ -12,75 +12,7 @@ impl<'tcx, T: ty::TypeFoldable<ty::TyCtxt<'tcx>>> ty::Binder<'tcx, T> {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-pub struct AnnotatedPredicate<'tcx> {
-    pub is_extra_self_predicate: bool,
-    /// Note: they are all actually `Clause`s.
-    pub predicate: ty::Predicate<'tcx>,
-    pub span: rustc_span::Span,
-}
-
-#[extension_traits::extension(pub trait TyCtxtExtPredOrAbove)]
-impl<'tcx> ty::TyCtxt<'tcx> {
-    /// Just like `TyCtxt::predicates_defined_on`, but in the case of
-    /// a trait or impl item, also includes the predicates defined on
-    /// the parent.
-    fn predicates_defined_on_or_above(
-        self,
-        did: rustc_span::def_id::DefId,
-    ) -> Vec<AnnotatedPredicate<'tcx>> {
-        let mut next_did = Some(did);
-        let mut predicates = vec![];
-        while let Some(did) = next_did {
-            let (preds, parent) = self.annotated_predicates_of(did);
-            next_did = parent;
-            predicates.extend(preds)
-        }
-        predicates
-    }
-
-    fn annotated_predicates_of(
-        self,
-        did: rustc_span::def_id::DefId,
-    ) -> (
-        impl Iterator<Item = AnnotatedPredicate<'tcx>>,
-        Option<rustc_span::def_id::DefId>,
-    ) {
-        let with_self = self.predicates_of(did);
-        let parent = with_self.parent;
-        let with_self = {
-            let extra_predicates: Vec<(ty::Clause<'_>, rustc_span::Span)> =
-                if rustc_hir::def::DefKind::OpaqueTy == self.def_kind(did) {
-                    // An opaque type (e.g. `impl Trait`) provides
-                    // predicates by itself: we need to account for them.
-                    self.explicit_item_bounds(did)
-                        .skip_binder() // Skips an `EarlyBinder`, likely for GATs
-                        .iter()
-                        .copied()
-                        .collect()
-                } else {
-                    vec![]
-                };
-            with_self.predicates.iter().copied().chain(extra_predicates)
-        };
-        let without_self: Vec<ty::Clause<'_>> = self
-            .predicates_defined_on(did)
-            .predicates
-            .iter()
-            .copied()
-            .map(|(clause, _)| clause)
-            .collect();
-        (
-            with_self.map(move |(clause, span)| AnnotatedPredicate {
-                is_extra_self_predicate: !without_self.contains(&clause),
-                predicate: clause.as_predicate(),
-                span,
-            }),
-            parent,
-        )
-    }
-}
-
+// TODO: this seems to be constructing a `Self: Trait` clause. Document what it does exactly.
 pub fn poly_trait_ref<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
     assoc: &ty::AssocItem,

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
 #[derive(AdtInto)]
-#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: search_clause::PathChunk<'tcx>, state: S as s)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc::PathChunk<'tcx>, state: S as s)]
 #[derive_group(Serializers)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
 pub enum ImplExprPathChunk {
@@ -22,16 +22,24 @@ pub enum ImplExprPathChunk {
 
 /// The source of a particular trait implementation. Most often this is either `Concrete` for a
 /// concrete `impl Trait for Type {}` item, or `LocalBound` for a context-bound `where T: Trait`.
+#[derive(AdtInto)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc::ImplExprAtom<'tcx>, state: S as s)]
 #[derive_group(Serializers)]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
 pub enum ImplExprAtom {
     /// A concrete `impl Trait for Type {}` item.
     Concrete {
+        #[from(def_id)]
         id: GlobalIdent,
         generics: Vec<GenericArg>,
     },
     /// A context-bound clause like `where T: Trait`.
     LocalBound {
+        #[not_in_source]
+        #[value({
+            let Self::LocalBound { predicate, .. } = self else { unreachable!() };
+            predicate.sinto(s).id
+        })]
         predicate_id: PredicateId,
         r#trait: Binder<TraitRef>,
         path: Vec<ImplExprPathChunk>,
@@ -59,7 +67,8 @@ pub enum ImplExprAtom {
 /// "hello").clone()` combines the generic implementation of `Clone` for `(A, B)` with the
 /// concrete implementations for `u8` and `&str`, represented as a tree.
 #[derive_group(Serializers)]
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, JsonSchema, AdtInto)]
+#[args(<'tcx, S: UnderOwnerState<'tcx> >, from: rustc::ImplExpr<'tcx>, state: S as s)]
 pub struct ImplExpr {
     /// The trait this is an impl for.
     pub r#trait: Binder<TraitRef>,
@@ -71,26 +80,14 @@ pub struct ImplExpr {
 
 #[cfg(feature = "rustc")]
 pub mod rustc {
-    use super::*;
+    use rustc_hir::def_id::DefId;
+    use rustc_middle::ty::*;
+
     // FIXME: this has visibility `pub(crate)` only because of https://github.com/rust-lang/rust/issues/83049
     pub(crate) mod search_clause {
-        use crate::prelude::UnderOwnerState;
+        use super::{Path, PathChunk};
         use crate::rustc_utils::*;
         use rustc_middle::ty::*;
-
-        #[derive(Clone, Debug)]
-        pub enum PathChunk<'tcx> {
-            AssocItem {
-                item: AssocItem,
-                predicate: PolyTraitPredicate<'tcx>,
-                index: usize,
-            },
-            Parent {
-                predicate: PolyTraitPredicate<'tcx>,
-                index: usize,
-            },
-        }
-        pub type Path<'tcx> = Vec<PathChunk<'tcx>>;
 
         /// Custom equality on `Predicate`s.
         ///
@@ -109,13 +106,12 @@ pub mod rustc {
         ///
         /// [1]: https://github.com/rust-lang/rust/blob/b0889cb4ed0e6f3ed9f440180678872b02e7052c/compiler/rustc_builtin_macros/src/deriving/hash.rs#L20
         /// [2]: https://github.com/rust-lang/rust/blob/b0889cb4ed0e6f3ed9f440180678872b02e7052c/compiler/rustc_middle/src/ty/print/mod.rs#L141
-        fn predicate_equality<'tcx, S: UnderOwnerState<'tcx>>(
+        fn predicate_equality<'tcx>(
+            tcx: TyCtxt<'tcx>,
             x: Predicate<'tcx>,
             y: Predicate<'tcx>,
             param_env: rustc_middle::ty::ParamEnv<'tcx>,
-            s: &S,
         ) -> bool {
-            let tcx = s.base().tcx;
             let erase_and_norm =
                 |x| tcx.erase_regions(tcx.try_normalize_erasing_regions(param_env, x).unwrap_or(x));
             // Lifetime and constantness are irrelevant when resolving instances
@@ -124,61 +120,61 @@ pub mod rustc {
             let sx = format!("{:?}", x.kind().skip_binder());
             let sy = format!("{:?}", y.kind().skip_binder());
             let result = sx == sy;
-            const DEBUG: bool = false;
-            if DEBUG && result {
-                use crate::{Predicate, SInto};
-                let xs: Predicate = x.sinto(s);
-                let ys: Predicate = y.sinto(s);
-                if x != y {
-                    eprintln!(
-                        "######################## predicate_equality ########################"
-                    );
-                    eprintln!("x={:#?}", x);
-                    eprintln!("y={:#?}", y);
-                    eprintln!(
-                        "########################        sinto       ########################"
-                    );
-                    eprintln!("sinto(x)={:#?}", xs);
-                    eprintln!("sinto(y)={:#?}", ys);
-                }
-            }
+            // const DEBUG: bool = false;
+            // if DEBUG && result {
+            //     use crate::{Predicate, SInto};
+            //     let xs: Predicate = x.sinto(s);
+            //     let ys: Predicate = y.sinto(s);
+            //     if x != y {
+            //         eprintln!(
+            //             "######################## predicate_equality ########################"
+            //         );
+            //         eprintln!("x={:#?}", x);
+            //         eprintln!("y={:#?}", y);
+            //         eprintln!(
+            //             "########################        sinto       ########################"
+            //         );
+            //         eprintln!("sinto(x)={:#?}", xs);
+            //         eprintln!("sinto(y)={:#?}", ys);
+            //     }
+            // }
             result
         }
 
         #[extension_traits::extension(pub trait TraitPredicateExt)]
-        impl<'tcx, S: UnderOwnerState<'tcx>> PolyTraitPredicate<'tcx> {
+        impl<'tcx> PolyTraitPredicate<'tcx> {
             fn predicates_to_poly_trait_predicates(
                 self,
-                s: &S,
+                tcx: TyCtxt<'tcx>,
                 predicates: impl Iterator<Item = Predicate<'tcx>>,
             ) -> impl Iterator<Item = PolyTraitPredicate<'tcx>> {
-                let tcx = s.base().tcx;
                 let generics = self.skip_binder().trait_ref.args;
                 predicates
                     .filter_map(|pred| pred.as_trait_clause())
                     .map(move |clause| clause.subst(tcx, generics))
             }
 
-            #[tracing::instrument(level = "trace", skip(s))]
-            fn parents_trait_predicates(self, s: &S) -> Vec<(usize, PolyTraitPredicate<'tcx>)> {
-                let tcx = s.base().tcx;
+            #[tracing::instrument(level = "trace", skip(tcx))]
+            fn parents_trait_predicates(
+                self,
+                tcx: TyCtxt<'tcx>,
+            ) -> Vec<(usize, PolyTraitPredicate<'tcx>)> {
                 let predicates = tcx
                     .predicates_defined_on_or_above(self.def_id())
                     .into_iter()
                     .map(|apred| apred.predicate);
-                self.predicates_to_poly_trait_predicates(s, predicates)
+                self.predicates_to_poly_trait_predicates(tcx, predicates)
                     .enumerate()
                     .collect()
             }
-            #[tracing::instrument(level = "trace", skip(s))]
+            #[tracing::instrument(level = "trace", skip(tcx))]
             fn associated_items_trait_predicates(
                 self,
-                s: &S,
+                tcx: TyCtxt<'tcx>,
             ) -> Vec<(
                 AssocItem,
                 EarlyBinder<'tcx, Vec<(usize, PolyTraitPredicate<'tcx>)>>,
             )> {
-                let tcx = s.base().tcx;
                 tcx.associated_items(self.def_id())
                     .in_definition_order()
                     .filter(|item| item.kind == AssocKind::Type)
@@ -186,7 +182,7 @@ pub mod rustc {
                     .map(|item| {
                         let bounds = tcx.item_bounds(item.def_id).map_bound(|clauses| {
                             self.predicates_to_poly_trait_predicates(
-                                s,
+                                tcx,
                                 clauses.into_iter().map(|clause| clause.as_predicate()),
                             )
                             .enumerate()
@@ -198,15 +194,13 @@ pub mod rustc {
             }
         }
 
-        #[tracing::instrument(level = "trace", skip(s, param_env))]
-        pub fn path_to<'tcx, S: UnderOwnerState<'tcx>>(
+        #[tracing::instrument(level = "trace", skip(tcx, param_env))]
+        pub fn path_to<'tcx>(
+            tcx: TyCtxt<'tcx>,
             starting_points: &[AnnotatedPredicate<'tcx>],
-            s: &S,
             target: PolyTraitRef<'tcx>,
             param_env: rustc_middle::ty::ParamEnv<'tcx>,
         ) -> Option<(Path<'tcx>, AnnotatedPredicate<'tcx>)> {
-            let tcx = s.base().tcx;
-
             /// A candidate projects `self` along a path reaching some
             /// predicate. A candidate is selected when its predicate
             /// is the one expected, aka `target`.
@@ -244,12 +238,12 @@ pub mod rustc {
                 }
 
                 // if the candidate equals the target, let's return its path
-                if predicate_equality(candidate.pred.upcast(tcx), target_pred, param_env, s) {
+                if predicate_equality(tcx, candidate.pred.upcast(tcx), target_pred, param_env) {
                     return Some((candidate.path, candidate.origin));
                 }
 
                 // otherwise, we add to the queue all paths reachable from the candidate
-                for (index, parent_pred) in candidate.pred.parents_trait_predicates(s) {
+                for (index, parent_pred) in candidate.pred.parents_trait_predicates(tcx) {
                     let mut path = candidate.path.clone();
                     path.push(PathChunk::Parent {
                         predicate: parent_pred,
@@ -261,7 +255,7 @@ pub mod rustc {
                         origin: candidate.origin,
                     });
                 }
-                for (item, binder) in candidate.pred.associated_items_trait_predicates(s) {
+                for (item, binder) in candidate.pred.associated_items_trait_predicates(tcx) {
                     for (index, parent_pred) in binder.skip_binder().into_iter() {
                         let mut path = candidate.path.clone();
                         path.push(PathChunk::AssocItem {
@@ -281,8 +275,67 @@ pub mod rustc {
         }
     }
 
-    impl ImplExprAtom {
-        fn with_args(self, args: Vec<ImplExpr>, r#trait: Binder<TraitRef>) -> ImplExpr {
+    #[derive(Debug, Clone)]
+    pub enum PathChunk<'tcx> {
+        AssocItem {
+            item: AssocItem,
+            predicate: PolyTraitPredicate<'tcx>,
+            index: usize,
+        },
+        Parent {
+            predicate: PolyTraitPredicate<'tcx>,
+            index: usize,
+        },
+    }
+    pub type Path<'tcx> = Vec<PathChunk<'tcx>>;
+
+    #[derive(Debug, Clone)]
+    pub enum ImplExprAtom<'tcx> {
+        /// A concrete `impl Trait for Type {}` item.
+        Concrete {
+            def_id: DefId,
+            generics: GenericArgsRef<'tcx>,
+        },
+        /// A context-bound clause like `where T: Trait`.
+        LocalBound {
+            predicate: Predicate<'tcx>,
+            r#trait: PolyTraitRef<'tcx>,
+            path: Path<'tcx>,
+        },
+        /// The automatic clause `Self: Trait` present inside a `impl Trait for Type {}` item.
+        SelfImpl {
+            r#trait: PolyTraitRef<'tcx>,
+            path: Path<'tcx>,
+        },
+        /// `dyn Trait` is a wrapped value with a virtual table for trait
+        /// `Trait`.  In other words, a value `dyn Trait` is a dependent
+        /// triple that gathers a type τ, a value of type τ and an
+        /// instance of type `Trait`.
+        /// `dyn Trait` implements `Trait` using a built-in implementation; this refers to that
+        /// built-in implementation.
+        Dyn,
+        /// A built-in trait whose implementation is computed by the compiler, such as `Sync`.
+        Builtin { r#trait: PolyTraitRef<'tcx> },
+        /// Anything else. Currently used for trait upcasting and trait aliases.
+        Todo(String),
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct ImplExpr<'tcx> {
+        /// The trait this is an impl for.
+        pub r#trait: PolyTraitRef<'tcx>,
+        /// The kind of implemention of the root of the tree.
+        pub r#impl: ImplExprAtom<'tcx>,
+        /// A list of `ImplExpr`s required to fully specify the trait references in `impl`.
+        pub args: Vec<Self>,
+    }
+
+    impl<'tcx> ImplExprAtom<'tcx> {
+        fn with_args(
+            self,
+            args: Vec<ImplExpr<'tcx>>,
+            r#trait: PolyTraitRef<'tcx>,
+        ) -> ImplExpr<'tcx> {
             ImplExpr {
                 r#impl: self,
                 args,
@@ -291,154 +344,120 @@ pub mod rustc {
         }
     }
 
-    #[tracing::instrument(level = "trace", skip(s))]
-    fn impl_exprs<'tcx, S: UnderOwnerState<'tcx>>(
-        s: &S,
+    #[tracing::instrument(level = "trace", skip(tcx))]
+    fn impl_exprs<'tcx>(
+        tcx: TyCtxt<'tcx>,
+        owner_id: DefId,
         obligations: &Vec<
             rustc_trait_selection::traits::Obligation<'tcx, rustc_middle::ty::Predicate<'tcx>>,
         >,
-    ) -> Vec<ImplExpr> {
+    ) -> Vec<ImplExpr<'tcx>> {
         obligations
             .into_iter()
             .flat_map(|obligation| {
                 obligation.predicate.as_trait_clause().map(|trait_ref| {
-                    trait_ref
-                        .map_bound(|p| p.trait_ref)
-                        .impl_expr(s, obligation.param_env)
+                    trait_ref.map_bound(|p| p.trait_ref).impl_expr(
+                        tcx,
+                        owner_id,
+                        obligation.param_env,
+                    )
                 })
             })
             .collect()
     }
 
     pub trait IntoImplExpr<'tcx> {
-        fn impl_expr<S: UnderOwnerState<'tcx>>(
+        fn impl_expr(
             &self,
-            s: &S,
+            tcx: TyCtxt<'tcx>,
+            // The id of the enclosing item
+            owner_id: DefId,
             param_env: rustc_middle::ty::ParamEnv<'tcx>,
-        ) -> ImplExpr;
+        ) -> ImplExpr<'tcx>;
     }
 
     impl<'tcx> IntoImplExpr<'tcx> for rustc_middle::ty::PolyTraitPredicate<'tcx> {
-        fn impl_expr<S: UnderOwnerState<'tcx>>(
+        fn impl_expr(
             &self,
-            s: &S,
+            tcx: TyCtxt<'tcx>,
+            owner_id: DefId,
             param_env: rustc_middle::ty::ParamEnv<'tcx>,
-        ) -> ImplExpr {
+        ) -> ImplExpr<'tcx> {
             use rustc_middle::ty::ToPolyTraitRef;
-            self.to_poly_trait_ref().impl_expr(s, param_env)
+            self.to_poly_trait_ref().impl_expr(tcx, owner_id, param_env)
         }
     }
     impl<'tcx> IntoImplExpr<'tcx> for rustc_middle::ty::PolyTraitRef<'tcx> {
-        #[tracing::instrument(level = "trace", skip(s, param_env))]
-        fn impl_expr<S: UnderOwnerState<'tcx>>(
+        #[tracing::instrument(level = "trace", skip(tcx, param_env))]
+        fn impl_expr(
             &self,
-            s: &S,
+            tcx: TyCtxt<'tcx>,
+            owner_id: DefId,
             param_env: rustc_middle::ty::ParamEnv<'tcx>,
-        ) -> ImplExpr {
+        ) -> ImplExpr<'tcx> {
             use rustc_trait_selection::traits::*;
-            let trait_ref: Binder<TraitRef> = self.sinto(s);
-            match select_trait_candidate(s, param_env, *self) {
-                ImplSource::UserDefined(ImplSourceUserDefinedData {
+            match copy_paste_from_rustc::codegen_select_candidate(tcx, (param_env, *self)) {
+                // Err(error) => fatal!(
+                //     s,
+                //     "Cannot handle error `{:?}` selecting `{:?}`",
+                //     error,
+                //     trait_ref
+                // ),
+                Err(_) => todo!(),
+                Ok(ImplSource::UserDefined(ImplSourceUserDefinedData {
                     impl_def_id,
                     args: generics,
                     nested,
-                }) => ImplExprAtom::Concrete {
-                    id: impl_def_id.sinto(s),
-                    generics: generics.sinto(s),
+                })) => ImplExprAtom::Concrete {
+                    def_id: impl_def_id,
+                    generics,
                 }
-                .with_args(impl_exprs(s, &nested), trait_ref),
-                ImplSource::Param(nested) => {
-                    let tcx = s.base().tcx;
-                    let predicates = tcx.predicates_defined_on_or_above(s.owner_id());
+                .with_args(impl_exprs(tcx, owner_id, &nested), *self),
+                Ok(ImplSource::Param(nested)) => {
+                    use crate::TyCtxtExtPredOrAbove;
+                    let predicates = tcx.predicates_defined_on_or_above(owner_id);
                     let Some((path, apred)) =
-                        search_clause::path_to(&predicates, s, self.clone(), param_env)
+                        search_clause::path_to(tcx, &predicates, self.clone(), param_env)
                     else {
-                        supposely_unreachable_fatal!(s, "ImplExprPredNotFound"; {
-                            self, nested, predicates, trait_ref
-                        })
+                        todo!()
+                        // supposely_unreachable_fatal!(s, "ImplExprPredNotFound"; {
+                        //     self, nested, predicates, trait_ref
+                        // })
                     };
 
                     use rustc_middle::ty::ToPolyTraitRef;
+                    // TODO: unwrap
                     let r#trait = apred
                         .predicate
                         .as_trait_clause()
-                        .s_unwrap(s)
-                        .to_poly_trait_ref()
-                        .sinto(s);
-                    let path = path.sinto(s);
+                        .unwrap()
+                        .to_poly_trait_ref();
                     if apred.is_extra_self_predicate {
                         ImplExprAtom::SelfImpl { r#trait, path }
-                            .with_args(impl_exprs(s, &nested), trait_ref)
+                            .with_args(impl_exprs(tcx, owner_id, &nested), *self)
                     } else {
                         ImplExprAtom::LocalBound {
-                            predicate_id: apred.predicate.sinto(s).id,
+                            predicate: apred.predicate,
                             r#trait,
                             path,
                         }
-                        .with_args(impl_exprs(s, &nested), trait_ref)
+                        .with_args(impl_exprs(tcx, owner_id, &nested), *self)
                     }
                 }
                 // We ignore the contained obligations here. For example for `(): Send`, the
                 // obligations contained would be `[(): Send]`, which leads to an infinite loop. There
                 // might be important obligation shere inother cases; we'll have to see if that comes
                 // up.
-                ImplSource::Builtin(source, _ignored) => {
+                Ok(ImplSource::Builtin(source, _ignored)) => {
                     let atom = match source {
                         BuiltinImplSource::Object { .. } => ImplExprAtom::Dyn,
                         _ => ImplExprAtom::Builtin {
-                            r#trait: trait_ref.clone(),
+                            r#trait: self.clone(),
                         },
                     };
-                    atom.with_args(vec![], trait_ref)
+                    atom.with_args(vec![], *self)
                 }
             }
-        }
-    }
-
-    /// Given a clause `clause` in the context of some impl. block
-    /// `impl_did`, susbts correctly `Self` from `clause` and (1) derive a
-    /// `Clause` and (2) resolve an `ImplExpr`.
-    pub fn super_clause_to_clause_and_impl_expr<'tcx, S: UnderOwnerState<'tcx>>(
-        s: &S,
-        impl_did: rustc_span::def_id::DefId,
-        clause: rustc_middle::ty::Clause<'tcx>,
-        span: rustc_span::Span,
-    ) -> Option<(Clause, ImplExpr, Span)> {
-        let tcx = s.base().tcx;
-        let impl_trait_ref = tcx
-            .impl_trait_ref(impl_did)
-            .map(|binder| rustc_middle::ty::Binder::dummy(binder.instantiate_identity()))?;
-        let original_predicate_id = {
-            // We don't want the id of the substituted clause id, but the
-            // original clause id (with, i.e., `Self`)
-            let s = &with_owner_id(s.base(), (), (), impl_trait_ref.def_id());
-            clause.sinto(s).id
-        };
-        let new_clause = clause.instantiate_supertrait(tcx, impl_trait_ref);
-        let impl_expr = new_clause
-            .as_predicate()
-            .as_trait_clause()?
-            .impl_expr(s, s.param_env());
-        let mut new_clause_no_binder = new_clause.sinto(s);
-        new_clause_no_binder.id = original_predicate_id;
-        Some((new_clause_no_binder, impl_expr, span.sinto(s)))
-    }
-
-    #[tracing::instrument(level = "trace", skip(s, param_env))]
-    pub fn select_trait_candidate<'tcx, S: UnderOwnerState<'tcx>>(
-        s: &S,
-        param_env: rustc_middle::ty::ParamEnv<'tcx>,
-        trait_ref: rustc_middle::ty::PolyTraitRef<'tcx>,
-    ) -> rustc_trait_selection::traits::Selection<'tcx> {
-        let tcx = s.base().tcx;
-        match copy_paste_from_rustc::codegen_select_candidate(tcx, (param_env, trait_ref)) {
-            Ok(selection) => selection,
-            Err(error) => fatal!(
-                s,
-                "Cannot handle error `{:?}` selecting `{:?}`",
-                error,
-                trait_ref
-            ),
         }
     }
 
@@ -527,5 +546,37 @@ pub mod rustc {
         }
     }
 }
+
 #[cfg(feature = "rustc")]
-pub use self::rustc::*;
+pub use self::rustc::IntoImplExpr;
+
+/// Given a clause `clause` in the context of some impl. block
+/// `impl_did`, susbts correctly `Self` from `clause` and (1) derive a
+/// `Clause` and (2) resolve an `ImplExpr`.
+#[cfg(feature = "rustc")]
+pub fn super_clause_to_clause_and_impl_expr<'tcx, S: UnderOwnerState<'tcx>>(
+    s: &S,
+    impl_did: rustc_span::def_id::DefId,
+    clause: rustc_middle::ty::Clause<'tcx>,
+    span: rustc_span::Span,
+) -> Option<(Clause, ImplExpr, Span)> {
+    let tcx = s.base().tcx;
+    let impl_trait_ref = tcx
+        .impl_trait_ref(impl_did)
+        .map(|binder| rustc_middle::ty::Binder::dummy(binder.instantiate_identity()))?;
+    let original_predicate_id = {
+        // We don't want the id of the substituted clause id, but the
+        // original clause id (with, i.e., `Self`)
+        let s = &with_owner_id(s.base(), (), (), impl_trait_ref.def_id());
+        clause.sinto(s).id
+    };
+    let new_clause = clause.instantiate_supertrait(tcx, impl_trait_ref);
+    let impl_expr = new_clause
+        .as_predicate()
+        .as_trait_clause()?
+        .impl_expr(tcx, s.owner_id(), s.param_env())
+        .sinto(s);
+    let mut new_clause_no_binder = new_clause.sinto(s);
+    new_clause_no_binder.id = original_predicate_id;
+    Some((new_clause_no_binder, impl_expr, span.sinto(s)))
+}

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -58,8 +58,6 @@ pub enum ImplExprAtom {
     Dyn,
     /// A built-in trait whose implementation is computed by the compiler, such as `Sync`.
     Builtin { r#trait: Binder<TraitRef> },
-    /// Anything else. Currently used for trait upcasting and trait aliases.
-    Todo(String),
 }
 
 /// An `ImplExpr` describes the full data of a trait implementation. Because of generics, this may
@@ -327,8 +325,6 @@ pub mod rustc {
         Dyn,
         /// A built-in trait whose implementation is computed by the compiler, such as `Sync`.
         Builtin { r#trait: PolyTraitRef<'tcx> },
-        /// Anything else. Currently used for trait upcasting and trait aliases.
-        Todo(String),
     }
 
     #[derive(Clone, Debug)]

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -475,9 +475,15 @@ pub mod rustc {
                     ));
                 };
 
+                let Some(trait_clause) = apred.clause.as_trait_clause() else {
+                    return Err(format!(
+                        "Candidate origin for `{tref:?}` is a clause but not a \
+                        trait clause: `{:?}`",
+                        apred.clause
+                    ));
+                };
                 use rustc_middle::ty::ToPolyTraitRef;
-                // TODO: unwrap
-                let r#trait = apred.clause.as_trait_clause().unwrap().to_poly_trait_ref();
+                let r#trait = trait_clause.to_poly_trait_ref();
                 if apred.is_extra_self_predicate {
                     ImplExprAtom::SelfImpl { r#trait, path }
                         .with_args(impl_exprs(tcx, owner_id, &nested)?, *tref)

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -87,7 +87,7 @@ pub mod rustc {
     {
         fn sinto(&self, s: &S) -> crate::ImplExpr {
             use crate::ParamEnv;
-            match self.impl_expr(s.base().tcx, s.owner_id(), s.param_env()) {
+            match impl_expr(s.base().tcx, s.owner_id(), s.param_env(), self) {
                 Ok(x) => x.sinto(s),
                 Err(e) => crate::fatal!(s, "{}", e),
             }
@@ -365,93 +365,81 @@ pub mod rustc {
             .into_iter()
             .flat_map(|obligation| {
                 obligation.predicate.as_trait_clause().map(|trait_ref| {
-                    trait_ref.map_bound(|p| p.trait_ref).impl_expr(
+                    impl_expr(
                         tcx,
                         owner_id,
                         obligation.param_env,
+                        &trait_ref.map_bound(|p| p.trait_ref),
                     )
                 })
             })
             .collect()
     }
 
-    trait IntoImplExpr<'tcx> {
-        fn impl_expr(
-            &self,
-            tcx: TyCtxt<'tcx>,
-            // The id of the enclosing item
-            owner_id: DefId,
-            param_env: rustc_middle::ty::ParamEnv<'tcx>,
-        ) -> Result<ImplExpr<'tcx>, String>;
-    }
+    #[tracing::instrument(level = "trace", skip(tcx, param_env))]
+    fn impl_expr<'tcx>(
+        tcx: TyCtxt<'tcx>,
+        owner_id: DefId,
+        param_env: rustc_middle::ty::ParamEnv<'tcx>,
+        tref: &rustc_middle::ty::PolyTraitRef<'tcx>,
+    ) -> Result<ImplExpr<'tcx>, String> {
+        use rustc_trait_selection::traits::*;
+        let impl_source = copy_paste_from_rustc::codegen_select_candidate(tcx, (param_env, *tref))
+            .map_err(|e| format!("Cannot handle error `{e:?}` selecting `{tref:?}`"))?;
+        Ok(match impl_source {
+            ImplSource::UserDefined(ImplSourceUserDefinedData {
+                impl_def_id,
+                args: generics,
+                nested,
+            }) => ImplExprAtom::Concrete {
+                def_id: impl_def_id,
+                generics,
+            }
+            .with_args(impl_exprs(tcx, owner_id, &nested)?, *tref),
+            ImplSource::Param(nested) => {
+                use crate::TyCtxtExtPredOrAbove;
+                let predicates = tcx.predicates_defined_on_or_above(owner_id);
+                let Some((path, apred)) =
+                    search_clause::path_to(tcx, &predicates, tref.clone(), param_env)
+                else {
+                    return Err(format!(
+                        "Could not find a clause for `{tref:?}` in the item parameters"
+                    ));
+                };
 
-    impl<'tcx> IntoImplExpr<'tcx> for rustc_middle::ty::PolyTraitRef<'tcx> {
-        #[tracing::instrument(level = "trace", skip(tcx, param_env))]
-        fn impl_expr(
-            &self,
-            tcx: TyCtxt<'tcx>,
-            owner_id: DefId,
-            param_env: rustc_middle::ty::ParamEnv<'tcx>,
-        ) -> Result<ImplExpr<'tcx>, String> {
-            use rustc_trait_selection::traits::*;
-            let impl_source =
-                copy_paste_from_rustc::codegen_select_candidate(tcx, (param_env, *self))
-                    .map_err(|e| format!("Cannot handle error `{e:?}` selecting `{self:?}`"))?;
-            Ok(match impl_source {
-                ImplSource::UserDefined(ImplSourceUserDefinedData {
-                    impl_def_id,
-                    args: generics,
-                    nested,
-                }) => ImplExprAtom::Concrete {
-                    def_id: impl_def_id,
-                    generics,
-                }
-                .with_args(impl_exprs(tcx, owner_id, &nested)?, *self),
-                ImplSource::Param(nested) => {
-                    use crate::TyCtxtExtPredOrAbove;
-                    let predicates = tcx.predicates_defined_on_or_above(owner_id);
-                    let Some((path, apred)) =
-                        search_clause::path_to(tcx, &predicates, self.clone(), param_env)
-                    else {
-                        return Err(format!(
-                            "Could not find a clause for `{self:?}` in the item parameters"
-                        ));
-                    };
-
-                    use rustc_middle::ty::ToPolyTraitRef;
-                    // TODO: unwrap
-                    let r#trait = apred
-                        .predicate
-                        .as_trait_clause()
-                        .unwrap()
-                        .to_poly_trait_ref();
-                    if apred.is_extra_self_predicate {
-                        ImplExprAtom::SelfImpl { r#trait, path }
-                            .with_args(impl_exprs(tcx, owner_id, &nested)?, *self)
-                    } else {
-                        ImplExprAtom::LocalBound {
-                            predicate: apred.predicate,
-                            r#trait,
-                            path,
-                        }
-                        .with_args(impl_exprs(tcx, owner_id, &nested)?, *self)
+                use rustc_middle::ty::ToPolyTraitRef;
+                // TODO: unwrap
+                let r#trait = apred
+                    .predicate
+                    .as_trait_clause()
+                    .unwrap()
+                    .to_poly_trait_ref();
+                if apred.is_extra_self_predicate {
+                    ImplExprAtom::SelfImpl { r#trait, path }
+                        .with_args(impl_exprs(tcx, owner_id, &nested)?, *tref)
+                } else {
+                    ImplExprAtom::LocalBound {
+                        predicate: apred.predicate,
+                        r#trait,
+                        path,
                     }
+                    .with_args(impl_exprs(tcx, owner_id, &nested)?, *tref)
                 }
-                // We ignore the contained obligations here. For example for `(): Send`, the
-                // obligations contained would be `[(): Send]`, which leads to an infinite loop. There
-                // might be important obligation shere inother cases; we'll have to see if that comes
-                // up.
-                ImplSource::Builtin(source, _ignored) => {
-                    let atom = match source {
-                        BuiltinImplSource::Object { .. } => ImplExprAtom::Dyn,
-                        _ => ImplExprAtom::Builtin {
-                            r#trait: self.clone(),
-                        },
-                    };
-                    atom.with_args(vec![], *self)
-                }
-            })
-        }
+            }
+            // We ignore the contained obligations here. For example for `(): Send`, the
+            // obligations contained would be `[(): Send]`, which leads to an infinite loop. There
+            // might be important obligation shere inother cases; we'll have to see if that comes
+            // up.
+            ImplSource::Builtin(source, _ignored) => {
+                let atom = match source {
+                    BuiltinImplSource::Object { .. } => ImplExprAtom::Dyn,
+                    _ => ImplExprAtom::Builtin {
+                        r#trait: tref.clone(),
+                    },
+                };
+                atom.with_args(vec![], *tref)
+            }
+        })
     }
 
     mod copy_paste_from_rustc {

--- a/frontend/exporter/src/types/copied.rs
+++ b/frontend/exporter/src/types/copied.rs
@@ -1832,7 +1832,9 @@ impl Alias {
                 };
                 AliasKind::Projection {
                     assoc_item: tcx.associated_item(alias_ty.def_id).sinto(s),
-                    impl_expr: poly_trait_ref.impl_expr(s, s.param_env()),
+                    impl_expr: poly_trait_ref
+                        .impl_expr(s.base().tcx, s.owner_id(), s.param_env())
+                        .sinto(s),
                 }
             }
             RustAliasKind::Inherent => AliasKind::Inherent,
@@ -2485,7 +2487,9 @@ pub enum ExprKind {
                     let impl_expr = {
                         // TODO: we should not wrap into a dummy binder
                         let poly_trait_ref = ty::Binder::dummy(trait_ref);
-                        poly_trait_ref.impl_expr(gstate, gstate.param_env())
+                        poly_trait_ref
+                            .impl_expr(gstate.base().tcx, gstate.owner_id(), gstate.param_env())
+                            .sinto(gstate)
                     };
                     let assoc_generics = tcx.generics_of(assoc_item.def_id);
                     let assoc_generics = translated_generics.drain(0..assoc_generics.parent_count);
@@ -2744,7 +2748,11 @@ pub enum ExprKind {
             let tcx = gstate.base().tcx;
             tcx.opt_associated_item(*def_id).as_ref().and_then(|assoc| {
                 poly_trait_ref(gstate, assoc, args)
-            }).map(|poly_trait_ref| poly_trait_ref.impl_expr(gstate, gstate.param_env()))
+            }).map(|poly_trait_ref|
+                poly_trait_ref
+                    .impl_expr(gstate.base().tcx, gstate.owner_id(), gstate.param_env())
+                    .sinto(gstate)
+            )
         })]
         r#impl: Option<ImplExpr>,
     },

--- a/frontend/exporter/src/types/mir_traits.rs
+++ b/frontend/exporter/src/types/mir_traits.rs
@@ -27,7 +27,9 @@ pub fn solve_trait<'tcx, S: BaseState<'tcx> + HasOwnerId>(
     param_env: rustc_middle::ty::ParamEnv<'tcx>,
     trait_ref: rustc_middle::ty::PolyTraitRef<'tcx>,
 ) -> ImplExpr {
-    let mut impl_expr = trait_ref.impl_expr(s, param_env);
+    let mut impl_expr = trait_ref
+        .impl_expr(s.base().tcx, s.owner_id(), param_env)
+        .sinto(s);
     // TODO: this is a bug in hax: in case of method calls, the trait ref
     // contains the generics for the trait ref + the generics for the method
     let trait_def_id: rustc_hir::def_id::DefId =

--- a/frontend/exporter/src/types/mir_traits.rs
+++ b/frontend/exporter/src/types/mir_traits.rs
@@ -8,7 +8,6 @@ pub fn get_trait_info<'tcx, S: UnderOwnerState<'tcx>>(
     assoc: &rustc_middle::ty::AssocItem,
 ) -> ImplExpr {
     let tcx = s.base().tcx;
-    let param_env = s.param_env();
 
     // Retrieve the trait
     let tr_def_id = tcx.trait_of_item(assoc.def_id).unwrap();
@@ -19,17 +18,14 @@ pub fn get_trait_info<'tcx, S: UnderOwnerState<'tcx>>(
     let tr_ref = rustc_middle::ty::Binder::dummy(tr_ref);
 
     // Solve
-    solve_trait(s, param_env, tr_ref)
+    solve_trait(s, tr_ref)
 }
 
 pub fn solve_trait<'tcx, S: BaseState<'tcx> + HasOwnerId>(
     s: &S,
-    param_env: rustc_middle::ty::ParamEnv<'tcx>,
     trait_ref: rustc_middle::ty::PolyTraitRef<'tcx>,
 ) -> ImplExpr {
-    let mut impl_expr = trait_ref
-        .impl_expr(s.base().tcx, s.owner_id(), param_env)
-        .sinto(s);
+    let mut impl_expr: ImplExpr = trait_ref.sinto(s);
     // TODO: this is a bug in hax: in case of method calls, the trait ref
     // contains the generics for the trait ref + the generics for the method
     let trait_def_id: rustc_hir::def_id::DefId =
@@ -50,12 +46,12 @@ pub fn solve_trait<'tcx, S: BaseState<'tcx> + HasOwnerId>(
 /// (instead of the ones returned by [TyCtxt::predicates_defined_on].
 pub fn solve_item_traits<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
-    param_env: rustc_middle::ty::ParamEnv<'tcx>,
     def_id: rustc_hir::def_id::DefId,
     generics: rustc_middle::ty::GenericArgsRef<'tcx>,
     predicates: Option<rustc_middle::ty::GenericPredicates<'tcx>>,
 ) -> Vec<ImplExpr> {
     let tcx = s.base().tcx;
+    let param_env = s.param_env();
 
     let mut impl_exprs = Vec::new();
 
@@ -78,7 +74,7 @@ pub fn solve_item_traits<'tcx, S: UnderOwnerState<'tcx>>(
                 // TODO: try `EarlyBinder::subst(...)`?
                 tcx.instantiate_and_normalize_erasing_regions(generics, param_env, value)
             });
-            let impl_expr = solve_trait(s, param_env, trait_ref);
+            let impl_expr = solve_trait(s, trait_ref);
             impl_exprs.push(impl_expr);
         }
     }


### PR DESCRIPTION
This PR makes it so trait solving never calls into `SInto`, as that was causing headaches with binders. There is still more work to do to clarify trait solving but that's less of a priority.