### PR TITLE
Grammar rules as documentation on the AST module

### DIFF
--- a/engine/lib/ast.ml
+++ b/engine/lib/ast.ml
@@ -115,30 +115,48 @@ functor
 
     type ty =
       | TBool
+      (** [ bool ] **)
       | TChar
+      (** [ char ] **)
       | TInt of int_kind
+      (** [ int <int_kind> ] **)
       | TFloat of float_kind
+      (** [ float <float_kind> ] **)
       | TStr
+      (** [ str ] **)
       | TApp of { ident : global_ident; args : generic_value list }
+      (** [ <ident>( [<arg>]* ) ] **)
       | TArray of { typ : ty; length : expr }
+      (** [ [<typ>, <length>] ] **)
       | TSlice of { witness : F.slice; ty : ty }
+      (** [ (when slice) [<ty>] ] **)
       | TRawPointer of { witness : F.raw_pointer } (* todo *)
+      (** [ (when raw_pointer) *const <ty> or (when raw_pointer) *mut <ty> ] **)
       | TRef of {
           witness : F.reference;
           region : todo;
           typ : ty;
           mut : F.mutable_reference mutability;
         }
+      (** [ (when reference) &<typ> or (when reference and mut_reference) &mut <typ>] **) (* TODO: Region *)
       | TParam of local_ident
+      (** [ <local_ident> ] **)
       | TArrow of ty list * ty
+      (** [ [<ty>]+ -> <ty> ] **) (* TODO: empty is unit? + or * *)
       | TAssociatedType of { impl : impl_expr; item : concrete_ident }
+      (** [ <impl>::<item> ] **)
       | TOpaque of concrete_ident
+      (** [ <concrete_ident> ] **)
       | TDyn of { witness : F.dyn; goals : dyn_trait_goal list }
+      (** [ (when dyn) [<goals>]* ] **)
 
     and generic_value =
       | GLifetime of { lt : todo; witness : F.lifetime }
+      (** [ (when lifetime) '<lt> ] **)
       | GType of ty
+      (** [ <ty> ] **)
       | GConst of expr
+      (** [ const <expr>: <expr.ty> ] **) (* TODO constant expr *)
 
     and impl_expr = { kind : impl_expr_kind; goal : trait_goal }
 


### PR DESCRIPTION
Following a discussion with @karthikbhargavan, @cmester0 and I have been experimenting with putting OCaml comments directly onto the AST module, documenting the grammar rules covered by the internal AST of hax.

However, we believe that's not the best way to do things.

@cmester0 had a great idea: use the rust printer of hax to generate the grammar.

The idea is the following:
 - we define two top-level values for each type: `enumerate` and `default`
 - `enumerate` for type `t` is of type `t set`, `default` for type `t` is of type `t`
 - `enumerate` for each `t` scalar will be a default value (say 0 for ints, "" for strings, etc.)
 - `enumerate` of `t list` would be all possible combinations of the values `enumerate<t>` in list of length from zero to say 3 
 - `enumerate` of `t option` would be the set `None` and `Some` of all the values in `enumerate` for type `t`
 - for every type of the AST, we derive via PPX `default` and `enumerate`. We need to make sure those `enumerate` are finite somehow (we can have a `seen` list of values, or do something statically, let's see)
 - use the rust printer to generate rules

Status: let's not merge this