### PR TITLE
Quote items track replace

### DIFF
--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -1465,7 +1465,7 @@ struct
         let tcinst = F.term @@ F.AST.Var FStar_Parser_Const.tcinstance_lid in
         F.decls ~fsti:ctx.interface_mode ~attrs:[ tcinst ]
         @@ F.AST.TopLevelLet (NoLetQualifier, [ (pat, body) ])
-    | Quote quote ->
+    | Quote { quote; _ } ->
         let fstar_opts =
           Attrs.find_unique_attr e.attrs ~f:(function
             | ItemQuote q -> Some q.fstar_options

--- a/engine/backends/proverif/proverif_backend.ml
+++ b/engine/backends/proverif/proverif_backend.ml
@@ -635,7 +635,7 @@ module Make (Options : OPTS) : MAKE = struct
                 ^^ separate_map hardline
                      (fun variant -> fun_and_reduc name variant)
                      variants
-          | Quote quote -> print#quote quote
+          | Quote { quote; _ } -> print#quote quote
           | _ -> empty
 
         method! expr_let : lhs:pat -> rhs:expr -> expr fn =

--- a/engine/lib/ast.ml
+++ b/engine/lib/ast.ml
@@ -99,6 +99,29 @@ type literal =
 type 'mut_witness mutability = Mutable of 'mut_witness | Immutable
 [@@deriving show, yojson, hash, compare, sexp, hash, eq]
 
+type item_kind =
+  [ `Fn
+  | `TyAlias
+  | `Type
+  | `IMacroInvokation
+  | `Trait
+  | `Impl
+  | `Alias
+  | `Use
+  | `Quote
+  | `HaxError
+  | `NotImplementedYet ]
+[@@deriving show, yojson, hash, compare, sexp, hash, eq]
+(** Describes the (shallow) kind of an item. *)
+
+type item_quote_origin = {
+  item_kind : item_kind;
+  item_ident : concrete_ident;
+  position : [ `Before | `After | `Replace ];
+}
+[@@deriving show, yojson, hash, compare, sexp, hash, eq]
+(** From where does a quote item comes from? *)
+
 module Make =
 functor
   (F : Features.T)
@@ -434,7 +457,7 @@ functor
           is_external : bool;
           rename : string option;
         }
-      | Quote of quote
+      | Quote of { quote : quote; origin : item_quote_origin }
       | HaxError of string
       | NotImplementedYet
 

--- a/engine/lib/ast_utils.ml
+++ b/engine/lib/ast_utils.ml
@@ -999,6 +999,20 @@ module Make (F : Features.T) = struct
     in
     Some { pat; typ; typ_span = Some span; attrs = [] }
 
