### PR TITLE
Improve trait resolution

### DIFF
--- a/frontend/exporter/src/constant_utils.rs
+++ b/frontend/exporter/src/constant_utils.rs
@@ -433,7 +433,7 @@ mod rustc {
 
                         // Solve the trait obligations
                         let parent_def_id = tcx.parent(ucv.def);
-                        let trait_refs = solve_item_traits(s, parent_def_id, ucv.args);
+                        let trait_refs = solve_item_required_traits(s, parent_def_id, ucv.args);
 
                         // Convert
                         let id = ucv.def.sinto(s);

--- a/frontend/exporter/src/constant_utils.rs
+++ b/frontend/exporter/src/constant_utils.rs
@@ -433,7 +433,7 @@ mod rustc {
 
                         // Solve the trait obligations
                         let parent_def_id = tcx.parent(ucv.def);
-                        let trait_refs = solve_item_traits(s, parent_def_id, ucv.args, None);
+                        let trait_refs = solve_item_traits(s, parent_def_id, ucv.args);
 
                         // Convert
                         let id = ucv.def.sinto(s);

--- a/frontend/exporter/src/traits/resolution.rs
+++ b/frontend/exporter/src/traits/resolution.rs
@@ -261,6 +261,7 @@ impl<'tcx> PredicateSearcher<'tcx> {
             .iter()
             .filter_map(|(clause, _span)| clause.as_trait_clause())
             .map(|trait_pred| trait_pred.map_bound(|p| p.trait_ref))
+            .map(|trait_ref| EarlyBinder::bind(trait_ref).instantiate(tcx, alias_ty.args))
             .map(|trait_ref| self.resolve(&trait_ref, warn))
             .collect::<Result<_, _>>()?;
 

--- a/frontend/exporter/src/traits/utils.rs
+++ b/frontend/exporter/src/traits/utils.rs
@@ -1,32 +1,42 @@
+//! Each item can involve three kinds of predicates:
+//! - input aka required predicates: the predicates required to mention the item. These are usually `where`
+//!   clauses (or equivalent) on the item:
+//! ```ignore
+//! struct Foo<T: Clone> { ... }
+//! trait Foo<T> where T: Clone { ... }
+//! fn function<I>() where I: Iterator, I::Item: Clone { ... }
+//! ```
+//! - output aka implied predicates: the predicates that are implied by the presence of this item in a
+//!   signature. This is mostly trait parent predicates:
+//! ```ignore
+//! trait Foo: Clone { ... }
+//! fn bar<T: Foo>() {
+//!   // from `T: Foo` we can deduce `T: Clone`
+//! }
+//! ```
+//!   This could also include implied predicates such as `&'a T` implying `T: 'a` but we don't
+//!   consider these.
+//! - "self" predicate: that's the special `Self: Trait` predicate in scope within a trait
+//!   declaration or implementation for trait `Trait`.
+//!
+//! Note that within a given item the polarity is reversed: input predicates are the ones that can
+//! be assumed to hold and output predicates must be proven to hold. The "self" predicate is both
+//! assumed and proven within an impl block, and just assumed within a trait declaration block.
+//!
+//! The current implementation considers all predicates on traits to be outputs, which has the
+//! benefit of reducing the size of signatures. Moreover, the rules on which bounds are required vs
+//! implied are subtle. We may change this if this proves to be a problem.
 use rustc_hir::def::DefKind;
 use rustc_middle::ty::*;
+use rustc_span::def_id::DefId;
 
-/// Just like `TyCtxt::predicates_of`, but in the case of a trait or impl item or closures,
-/// also includes the predicates defined on the parents. Also this returns the special
-/// `Self` clause separately.
-pub fn predicates_of_or_above<'tcx>(
+/// The predicates that must hold to mention this item.
+pub fn required_predicates<'tcx>(
     tcx: TyCtxt<'tcx>,
-    did: rustc_span::def_id::DefId,
-) -> (
-    Vec<PolyTraitPredicate<'tcx>>,
-    Option<PolyTraitPredicate<'tcx>>,
-) {
+    def_id: DefId,
+) -> impl Iterator<Item = Clause<'tcx>> {
     use DefKind::*;
-    let def_kind = tcx.def_kind(did);
-
-    let (mut predicates, mut self_pred) = match def_kind {
-        // These inherit some predicates from their parent.
-        AssocTy | AssocFn | AssocConst | Closure => {
-            let parent = tcx.parent(did);
-            predicates_of_or_above(tcx, parent)
-        }
-        _ => (vec![], None),
-    };
-
-    match def_kind {
-        // Don't list the predicates of traits, we already list the `Self` clause from
-        // which we can resolve anything needed.
-        Trait => {}
+    match tcx.def_kind(def_id) {
         AssocConst
         | AssocFn
         | AssocTy
@@ -40,29 +50,84 @@ pub fn predicates_of_or_above<'tcx>(
         | Struct
         | TraitAlias
         | TyAlias
-        | Union => {
-            // Only these kinds may reasonably have predicates; we have to filter
-            // otherwise calling `predicates_defined_on` may ICE.
-            predicates.extend(
-                tcx.predicates_defined_on(did)
-                    .predicates
-                    .iter()
-                    .filter_map(|(clause, _span)| clause.as_trait_clause()),
-            );
-        }
-        _ => {}
+        | Union => Some(
+            tcx.predicates_defined_on(def_id)
+                .predicates
+                .iter()
+                .map(|(clause, _span)| *clause),
+        ),
+        // We consider all predicates on traits to be outputs
+        Trait => None,
+        // `predicates_defined_on ICEs on other def kinds.
+        _ => None,
     }
+    .into_iter()
+    .flatten()
+}
 
-    // Add the extra `Self: Trait` predicate.
-    match def_kind {
-        Trait => {
-            // Add the special `Self: Trait` clause.
-            // Copied from the code of `tcx.predicates_of()`.
-            let self_clause: Clause<'_> = TraitRef::identity(tcx, did).upcast(tcx);
-            self_pred = Some(self_clause.as_trait_clause().unwrap());
-        }
-        _ => {}
+/// The special "self" predicate on a trait.
+pub fn self_predicate<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> Option<PolyTraitRef<'tcx>> {
+    use DefKind::*;
+    match tcx.def_kind(def_id) {
+        // Copied from the code of `tcx.predicates_of()`.
+        Trait => Some(Binder::dummy(TraitRef::identity(tcx, def_id))),
+        _ => None,
     }
+}
+
+/// The predicates that can be deduced from the presence of this item in a signature. We only
+/// consider predicates implied by traits here, not implied bounds such as `&'a T` implying `T:
+/// 'a`.
+pub fn implied_predicates<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    def_id: DefId,
+) -> impl Iterator<Item = Clause<'tcx>> {
+    use DefKind::*;
+    match tcx.def_kind(def_id) {
+        // We consider all predicates on traits to be outputs
+        Trait => tcx
+            .predicates_defined_on(def_id)
+            .predicates
+            .iter()
+            .map(|(clause, _span)| *clause)
+            .collect::<Vec<_>>(),
+        AssocTy => tcx
+            // TODO: `item_bounds` contains parent traits, use `explicit_item_bounds` instead.
+            .item_bounds(def_id)
+            .instantiate_identity()
+            .iter()
+            .collect(),
+        _ => vec![],
+    }
+    .into_iter()
+}
+
+/// Accumulates the `required_predicates` of this item and its parents, starting from the parents.
+/// Also returns the special `Self` clause separately.
+pub fn predicates_of_or_above<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    def_id: DefId,
+) -> (
+    Vec<PolyTraitPredicate<'tcx>>,
+    Option<PolyTraitPredicate<'tcx>>,
+) {
+    use DefKind::*;
+    let def_kind = tcx.def_kind(def_id);
+
+    let (mut predicates, self_pred) = match def_kind {
+        // These inherit some predicates from their parent.
+        AssocTy | AssocFn | AssocConst | Closure => {
+            let parent = tcx.parent(def_id);
+            predicates_of_or_above(tcx, parent)
+        }
+        _ => {
+            let self_pred = self_predicate(tcx, def_id).map(|clause| clause.upcast(tcx));
+            (vec![], self_pred)
+        }
+    };
+
+    predicates
+        .extend(required_predicates(tcx, def_id).filter_map(|clause| clause.as_trait_clause()));
 
     (predicates, self_pred)
 }

