### PR TITLE
fix #422

### DIFF
--- a/proof-libs/fstar/rust_primitives/Rust_primitives.Integers.fsti
+++ b/proof-libs/fstar/rust_primitives/Rust_primitives.Integers.fsti
@@ -492,7 +492,6 @@ val get_bit_shr #t #u (x: int_t t) (y: int_t u) (i: usize {v i < bits t})
                          else 0))
     [SMTPat (get_bit (x >>! y) i)]
 
-// TODO(issue #422): check for neg numbers
 /// Bit-wise semantics of integer casts
 val get_bit_cast #t #u
   (x: int_t t) (nth: usize)


### PR DESCRIPTION
I tested empirically that lemma here: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=cae2ae9ad9e37b253d68f3afb442c251

fix #422

-------------------
Here is the script that tests this lemma empirically:
```rust
use std::fmt::Binary;

trait HasBits {
    fn bits() -> u32;
}

macro_rules! mk_has_bits {
  ($t:ident) => {
    impl HasBits for $t {
        fn bits() -> u32 {
            Self::BITS
        }
    }
  }
}

mk_has_bits!(u8);
mk_has_bits!(u16);
mk_has_bits!(u32);
mk_has_bits!(u64);
mk_has_bits!(u128);
mk_has_bits!(i8);
mk_has_bits!(i16);
mk_has_bits!(i32);
mk_has_bits!(i64);
mk_has_bits!(i128);

fn get_bit<T: Binary>(x: T, n: u32) -> u8 {
    let chars: Vec<_> = format!("{:b}", x).chars().rev().collect();
    if chars.get(n as usize).cloned().unwrap_or('0') == '1' { 1 } else { 0 }
}

fn lemma<T: Binary + HasBits + Copy, U: Binary + HasBits + Copy>(
    t: T,
    n: u32,
    cast: &impl Fn(T) -> U,
) -> bool {
    if n < U::bits() && n < T::bits() {
        get_bit(cast(t), n) == get_bit(t, n)
    } else {
        true
    }
}

fn lemma_forall<T: Binary + HasBits + Copy, U: Binary + HasBits + Copy>(
    t: T,
    cast: &impl Fn(T) -> U,
) -> bool {
    for n in 0..128 {
        if !lemma(t, n, cast) {
            return false;
        }
    }
    true
}

macro_rules! test {
    ($t:ident, $u:ident) => {
        {
            println!("TEST: t={} u={}", stringify!($t), stringify!($u));
            let range = $t::MIN..$t::MAX;
            let len = range.len();
            let mut percentage0 = 0;
            let mut n = 0;
            for x in range.clone() {
                let percentage = ((n * 10) / len) * 10;
                if percentage != percentage0 {
                    println!("{percentage}%");
                }
                percentage0 = percentage;
                if !lemma_forall(x, &|x| x as $u) {
                    println!(">>>>>>>>>>>> BAD: {x}");
                    return;
                }
                n += 1;
            }
            println!("DONE");
        }
    }
}

fn main() {
    test!(i16, i32);
    test!(i16, u32);
    test!(i16, i16);
    test!(i16, u16);
    test!(i16, u8);
    test!(i16, i8);
    
    test!(u16, i32);
    test!(u16, u32);
    test!(u16, i16);
    test!(u16, u16);
    test!(u16, u8);
    test!(u16, i8);
    
    test!(i8, i16);
    test!(i8, u16);
    test!(i8, u8);
    test!(i8, i8);
    
    test!(u8, i16);
    test!(u8, u16);
    test!(u8, u8);
    test!(u8, i8);
}
```