### PR TITLE
Prefer `try_normalize_erasing_regions`

### DIFF
--- a/frontend/exporter/src/constant_utils.rs
+++ b/frontend/exporter/src/constant_utils.rs
@@ -419,8 +419,10 @@ mod rustc {
                 }))
             } else {
                 let param_env = s.param_env();
-                let ty = s.base().tcx.type_of(ucv.def);
-                let ty = tcx.instantiate_and_normalize_erasing_regions(ucv.args, param_env, ty);
+                let ty = s.base().tcx.type_of(ucv.def).instantiate(tcx, ucv.args);
+                let ty = tcx
+                    .try_normalize_erasing_regions(param_env, ty)
+                    .unwrap_or(ty);
                 let kind = if let Some(assoc) = s.base().tcx.opt_associated_item(ucv.def) {
                     if assoc.trait_item_def_id.is_some() {
                         // This must be a trait declaration constant

--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -623,7 +623,9 @@ pub mod rustc {
             (param_env, trait_ref): (ty::ParamEnv<'tcx>, ty::PolyTraitRef<'tcx>),
         ) -> Result<rustc_trait_selection::traits::Selection<'tcx>, CodegenObligationError>
         {
-            let trait_ref = tcx.normalize_erasing_regions(param_env, trait_ref);
+            let trait_ref = tcx
+                .try_normalize_erasing_regions(param_env, trait_ref)
+                .unwrap_or(trait_ref);
 
             // Do the initial selection for the obligation. This yields the
             // shallow result we are looking for -- that is, what specific impl.

--- a/frontend/exporter/src/types/mir_traits.rs
+++ b/frontend/exporter/src/types/mir_traits.rs
@@ -68,13 +68,14 @@ pub fn solve_item_traits<'tcx, S: UnderOwnerState<'tcx>>(
         if let Some(trait_clause) = pred.as_trait_clause() {
             let poly_trait_ref = trait_clause.map_bound(|clause| clause.trait_ref);
             // Apply the substitution
-            let value = rustc_middle::ty::EarlyBinder::bind(poly_trait_ref);
-            // Warning: this erases regions. We don't really have a way to substitute without
+            let poly_trait_ref =
+                rustc_middle::ty::EarlyBinder::bind(poly_trait_ref).instantiate(tcx, generics);
+            // Warning: this erases regions. We don't really have a way to normalize without
             // erasing regions, but this may cause problems in trait solving if there are trait
             // impls that include `'static` lifetimes.
-            // TODO: try `EarlyBinder::subst(...)`?
-            let poly_trait_ref =
-                tcx.instantiate_and_normalize_erasing_regions(generics, param_env, value);
+            let poly_trait_ref = tcx
+                .try_normalize_erasing_regions(param_env, poly_trait_ref)
+                .unwrap_or(poly_trait_ref);
             let impl_expr = solve_trait(s, poly_trait_ref);
             impl_exprs.push(impl_expr);
         }

--- a/frontend/exporter/src/types/new/full_def.rs
+++ b/frontend/exporter/src/types/new/full_def.rs
@@ -385,7 +385,8 @@ fn normalize_trait_clauses<'tcx, S: UnderOwnerState<'tcx>>(
                 clause = s
                     .base()
                     .tcx
-                    .normalize_erasing_regions(s.param_env(), clause);
+                    .try_normalize_erasing_regions(s.param_env(), clause)
+                    .unwrap_or(clause);
             }
             (clause.as_predicate(), *span)
         })


### PR DESCRIPTION
There are some contexts where normalization can fail (particularly type aliases), which causes a compiler panic.