--- a/frontend/exporter/src/types/mir.rs
+++ b/frontend/exporter/src/types/mir.rs
@@ -978,15 +978,14 @@ pub enum AggregateKind {
         let closure = generics.as_closure();
         let sig = closure.sig().sinto(s);
 
-        // Solve the trait obligations. Note that we solve the parent
+        // Solve the predicates from the parent (i.e., the function which calls the closure).
         let tcx = s.base().tcx;
         let parent_generics = closure.parent_args();
         let generics = tcx.mk_args(parent_generics);
-        // Retrieve the predicates from the parent (i.e., the function which calls
-        // the closure).
-        let predicates = tcx.predicates_defined_on(tcx.generics_of(rust_id).parent.unwrap());
+        // TODO: does this handle nested closures?
+        let parent = tcx.generics_of(rust_id).parent.unwrap();
+        let trait_refs = solve_item_traits(s, *rust_id, generics, Some(parent));
 
-        let trait_refs = solve_item_traits(s, *rust_id, generics, Some(predicates));
         AggregateKind::Closure(def_id, parent_generics.sinto(s), trait_refs, sig)
     })]
     Closure(DefId, Vec<GenericArg>, Vec<ImplExpr>, PolyFnSig),

--- a/frontend/exporter/src/types/mir.rs
+++ b/frontend/exporter/src/types/mir.rs
@@ -315,7 +315,7 @@ pub(crate) fn get_function_from_def_id_and_generics<'tcx, S: BaseState<'tcx> + H
     // fn foo<T : Bar>(...)
     //            ^^^
     // ```
