### PR TITLE
fix(exporter/thir): fix #1048

### DIFF
--- a/test-harness/src/snapshots/toolchain__functions into-fstar.snap
+++ b/test-harness/src/snapshots/toolchain__functions into-fstar.snap
@@ -26,6 +26,34 @@ exit = 0
 diagnostics = []
 
 [stdout.files]
+"Functions.Issue_1048_.fst" = '''
+module Functions.Issue_1048_
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open Core
+open FStar.Mul
+
+type t_CallableViaDeref = | CallableViaDeref : t_CallableViaDeref
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl: Core.Ops.Deref.t_Deref t_CallableViaDeref =
+  {
+    f_Target = Prims.unit -> bool;
+    f_deref_pre = (fun (self: t_CallableViaDeref) -> true);
+    f_deref_post = (fun (self: t_CallableViaDeref) (out: (Prims.unit -> bool)) -> true);
+    f_deref
+    =
+    fun (self: t_CallableViaDeref) ->
+      fun temp_0_ ->
+        let _:Prims.unit = temp_0_ in
+        true
+  }
+
+let call_via_deref (_: Prims.unit) : bool =
+  Core.Ops.Deref.f_deref #t_CallableViaDeref
+    #FStar.Tactics.Typeclasses.solve
+    (CallableViaDeref <: t_CallableViaDeref)
+    ()
+'''
 "Functions.fst" = '''
 module Functions
 #set-options "--fuel 0 --ifuel 1 --z3rlimit 15"

--- a/tests/functions/Cargo.toml
+++ b/tests/functions/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 hax-lib = { path = "../../hax-lib" }
 
 [package.metadata.hax-tests]
-into."fstar+coq" = { snapshot = "stdout" }
+into."fstar" = { snapshot = "stdout" }

--- a/tests/functions/src/lib.rs
+++ b/tests/functions/src/lib.rs
@@ -4,3 +4,19 @@ fn calling_function_pointer() {
     let f_ptr = f::<i32>;
     f_ptr();
 }
+
+mod issue_1048 {
+    pub struct CallableViaDeref;
+
+    impl core::ops::Deref for CallableViaDeref {
+        type Target = fn() -> bool;
+
+        fn deref(&self) -> &Self::Target {
+            &((|| true) as fn() -> bool)
+        }
+    }
+
+    pub fn call_via_deref() -> bool {
+        CallableViaDeref()
+    }
+}


### PR DESCRIPTION
We were missing the case where a function is not directly a function but a refrence (or nested references) to a function.