### PR TITLE
Remove workaround in trait resolution for associated items

### DIFF
--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -257,7 +257,7 @@ pub mod rustc {
         }
 
         // Lifetimes are irrelevant when resolving instances.
-        pub(super) fn erase_and_norm<'tcx, T>(
+        pub(crate) fn erase_and_norm<'tcx, T>(
             tcx: TyCtxt<'tcx>,
             param_env: ParamEnv<'tcx>,
             x: T,


### PR DESCRIPTION
Now that we thoroughly erase lifetimes in trait resolution, we shouldn't have any binder problems left.

Fixes https://github.com/hacspec/hax/issues/747