-    let mut trait_refs = solve_item_traits(s, def_id, generics, None);
+    let mut trait_refs = solve_item_traits(s, def_id, generics);
 
     // Check if this is a trait method call: retrieve the trait source if
     // it is the case (i.e., where does the method come from? Does it refer
@@ -397,7 +397,7 @@ pub(crate) fn get_function_from_def_id_and_generics<'tcx, S: BaseState<'tcx> + H
                 let container_generics = tcx.generics_of(container_def_id);
                 let container_generics = generics.truncate_to(tcx, container_generics);
                 let container_trait_refs =
-                    solve_item_traits(s, container_def_id, container_generics, None);
+                    solve_item_traits(s, container_def_id, container_generics);
                 trait_refs.extend(container_trait_refs);
                 (generics.sinto(s), Option::None)
             }
@@ -950,7 +950,7 @@ pub enum AggregateKind {
     Tuple,
     #[custom_arm(rustc_middle::mir::AggregateKind::Adt(def_id, vid, generics, annot, fid) => {
         let adt_kind = s.base().tcx.adt_def(def_id).adt_kind().sinto(s);
-        let trait_refs = solve_item_traits(s, *def_id, generics, None);
+        let trait_refs = solve_item_traits(s, *def_id, generics);
         AggregateKind::Adt(
             def_id.sinto(s),
             vid.sinto(s),
@@ -984,7 +984,7 @@ pub enum AggregateKind {
         let generics = tcx.mk_args(parent_generics);
         // TODO: does this handle nested closures?
         let parent = tcx.generics_of(rust_id).parent.unwrap();
-        let trait_refs = solve_item_traits(s, *rust_id, generics, Some(parent));
+        let trait_refs = solve_item_traits(s, parent, generics);
 
         AggregateKind::Closure(def_id, parent_generics.sinto(s), trait_refs, sig)
     })]

