### PR TITLE
fix: rustc_private

### DIFF
--- a/hax-types/src/lib.rs
+++ b/hax-types/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(rustc_private)]
+#![cfg_attr(feature = "rustc", feature(rustc_private))]
 //! This crate contains the type definitions that are used to communicate between:
 //!  - the command line (the `cargo-hax` binary);
 //!  - the custom rustc driver;


### PR DESCRIPTION
#1036 added an unconditional feature(rustc_private) on crate `hax-types`, but we need that to be non-nightly (this is consumed by other crates)!