### PR TITLE
fix(engine/deps): stop re-computing over and over the set of assoc items

### DIFF
--- a/engine/bin/lib.ml
+++ b/engine/bin/lib.ml
@@ -47,9 +47,11 @@ let import_thir_items (include_clauses : Types.inclusion_clause list)
       items
     |> List.map ~f:snd
   in
+  Logs.info (fun m -> m "Items translated");
   let items = List.concat_map ~f:fst imported_items in
-  let associated_items (item : Deps.AST.item) =
-    Deps.uid_associated_items items item.attrs
+  let associated_items =
+    let assoc_items = Deps.uid_associated_items items in
+    fun (item : Deps.AST.item) -> assoc_items item.attrs
   in
   (* Build a map from idents to error reports *)
   let ident_to_reports =

--- a/engine/lib/dependencies.ml
+++ b/engine/lib/dependencies.ml
@@ -83,8 +83,8 @@ module Make (F : Features.T) = struct
       in
       set |> Set.to_list
 
-    let vertices_of_items ~original_items (items : item list) : G.E.t list =
-      let uid_associated_items = uid_associated_items original_items in
+    let vertices_of_items ~uid_associated_items (items : item list) : G.E.t list
+        =
       List.concat_map
         ~f:(fun i ->
           let assoc =
@@ -97,7 +97,8 @@ module Make (F : Features.T) = struct
       let init =
         List.fold ~init:G.empty ~f:(fun g -> ident_of >> G.add_vertex g) items
       in
-      vertices_of_items ~original_items items
+      let uid_associated_items = uid_associated_items original_items in
+      vertices_of_items ~uid_associated_items items
       |> List.fold ~init ~f:(G.add_edge >> uncurry)
 
     let transitive_dependencies_of (g : G.t) (selection : Concrete_ident.t list)


### PR DESCRIPTION
While debugging some bug, I noticed the dependency analysis was very slow, it was basically about precomputing the set of associated items instead of computing it over and over.