--- a/frontend/exporter/src/types/mir.rs
+++ b/frontend/exporter/src/types/mir.rs
@@ -315,7 +315,7 @@ pub(crate) fn get_function_from_def_id_and_generics<'tcx, S: BaseState<'tcx> + H
     // fn foo<T : Bar>(...)
     //            ^^^
     // ```
-    let mut trait_refs = solve_item_traits(s, def_id, generics);
+    let mut trait_refs = solve_item_required_traits(s, def_id, generics);
 
     // Check if this is a trait method call: retrieve the trait source if
     // it is the case (i.e., where does the method come from? Does it refer
@@ -397,7 +397,7 @@ pub(crate) fn get_function_from_def_id_and_generics<'tcx, S: BaseState<'tcx> + H
                 let container_generics = tcx.generics_of(container_def_id);
                 let container_generics = generics.truncate_to(tcx, container_generics);
                 let container_trait_refs =
-                    solve_item_traits(s, container_def_id, container_generics);
+                    solve_item_required_traits(s, container_def_id, container_generics);
                 trait_refs.extend(container_trait_refs);
                 (generics.sinto(s), Option::None)
             }
@@ -950,7 +950,7 @@ pub enum AggregateKind {
     Tuple,
     #[custom_arm(rustc_middle::mir::AggregateKind::Adt(def_id, vid, generics, annot, fid) => {
         let adt_kind = s.base().tcx.adt_def(def_id).adt_kind().sinto(s);
-        let trait_refs = solve_item_traits(s, *def_id, generics);
+        let trait_refs = solve_item_required_traits(s, *def_id, generics);
         AggregateKind::Adt(
             def_id.sinto(s),
             vid.sinto(s),
@@ -984,7 +984,7 @@ pub enum AggregateKind {
         let generics = tcx.mk_args(parent_generics);
         // TODO: does this handle nested closures?
         let parent = tcx.generics_of(rust_id).parent.unwrap();
-        let trait_refs = solve_item_traits(s, parent, generics);
+        let trait_refs = solve_item_required_traits(s, parent, generics);
 
         AggregateKind::Closure(def_id, parent_generics.sinto(s), trait_refs, sig)
     })]

--- a/frontend/exporter/src/types/new/full_def.rs
+++ b/frontend/exporter/src/types/new/full_def.rs
@@ -115,7 +115,12 @@ pub enum FullDefKind {
         #[value({
             use ty::Upcast;
             let tcx = s.base().tcx;
-            let pred: ty::TraitPredicate = ty::TraitRef::identity(tcx, s.owner_id()).upcast(tcx);
+            let pred: ty::TraitPredicate =
+                crate::traits::self_predicate(tcx, s.owner_id())
+                    .unwrap()
+                    .no_bound_vars()
+                    .unwrap()
+                    .upcast(tcx);
             pred.sinto(s)
         })]
         self_predicate: TraitPredicate,

--- a/frontend/exporter/src/types/thir.rs
+++ b/frontend/exporter/src/types/thir.rs
@@ -589,7 +589,7 @@ pub enum ExprKind {
                     Some((impl_expr, assoc_generics))
                 })();
                 generic_args = translated_generics;
-                bounds_impls = solve_item_traits(gstate, *def_id, generics, None);
+                bounds_impls = solve_item_traits(gstate, *def_id, generics);
                 Expr {
                     contents,
                     span: e.span.sinto(gstate),

--- a/frontend/exporter/src/types/thir.rs
+++ b/frontend/exporter/src/types/thir.rs
@@ -589,7 +589,7 @@ pub enum ExprKind {
                     Some((impl_expr, assoc_generics))
                 })();
                 generic_args = translated_generics;
