### PR TITLE
fix(engine): make consts fun. calls of arity 0 when there is an impl expr

### DIFF
--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -716,11 +716,17 @@ end) : EXPR = struct
                        typ = TInt { size = S8; signedness = Unsigned };
                      })
                    l))
-      | NamedConst { def_id = id; impl; _ } ->
+      | NamedConst { def_id = id; impl; _ } -> (
           let kind : Concrete_ident.Kind.t =
             match impl with Some _ -> AssociatedItem Value | _ -> Value
           in
-          GlobalVar (def_id kind id)
+          let f = GlobalVar (def_id kind id) in
+          match impl with
+          | Some impl ->
+              let trait = Some (c_impl_expr e.span impl, []) in
+              let f = { e = f; span; typ = TArrow ([], typ) } in
+              App { f; trait; args = []; generic_args = []; bounds_impls = [] }
+          | _ -> f)
       | Closure { body; params; upvars; _ } ->
           let params =
             List.filter_map ~f:(fun p -> Option.map ~f:c_pat p.pat) params

--- a/test-harness/src/snapshots/toolchain__naming into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__naming into-fstar.snap
@@ -127,7 +127,8 @@ let constants
       (#v_T: Type0)
       (#[FStar.Tactics.Typeclasses.tcresolve ()] i1: t_FooTrait v_T)
       (_: Prims.unit)
-    : usize = f_ASSOCIATED_CONSTANT +! v_INHERENT_CONSTANT
+    : usize =
+  (f_ASSOCIATED_CONSTANT #FStar.Tactics.Typeclasses.solve <: usize) +! v_INHERENT_CONSTANT
 
 let ff__g (_: Prims.unit) : Prims.unit = ()
 


### PR DESCRIPTION
The engine was dropping trait information when importing constants: now, if a constant `T::CONST` is an associated item of a non-inherent trait, we represent it `T::CONST` as a call to `CONST()` with the implementation expression for `T`.

Note that, in the engine, constants are already represented as functions of arity zero. Rust functions of arity zero are represented as functions that take exactly one `unit` input.

Fixes #840.