### PR TITLE
Cleanup trait resolution

### DIFF
--- a/frontend/exporter/src/state.rs
+++ b/frontend/exporter/src/state.rs
@@ -189,7 +189,7 @@ pub type StateWithThir<'tcx> =
 pub type StateWithMir<'tcx> =
     State<Base<'tcx>, (), types::RcMir<'tcx>, rustc_hir::def_id::DefId, ()>;
 
-impl<'tcx> State<Base<'tcx>, (), (), (), ()> {
+impl<'tcx> StateWithBase<'tcx> {
     pub fn new(
         tcx: rustc_middle::ty::TyCtxt<'tcx>,
         options: hax_frontend_exporter_options::Options,
@@ -243,6 +243,18 @@ impl<'tcx> StateWithThir<'tcx> {
             owner_id,
             binder: (),
             base,
+        }
+    }
+}
+
+impl<'tcx> StateWithOwner<'tcx> {
+    pub fn from_under_owner<S: UnderOwnerState<'tcx>>(s: &S) -> Self {
+        Self {
+            base: s.base(),
+            owner_id: s.owner_id(),
+            thir: (),
+            mir: (),
+            binder: (),
         }
     }
 }

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -155,6 +155,9 @@ pub mod rustc {
             };
 
             match def_kind {
+                // Don't list the predicates of traits, we already list the `Self` clause from
+                // which we can resolve anything needed.
+                Trait => {}
                 AssocConst
                 | AssocFn
                 | AssocTy
@@ -166,7 +169,6 @@ pub mod rustc {
                 | OpaqueTy
                 | Static { .. }
                 | Struct
-                | Trait
                 | TraitAlias
                 | TyAlias
                 | Union => {

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -87,7 +87,12 @@ pub mod rustc {
     impl<'tcx, S: crate::UnderOwnerState<'tcx>> crate::SInto<S, crate::ImplExpr>
         for rustc_middle::ty::PolyTraitRef<'tcx>
     {
+        #[tracing::instrument(level = "trace", skip(s))]
         fn sinto(&self, s: &S) -> crate::ImplExpr {
+            tracing::trace!(
+                "Enters sinto ({})",
+                stringify!(rustc_middle::ty::PolyTraitRef<'tcx>)
+            );
             use crate::ParamEnv;
             let warn = |msg: &str| crate::warning!(s, "{}", msg);
             match impl_expr(s.base().tcx, s.owner_id(), s.param_env(), self, &warn) {

--- a/frontend/exporter/src/types/copied.rs
+++ b/frontend/exporter/src/types/copied.rs
@@ -3729,6 +3729,10 @@ impl<T> Binder<T> {
         self.value
     }
 
+    pub fn hax_skip_binder_ref(&self) -> &T {
+        &self.value
+    }
+
     pub fn map<U>(self, f: impl FnOnce(T) -> U) -> Binder<U> {
         Binder {
             value: f(self.value),
@@ -3738,6 +3742,10 @@ impl<T> Binder<T> {
 
     pub fn inner_mut(&mut self) -> &mut T {
         &mut self.value
+    }
+
+    pub fn rebind<U>(&self, value: U) -> Binder<U> {
+        self.as_ref().map(|_| value)
     }
 }
 

--- a/frontend/exporter/src/types/copied.rs
+++ b/frontend/exporter/src/types/copied.rs
@@ -1850,11 +1850,7 @@ pub enum Ty {
         rustc_middle::ty::TyKind::Adt(adt_def, generics) => {
             let def_id = adt_def.did().sinto(state);
             let generic_args: Vec<GenericArg> = generics.sinto(state);
-            let trait_refs = if state.base().ty_alias_mode {
-                vec![]
-            } else {
-                solve_item_traits(state, adt_def.did(), generics, None)
-            };
+            let trait_refs = solve_item_traits(state, adt_def.did(), generics, None);
             Ty::Adt { def_id, generic_args, trait_refs }
         },
     )]

--- a/frontend/exporter/src/types/mir_traits.rs
+++ b/frontend/exporter/src/types/mir_traits.rs
@@ -66,16 +66,16 @@ pub fn solve_item_traits<'tcx, S: UnderOwnerState<'tcx>>(
     for (pred, _) in predicates.predicates {
         // Explore only the trait predicates
         if let Some(trait_clause) = pred.as_trait_clause() {
+            let poly_trait_ref = trait_clause.map_bound(|clause| clause.trait_ref);
             // Apply the substitution
-            let trait_ref = trait_clause.map_bound(|clause| {
-                let value = rustc_middle::ty::EarlyBinder::bind(clause.trait_ref);
-                // Warning: this erases regions. We don't really have a way to substitute without
-                // erasing regions, but this may cause problems in trait solving if there are trait
-                // impls that include `'static` lifetimes.
-                // TODO: try `EarlyBinder::subst(...)`?
-                tcx.instantiate_and_normalize_erasing_regions(generics, param_env, value)
-            });
-            let impl_expr = solve_trait(s, trait_ref);
+            let value = rustc_middle::ty::EarlyBinder::bind(poly_trait_ref);
+            // Warning: this erases regions. We don't really have a way to substitute without
+            // erasing regions, but this may cause problems in trait solving if there are trait
+            // impls that include `'static` lifetimes.
+            // TODO: try `EarlyBinder::subst(...)`?
+            let poly_trait_ref =
+                tcx.instantiate_and_normalize_erasing_regions(generics, param_env, value);
+            let impl_expr = solve_trait(s, poly_trait_ref);
             impl_exprs.push(impl_expr);
         }
     }

--- a/frontend/exporter/src/types/mir_traits.rs
+++ b/frontend/exporter/src/types/mir_traits.rs
@@ -44,6 +44,7 @@ pub fn solve_trait<'tcx, S: BaseState<'tcx> + HasOwnerId>(
 ///
 /// [predicates]: optional predicates, in case we want to solve custom predicates
 /// (instead of the ones returned by [TyCtxt::predicates_defined_on].
+#[tracing::instrument(level = "trace", skip(s))]
 pub fn solve_item_traits<'tcx, S: UnderOwnerState<'tcx>>(
     s: &S,
     def_id: rustc_hir::def_id::DefId,

--- a/frontend/exporter/src/types/new/full_def.rs
+++ b/frontend/exporter/src/types/new/full_def.rs
@@ -79,11 +79,10 @@ pub enum FullDefKind {
         predicates: GenericPredicates,
         // `predicates_of` has the special `Self: Trait` clause as its last element.
         #[value({
-            let (clause, _) = s.base().tcx.predicates_of(s.owner_id()).predicates.last().unwrap();
-            let Some(ty::ClauseKind::Trait(trait_ref)) = clause.kind().no_bound_vars() else {
-                panic!()
-            };
-            trait_ref.sinto(s)
+            use ty::Upcast;
+            let tcx = s.base().tcx;
+            let pred: ty::TraitPredicate = ty::TraitRef::identity(tcx, s.owner_id()).upcast(tcx);
+            pred.sinto(s)
         })]
         self_predicate: TraitPredicate,
         /// Associated items, in definition order.

--- a/frontend/exporter/src/types/new/full_def.rs
+++ b/frontend/exporter/src/types/new/full_def.rs
@@ -99,7 +99,9 @@ pub enum FullDefKind {
         #[value(s.base().tcx.hir().get_if_local(s.owner_id()).map(|node| {
             let rustc_hir::Node::Item(item) = node else { unreachable!() };
             let rustc_hir::ItemKind::TyAlias(ty, _generics) = &item.kind else { unreachable!() };
-            ty.sinto(s)
+            let mut s = State::from_under_owner(s);
+            s.base.ty_alias_mode = true;
+            ty.sinto(&s)
         }))]
         ty: Option<Ty>,
     },

--- a/test-harness/src/snapshots/toolchain__traits into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__traits into-fstar.snap
@@ -582,6 +582,11 @@ let closure_impl_expr_fngen
       <:
       Core.Iter.Adapters.Map.t_Map v_I v_F)
 
+let iter_option (#v_T: Type0) (x: Core.Option.t_Option v_T) : Core.Option.t_IntoIter v_T =
+  Core.Iter.Traits.Collect.f_into_iter #(Core.Option.t_Option v_T)
+    #FStar.Tactics.Typeclasses.solve
+    (Core.Option.impl__as_ref #v_T x <: Core.Option.t_Option v_T)
+
 class t_Foo (v_Self: Type0) = {
   f_AssocType:Type0;
   f_AssocType_15525962639250476383:t_SuperTrait f_AssocType;
@@ -619,11 +624,6 @@ let f (#v_T: Type0) (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: t_Foo v_T) (x
 
 let g (#v_T: Type0) (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: t_Foo v_T) (x: i1.f_AssocType)
     : u32 = f_function_of_super_trait #i1.f_AssocType #FStar.Tactics.Typeclasses.solve x
-
-let iter_option (#v_T: Type0) (x: Core.Option.t_Option v_T) : Core.Option.t_IntoIter v_T =
-  Core.Iter.Traits.Collect.f_into_iter #(Core.Option.t_Option v_T)
-    #FStar.Tactics.Typeclasses.solve
-    (Core.Option.impl__as_ref #v_T x <: Core.Option.t_Option v_T)
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 let impl_Foo_for_tuple_: t_Foo Prims.unit =

--- a/test-harness/src/snapshots/toolchain__traits into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__traits into-fstar.snap
@@ -620,6 +620,11 @@ let f (#v_T: Type0) (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: t_Foo v_T) (x
 let g (#v_T: Type0) (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: t_Foo v_T) (x: i1.f_AssocType)
     : u32 = f_function_of_super_trait #i1.f_AssocType #FStar.Tactics.Typeclasses.solve x
 
+let iter_option (#v_T: Type0) (x: Core.Option.t_Option v_T) : Core.Option.t_IntoIter v_T =
+  Core.Iter.Traits.Collect.f_into_iter #(Core.Option.t_Option v_T)
+    #FStar.Tactics.Typeclasses.solve
+    (Core.Option.impl__as_ref #v_T x <: Core.Option.t_Option v_T)
+
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 let impl_Foo_for_tuple_: t_Foo Prims.unit =
   {

--- a/tests/traits/src/lib.rs
+++ b/tests/traits/src/lib.rs
@@ -78,6 +78,11 @@ impl Error {
     }
 }
 
+// Trickier case.
+fn iter_option<'a, T>(x: &'a Option<T>) -> impl Iterator<Item = &'a T> {
+    x.as_ref().into_iter()
+}
+
 mod for_clauses {
     trait Foo<T> {
         fn to_t(&self) -> T;


### PR DESCRIPTION
This PR methodically cleans up trait resolution. It also tracks the index of locally-bound predicates for use in Charon. This solves many binder- and trait-resolution-related issues in Charon.