-                bounds_impls = solve_item_traits(gstate, *def_id, generics);
+                bounds_impls = solve_item_required_traits(gstate, *def_id, generics);
                 Expr {
                     contents,
                     span: e.span.sinto(gstate),

--- a/frontend/exporter/src/types/ty.rs
+++ b/frontend/exporter/src/types/ty.rs
@@ -792,7 +792,7 @@ pub enum TyKind {
         ty::TyKind::Adt(adt_def, generics) => {
             let def_id = adt_def.did().sinto(state);
             let generic_args: Vec<GenericArg> = generics.sinto(state);
-            let trait_refs = solve_item_traits(state, adt_def.did(), generics);
+            let trait_refs = solve_item_required_traits(state, adt_def.did(), generics);
             TyKind::Adt { def_id, generic_args, trait_refs }
         },
     )]
@@ -1322,7 +1322,8 @@ impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, ImplSubject> for ty::ImplSubject<'
                     trait_ref: trait_ref.sinto(s),
                     is_positive: matches!(polarity, ty::ImplPolarity::Positive),
                 };
-                let required_impl_exprs = solve_item_traits(s, trait_ref.def_id, trait_ref.args);
+                let required_impl_exprs =
+                    solve_item_implied_traits(s, trait_ref.def_id, trait_ref.args);
                 ImplSubject::Trait {
                     trait_pred,
                     required_impl_exprs,

--- a/frontend/exporter/src/types/ty.rs
+++ b/frontend/exporter/src/types/ty.rs
@@ -792,7 +792,7 @@ pub enum TyKind {
         ty::TyKind::Adt(adt_def, generics) => {
             let def_id = adt_def.did().sinto(state);
             let generic_args: Vec<GenericArg> = generics.sinto(state);
-            let trait_refs = solve_item_traits(state, adt_def.did(), generics, None);
+            let trait_refs = solve_item_traits(state, adt_def.did(), generics);
             TyKind::Adt { def_id, generic_args, trait_refs }
         },
     )]
@@ -1322,8 +1322,7 @@ impl<'tcx, S: UnderOwnerState<'tcx>> SInto<S, ImplSubject> for ty::ImplSubject<'
                     trait_ref: trait_ref.sinto(s),
                     is_positive: matches!(polarity, ty::ImplPolarity::Positive),
                 };
-                let required_impl_exprs =
-                    solve_item_traits(s, trait_ref.def_id, trait_ref.args, None);
+                let required_impl_exprs = solve_item_traits(s, trait_ref.def_id, trait_ref.args);
                 ImplSubject::Trait {
                     trait_pred,
                     required_impl_exprs,

--- a/frontend/exporter/src/utils.rs
+++ b/frontend/exporter/src/utils.rs
@@ -147,12 +147,3 @@ mod s_expect_impls {
         }
     }
 }
-
-macro_rules! s_assert {
-    ($s:ident, $assertion:expr) => {{
-        if !($assertion) {
-            fatal!($s, "assertion failed: {}", stringify!($assertion))
-        }
-    }};
-}
-pub(crate) use s_assert;


### PR DESCRIPTION
This continues my work in cleaning up trait resolution. Of particular importance is the clarification of "required" vs "implied" predicates: required predicates must be proven to mention an item (e.g. one must prove `T: Sized` to mention `Option<T>`) whereas implied predicates are implied by the item being present in a signature (e.g. `T: Copy` implies `T: Clone`).

So far we consider all predicates on a trait declaration to be implied, but that's not what rustc does. For example:
```rust
trait Foo<T: Clone>: ToString {}
```
Here (according to rustc) `T: Clone` is required to mention `Foo`, and `Self: ToString` is implied by `Self: Foo`. I don't know if considering `T: Clone` as implied (like we implicitly did today) could cause problems but at least now what's happening is clear.