### PR TITLE
Ignore structs in variants renaming for bundling.

### DIFF
--- a/engine/lib/dependencies.ml
+++ b/engine/lib/dependencies.ml
@@ -472,7 +472,7 @@ module Make (F : Features.T) = struct
       in
       let variants_renamings (previous_name, new_name) =
         match from_ident previous_name with
-        | Some { v = Type { variants; _ }; _ } ->
+        | Some { v = Type { variants; is_struct = false; _ }; _ } ->
             List.map variants ~f:(fun { name; _ } ->
                 ( name,
                   Concrete_ident.Create.move_under ~new_parent:new_name name ))


### PR DESCRIPTION
Fixes a regression introduced by #935  (see https://github.com/cryspen/libcrux/actions/runs/11153943502/job/31002385466).

That was caused by trying to rename a variant of a struct, but only enum variants should be renamed.