### PR TITLE
Make options extensible

### DIFF
--- a/cli/subcommands/src/cargo_hax.rs
+++ b/cli/subcommands/src/cargo_hax.rs
@@ -201,7 +201,7 @@ fn run_engine(
     haxmeta: HaxMeta<hax_frontend_exporter::ThirBody>,
     working_dir: PathBuf,
     manifest_dir: PathBuf,
-    backend: &BackendOptions,
+    backend: &BackendOptions<()>,
     message_format: MessageFormat,
 ) -> bool {
     let engine_options = EngineOptions {

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -68,7 +68,7 @@ end
 module AST = Ast.Make (InputLanguage)
 
 module BackendOptions = struct
-  type t = Hax_engine.Types.f_star_options
+  type t = Hax_engine.Types.f_star_options_for__null
 end
 
 open Ast

--- a/engine/backends/fstar/fstar_backend.mli
+++ b/engine/backends/fstar/fstar_backend.mli
@@ -1,2 +1,2 @@
 open Hax_engine.Backend
-include T with type BackendOptions.t = Hax_engine.Types.f_star_options
+include T with type BackendOptions.t = Hax_engine.Types.f_star_options_for__null

--- a/engine/utils/ocaml_of_json_schema/ocaml_of_json_schema.js
+++ b/engine/utils/ocaml_of_json_schema/ocaml_of_json_schema.js
@@ -434,6 +434,16 @@ let exporters = {
             return {type, parse, to_json};
         },
     },
+    empty_struct: {
+        guard: def => (eq(keys(def), new Set(["type"])) && def.type == 'object'),
+        f: (name, _) => {
+            return {
+                type: `EmptyStruct${name}`,
+                parse: `EmptyStruct${name}`,
+                to_json: '`Null',
+            };
+        },
+    },
     // object is a *flat* record
     object: {
         guard: def => (eq(keys(def), new Set(["type", "required", "properties"]))
@@ -462,6 +472,14 @@ let exporters = {
             && def.type == "string",
         f: (name, o) => {
             assert(o.enum.every(x => typeof x == "string"), 'not every enum is a string');
+
+            if(o.enum.length == 0) {
+                return {
+                    type: '|',
+                    parse: 'failwith "cannot parse an empty type"',
+                    to_json: 'match o with _ -> .',
+                };
+            }
 
             let variants = o.enum.map(n => ({
                 Δ: n,

--- a/hax-types/src/cli_options/extension.rs
+++ b/hax-types/src/cli_options/extension.rs
@@ -1,0 +1,48 @@
+/// This module defines a way to extend externally the CLI of hax, via
+/// the `Extension` trait. This trait defines one associated type per
+/// extension point.
+use crate::prelude::*;
+
+use clap::{Parser, Subcommand};
+
+macro_rules! mk_Extension_trait {
+    {$(type $name:ident : $kind:ident;)+} => {
+        pub trait Extension {
+            $(type $name: bincode::Decode
+              + bincode::Encode
+              + std::fmt::Debug
+              + for<'a> serde::Deserialize<'a>
+              + serde::Serialize
+              + JsonSchema
+              + Clone
+              + for<'a> bincode::BorrowDecode<'a>
+              + clap::$kind;)+
+        }
+
+        /// `()` is the empty extension
+        const _: () = {
+            use NoExtensionStruct as Args;
+            use NoExtensionEnum as Subcommand;
+
+            impl Extension for () {
+                $(type $name = $kind;)+
+            }
+        };
+
+    };
+}
+
+#[derive_group(Serializers)]
+#[derive(JsonSchema, Parser, Debug, Clone)]
+pub struct NoExtensionStruct {}
+
+#[derive_group(Serializers)]
+#[derive(JsonSchema, Subcommand, Debug, Clone)]
+pub enum NoExtensionEnum {}
+
+mk_Extension_trait! {
+    type Options: Args;
+    type Command: Subcommand;
+    type BackendOptions: Args;
+    type FStarOptions: Args;
+}

--- a/hax-types/src/diagnostics/message.rs
+++ b/hax-types/src/diagnostics/message.rs
@@ -21,7 +21,7 @@ pub enum HaxMessage {
     } = 2,
     CargoBuildFailure = 3,
     WarnExperimentalBackend {
-        backend: Backend,
+        backend: Backend<()>,
     } = 4,
 }
 

--- a/hax-types/src/engine_api.rs
+++ b/hax-types/src/engine_api.rs
@@ -6,7 +6,7 @@ type ThirBody = hax_frontend_exporter::ThirBody;
 #[derive_group(Serializers)]
 #[derive(JsonSchema, Debug, Clone)]
 pub struct EngineOptions {
-    pub backend: BackendOptions,
+    pub backend: BackendOptions<()>,
     pub input: Vec<hax_frontend_exporter::Item<ThirBody>>,
     pub impl_infos: Vec<(
         hax_frontend_exporter::DefId,


### PR DESCRIPTION
The CLI is defined with the rust library clap. This PR introduce a
trait `Extension` which define an associated type per type of
`cli_options`.

For now, not all the types have been added to that trait: let's do
that lazily.

With this PR, it is easy to define a superset of hax' CLI.