### PR TITLE
Determine emuerate value by index

### DIFF
--- a/proof-libs/fstar/rust_primitives/Rust_primitives.Hax.Folds.fsti
+++ b/proof-libs/fstar/rust_primitives/Rust_primitives.Hax.Folds.fsti
@@ -45,7 +45,7 @@ val fold_enumerated_slice
   (s: t_Slice t)
   (inv: acc_t -> (i:usize{v i <= v (length s)}) -> Type0)
   (init: acc_t {inv init (sz 0)})
-  (f: (acc:acc_t -> i:(usize & t) {v (fst i) < v (length s) /\ inv acc  (fst i)}
+  (f: (acc:acc_t -> i:(usize & t) {v (fst i) < v (length s) /\ snd i == Seq.index s (v (fst i)) /\ inv acc  (fst i)}
                  -> acc':acc_t    {v (fst i) < v (length s) /\ inv acc' (fst i)}))
   : result: acc_t {inv result (length s)}
 


### PR DESCRIPTION
In the loop body of `fold_enumerated_slice` I noticed that enumerate value is not equal to array element which is necessary for some use cases. An example of use case is here https://github.com/cryspen/libcrux/blob/dev-serialize/libcrux-ml-kem/proofs/fstar/extraction/Libcrux_ml_kem.Ind_cpa.fst#L218 where the enumerate value `re` has to be equal to the index element of `input` array.