### PR TITLE
some fixes for iterators.f_next and update_at_usize

### DIFF
--- a/proof-libs/fstar/core/Core.Iter.Traits.Iterator.fst
+++ b/proof-libs/fstar/core/Core.Iter.Traits.Iterator.fst
@@ -7,7 +7,7 @@ on their own. This is handy for revealing only certain fields of the
 instances of the `iterator` trait. *)
 
 unfold type t_next self item
-  = self -> self * option item
+  = self -> self * Core.Option.t_Option item
 unfold type t_contains self item
   = self -> item -> Type0
 unfold type t_fold self (item: Type0) (contains: t_contains self item)
@@ -31,7 +31,7 @@ unfold type t_all self item
 class iterator (self: Type u#0): Type u#1 = {
   [@@@FStar.Tactics.Typeclasses.no_method]
   f_Item: Type0;
-  f_next:      self -> self * option f_Item;
+  f_next:      self -> self * Core.Option.t_Option f_Item;
   f_contains:  self -> f_Item -> Type0;
   f_fold:      #b:Type0 -> s:self -> b -> (b -> i:f_Item{f_contains s i} -> b) -> b;
   f_enumerate: self -> Core.Iter.Adapters.Enumerate.t_Enumerate self;

--- a/proof-libs/fstar/core/Core.Iter.fsti
+++ b/proof-libs/fstar/core/Core.Iter.fsti
@@ -28,10 +28,10 @@ instance iterator_enumerate it {| i: iterator it |}: iterator (Core.Iter.Adapter
       let open Core.Ops in
       let iter, opt = f_next iter in
       match opt with
-      | Some value -> if v count = max_usize
-                     then {iter; count                }, None
-                     else {iter; count = count +. sz 1}, Some (count, value)
-      | None -> {iter; count}, None
+      | Core.Option.Option_Some value -> if v count = max_usize
+                     then {iter; count                }, Core.Option.Option_None
+                     else {iter; count = count +. sz 1}, Core.Option.Option_Some (count, value)
+      | Core.Option.Option_None -> {iter; count}, Core.Option.Option_None
     );
     f_contains  = iterator_enumerate_contains  it i;
     f_fold      = iterator_enumerate_fold      it i;
@@ -84,7 +84,7 @@ val iterator_slice_all (t: eqtype): t_all (t_Slice t) t
 instance iterator_slice (t: eqtype): iterator (t_Slice t) = {
   f_Item = t;
   f_next = iterator_slice_next t;
-  // size_hint = (fun s -> Some (Rust_primitives.Arrays.length s));
+  // size_hint = (fun s -> Core.Option.Option_Some (Rust_primitives.Arrays.length s));
   f_contains  = iterator_slice_contains  t;
   f_fold      = iterator_slice_fold      t;
   f_enumerate = iterator_slice_enumerate t;
@@ -106,7 +106,7 @@ val iterator_array_all (t: eqtype) len: t_all (t_Array t len) t
 instance iterator_array (t: eqtype) len: iterator (t_Array t len) = {
   f_Item = t;
   f_next = iterator_array_next t len;
-  // size_hint = (fun (_s: t_Array t len) -> Some len);
+  // size_hint = (fun (_s: t_Array t len) -> Core.Option.Option_Some len);
   f_contains  = iterator_array_contains  t len;
   f_fold      = iterator_array_fold      t len;
   f_enumerate = iterator_array_enumerate t len;

--- a/proof-libs/fstar/core/Core.Ops.Range.fsti
+++ b/proof-libs/fstar/core/Core.Ops.Range.fsti
@@ -23,8 +23,8 @@ val iterator_range_all t: t_all (t_Range (Rust_primitives.int_t t)) (Rust_primit
 instance iterator_range t: iterator (t_Range (Rust_primitives.int_t t)) = 
   { f_Item = Rust_primitives.int_t t;
     f_next = (fun {f_start; f_end} -> 
-       if f_start >=. f_end then ({f_start; f_end}, None)
-       else ({f_start = f_start +. Rust_primitives.mk_int 0; f_end}, Some f_start)
+       if f_start >=. f_end then ({f_start; f_end}, Core.Option.Option_None)
+       else ({f_start = f_start +. Rust_primitives.mk_int 0; f_end}, Core.Option.Option_Some f_start)
     );
     f_contains = (fun x i -> v i < v x.f_end /\ v i >= v x.f_start);
     f_fold = (fun #b r init f ->  if r.f_start >=. r.f_end then init

--- a/proof-libs/fstar/rust_primitives/Rust_primitives.Hax.Monomorphized_update_at.fst
+++ b/proof-libs/fstar/rust_primitives/Rust_primitives.Hax.Monomorphized_update_at.fst
@@ -4,9 +4,6 @@ open Rust_primitives
 open Rust_primitives.Hax
 open Core.Ops.Range
 
-let update_at_usize s i x = 
-  update_at s i x
-
 let update_at_range #n s i x = 
   let res = update_at s i x in
   admit(); // To be proved // see issue #423


### PR DESCRIPTION
The iterator model in the hax proof-libs used F* options instead of `Core.Option.t_Option`. This PR fixes that.
There is also a drive by fix remove the duplicate definition of `update_at_usize`