+  let kind_of_item (item : item) : item_kind =
+    match item.v with
+    | Fn _ -> `Fn
+    | TyAlias _ -> `TyAlias
+    | Type _ -> `Type
+    | IMacroInvokation _ -> `IMacroInvokation
+    | Trait _ -> `Trait
+    | Impl _ -> `Impl
+    | Alias _ -> `Alias
+    | Use _ -> `Use
+    | Quote _ -> `Quote
+    | HaxError _ -> `HaxError
+    | NotImplementedYet -> `NotImplementedYet
+
   let rec expr_of_lhs (span : span) (lhs : lhs) : expr =
     match lhs with
     | LhsLocalVar { var; typ } -> { e = LocalVar var; typ; span }

--- a/engine/lib/deprecated_generic_printer/deprecated_generic_printer.ml
+++ b/engine/lib/deprecated_generic_printer/deprecated_generic_printer.ml
@@ -407,7 +407,7 @@ module Make (F : Features.T) (View : Concrete_ident.VIEW_API) = struct
               safety ^^ !^"fn" ^^ space ^^ print#concrete_ident name ^^ generics
               ^^ params
               ^^ iblock braces (print#expr_at Item_Fn_body body)
-          | Quote quote -> print#quote quote
+          | Quote { quote; _ } -> print#quote quote
           | _ -> string "item not implemented"
 
         method generic_param' : generic_param fn =

--- a/engine/lib/generic_printer/generic_printer_template.ml
+++ b/engine/lib/generic_printer/generic_printer_template.ml
@@ -219,7 +219,8 @@ struct
       method item'_NotImplementedYet =
         default_document_for "item'_NotImplementedYet"
 
-      method item'_Quote ~super:_ _x2 = default_document_for "item'_Quote"
+      method item'_Quote ~super:_ ~quote:_ ~origin:_ =
+        default_document_for "item'_Quote"
 
       method item'_Trait ~super:_ ~name:_ ~generics:_ ~items:_ ~safety:_ =
         default_document_for "item'_Trait"

--- a/engine/lib/phases/phase_transform_hax_lib_inline.ml
+++ b/engine/lib/phases/phase_transform_hax_lib_inline.ml
@@ -166,6 +166,7 @@ module%inlined_contents Make (F : Features.T) = struct
         let before, after =
           let map_fst = List.map ~f:fst in
           try
+            let replace = Attrs.late_skip item.attrs in
             Attrs.associated_items Attr_payloads.AssocRole.ItemQuote item.attrs
             |> List.map ~f:(fun assoc_item ->
                    let e : A.expr =
@@ -181,7 +182,6 @@ module%inlined_contents Make (F : Features.T) = struct
                             (* ^ (UA.LiftToFullAst.expr e |> Print_rust.pexpr_str) *)
                             ^ [%show: A.expr] e)
                    in
-                   let v : B.item' = Quote quote in
                    let span = e.span in
                    let position, attr =
                      Attrs.find_unique_attr assoc_item.attrs ~f:(function
@@ -191,6 +191,21 @@ module%inlined_contents Make (F : Features.T) = struct
                             Error.assertion_failure assoc_item.span
                               "Malformed `Quote` item: could not find a \
                                ItemQuote payload")
+                   in
+                   let v : B.item' =
+                     let origin : item_quote_origin =
+                       {
+                         item_kind = UA.kind_of_item item;
+                         item_ident = item.ident;
+                         position =
+                           (if replace then `Replace
+                           else
+                             match position with
+                             | After -> `After
+                             | Before -> `Before);
+                       }
+                     in
+                     Quote { quote; origin }
                    in
                    let attrs = [ Attr_payloads.to_attr attr assoc_item.span ] in
                    (B.{ v; span; ident = item.ident; attrs }, position))

--- a/engine/lib/print_rust.ml
+++ b/engine/lib/print_rust.ml
@@ -592,7 +592,7 @@ module Raw = struct
             & !"{"
             & List.map ~f:pimpl_item items |> concat ~sep:!"\n"
             & !"}"
-        | Quote quote -> pquote e.span quote & !";"
+        | Quote { quote; _ } -> pquote e.span quote & !";"
         | _ -> raise NotImplemented
       in
       pattrs e.attrs & pi

--- a/engine/lib/subtype.ml
+++ b/engine/lib/subtype.ml
@@ -532,7 +532,7 @@ struct
             }
       | Alias { name; item } -> B.Alias { name; item }
       | Use { path; is_external; rename } -> B.Use { path; is_external; rename }
-      | Quote quote -> Quote (dquote span quote)
+      | Quote { quote; origin } -> Quote { quote = dquote span quote; origin }
       | HaxError e -> B.HaxError e
       | NotImplementedYet -> B.NotImplementedYet
 

--- a/engine/utils/generate_from_ast/codegen_visitor.ml
+++ b/engine/utils/generate_from_ast/codegen_visitor.ml
@@ -233,6 +233,7 @@ let is_allowed_opaque name =
       "quote";
       "float_kind";
       "int_kind";
+      "item_quote_origin";
     ]
   in
   List.mem ~equal:String.equal allowlist name


### PR DESCRIPTION
This PR adds a field `origin` to the constructor `Quote` for items.
This adds context when we use replace/before/after: backends now know where a quote comes from.