### PR TITLE
Intern `DefId`s

### DIFF
--- a/engine/lib/concrete_ident/concrete_ident.ml
+++ b/engine/lib/concrete_ident/concrete_ident.ml
@@ -27,7 +27,7 @@ module Imported = struct
   [@@deriving show, yojson, compare, sexp, eq, hash]
 
   let of_def_path_item : Types.def_path_item -> def_path_item = function
-    | CrateRoot -> CrateRoot
+    | CrateRoot _ -> CrateRoot
     | Impl -> Impl
     | ForeignMod -> ForeignMod
     | Use -> Use

--- a/engine/lib/concrete_ident/concrete_ident.ml
+++ b/engine/lib/concrete_ident/concrete_ident.ml
@@ -50,7 +50,8 @@ module Imported = struct
       disambiguator = MyInt64.to_int_exn disambiguator;
     }
 
-  let of_def_id Types.{ krate; path; _ } =
+  let of_def_id
+      ({ contents = { value = { krate; path; _ }; _ } } : Types.def_id) =
     { krate; path = List.map ~f:of_disambiguated_def_path_item path }
 
   let parent { krate; path; _ } = { krate; path = List.drop_last_exn path }
@@ -279,7 +280,7 @@ module View = struct
           namespace
         |> some_if_true
       in
-      let* last = List.last def_id.path in
+      let* last = List.last def_id.contents.value.path in
       let* () = some_if_true Int64.(last.disambiguator = zero) in
       last.data |> Imported.of_def_path_item |> string_of_def_path_item
       |> Option.map ~f:escape
@@ -387,7 +388,7 @@ module View = struct
                   namespace
            in
            let* typ = simple_ty_to_string ~namespace typ in
-           let* trait = List.last trait.path in
+           let* trait = List.last trait.contents.value.path in
            let* trait =
              Imported.of_def_path_item trait.data |> string_of_def_path_item
            in

--- a/engine/names/extract/build.rs
+++ b/engine/names/extract/build.rs
@@ -18,6 +18,7 @@ mod id_table {
     #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
     pub struct Node<T> {
         value: Arc<T>,
+        cache_id: u32,
     }
 
     impl<T> std::ops::Deref for Node<T> {

--- a/engine/names/extract/build.rs
+++ b/engine/names/extract/build.rs
@@ -86,7 +86,7 @@ fn def_id_to_str(def_id: &DefId) -> (Value, String) {
     };
     // Update the crate name in the json output as well.
     let mut json = serde_json::to_value(def_id).unwrap();
-    json["krate"] = Value::String(crate_name.to_owned());
+    json["contents"]["value"]["krate"] = Value::String(crate_name.to_owned());
 
     let crate_name = uppercase_first_letter(crate_name);
     let path = [crate_name]

--- a/engine/names/extract/build.rs
+++ b/engine/names/extract/build.rs
@@ -58,7 +58,7 @@ fn def_path_item_to_str(path_item: DefPathItem) -> String {
         | DefPathItem::ValueNs(s)
         | DefPathItem::MacroNs(s)
         | DefPathItem::LifetimeNs(s) => s,
-        DefPathItem::CrateRoot => "CrateRoot".into(),
+        DefPathItem::CrateRoot { name } => uppercase_first_letter(&name),
         DefPathItem::Impl => "Impl".into(),
         DefPathItem::ForeignMod => "ForeignMod".into(),
         DefPathItem::Use => "Use".into(),

--- a/engine/utils/ocaml_of_json_schema/ocaml_of_json_schema.js
+++ b/engine/utils/ocaml_of_json_schema/ocaml_of_json_schema.js
@@ -574,7 +574,31 @@ open ParseError
     impl += `
 and node_for__ty_kind = node_for_ty_kind_generated
 
-let cache_map: (int64, ${"[ `TyKind of ty_kind | `JSON of Yojson.Safe.t ]"}) Base.Hashtbl.t = Base.Hashtbl.create (module Base.Int64)
+type map_types = ${"[`TyKind of ty_kind]"}
+let cache_map: (int64, ${"[ `Value of map_types | `JSON of Yojson.Safe.t ]"}) Base.Hashtbl.t = Base.Hashtbl.create (module Base.Int64)
+
+let parse_table_id_node (type t) (encode: t -> map_types) (decode: map_types -> t option) (parse: Yojson.Safe.t -> t) (o: Yojson.Safe.t): (t * int64) = match o with
+    | \`Assoc alist -> begin
+          let id = match List.assoc "cache_id" alist with
+            | \`Int id -> Base.Int.to_int64 id
+            | \`Intlit lit -> (try Base.Int64.of_string lit with | _ -> failwith ("Base.Int64.of_string failed for " ^ lit))
+            | bad_json -> failwith ("parse_table_id_node: id was expected to be an int, got: " ^ Yojson.Safe.pretty_to_string bad_json ^ "\n\n\nfull json: " ^ Yojson.Safe.pretty_to_string o)
+          in
+          let decode v = decode v |> Base.Option.value_exn ~message:"parse_table_id_node: could not decode value (wrong type)" in
+          match List.assoc_opt "value" alist with
+          | Some json when (match json with \`Null -> false | _ -> true) ->
+            (parse json, id)
+          | _ ->
+            let value = match Base.Hashtbl.find cache_map id with
+            | None -> failwith ("parse_table_id_node: failed to lookup id " ^ Base.Int64.to_string id)
+            | Some (\`Value v) -> decode v
+            | Some (\`JSON json) ->
+                let value = parse json in
+                Base.Hashtbl.set cache_map ~key:id ~data:(\`Value (encode value));
+                value
+            in (value, id)
+       end
+    | _ -> failwith "parse_table_id_node: expected Assoc"
 
 `;
     impl += ('');
@@ -582,28 +606,15 @@ let cache_map: (int64, ${"[ `TyKind of ty_kind | `JSON of Yojson.Safe.t ]"}) Bas
         `parse_${name} (o: Yojson.Safe.t): ${name} = ${parse}`
     ).join('\nand '));
     impl += `
-and parse_node_for__ty_kind (o: Yojson.Safe.t): node_for__ty_kind = match o with
-    | \`Assoc alist -> begin
-          let id = match List.assoc "cache_id" alist with
-            | \`Int id -> Base.Int.to_int64 id
-            | \`Intlit lit -> (try Base.Int64.of_string lit with | _ -> failwith ("Base.Int64.of_string failed for " ^ lit))
-            | bad_json -> failwith ("parse_node_for__ty_kind: id was expected to be an int, got: " ^ Yojson.Safe.pretty_to_string bad_json ^ "\n\n\nfull json: " ^ Yojson.Safe.pretty_to_string o)
-          in
-          match List.assoc_opt "value" alist with
-          | Some json when (match json with \`Null -> false | _ -> true) ->
-            let value = parse_ty_kind json in
-            {value; id}
-          | _ ->
-            let value = match Base.Hashtbl.find cache_map id with
-            | None -> failwith ("parse_node_for__ty_kind: failed to lookup id " ^ Base.Int64.to_string id)
-            | Some (\`TyKind v) -> v
-            | Some (\`JSON json) ->
-                let v = parse_ty_kind json in
-                Base.Hashtbl.set cache_map ~key:id ~data:(\`TyKind v);
-                v
-            in {value; id}
-       end
-    | _ -> failwith "parse_node_for__ty_kind: expected Assoc"
+and parse_node_for__ty_kind (o: Yojson.Safe.t): node_for__ty_kind =
+   let (value, id) =
+       parse_table_id_node
+           (fun value -> \`TyKind value)
+           (function | \`TyKind value -> Some value | _ -> None)
+           parse_ty_kind
+           o
+   in
+   {value; id}
 `;
     impl += ('');
     impl += ('let rec ' + items.map(({name, type, parse, to_json}) =>

--- a/engine/utils/ocaml_of_json_schema/ocaml_of_json_schema.js
+++ b/engine/utils/ocaml_of_json_schema/ocaml_of_json_schema.js
@@ -538,8 +538,8 @@ function run(str){
 [@@@warning "-A"]`;
 
     let items = Object.entries(definitions)
-        .map(([name, def]) =>
-            [name == 'Node_for_TyKind' ? 'node_for_ty_kind_generated' : name, def])
+        .map(([name, def]) => ['Node_for_TyKind' == name ? 'node_for_ty_kind_generated' : name, def])
+        .map(([name, def]) => ['Node_for_DefIdContents' == name ? 'node_for_def_id_contents_generated' : name, def])
         .map(
             ([name, def]) => export_definition(name, def)
         ).filter(x => x instanceof Object);
@@ -573,8 +573,9 @@ open ParseError
     );
     impl += `
 and node_for__ty_kind = node_for_ty_kind_generated
+and node_for__def_id_contents = node_for_def_id_contents_generated
 
-type map_types = ${"[`TyKind of ty_kind]"}
+type map_types = ${"[`TyKind of ty_kind | `DefIdContents of def_id_contents]"}
 let cache_map: (int64, ${"[ `Value of map_types | `JSON of Yojson.Safe.t ]"}) Base.Hashtbl.t = Base.Hashtbl.create (module Base.Int64)
 
 let parse_table_id_node (type t) (name: string) (encode: t -> map_types) (decode: map_types -> t option) (parse: Yojson.Safe.t -> t) (o: Yojson.Safe.t): (t * int64) =
@@ -611,10 +612,19 @@ let parse_table_id_node (type t) (name: string) (encode: t -> map_types) (decode
     impl += `
 and parse_node_for__ty_kind (o: Yojson.Safe.t): node_for__ty_kind =
    let (value, id) =
-       parse_table_id_node
+       parse_table_id_node "TyKind"
            (fun value -> \`TyKind value)
            (function | \`TyKind value -> Some value | _ -> None)
            parse_ty_kind
+           o
+   in
+   {value; id}
+and parse_node_for__def_id_contents (o: Yojson.Safe.t): node_for__def_id_contents =
+   let (value, id) =
+       parse_table_id_node "DefIdContents"
+           (fun value -> \`DefIdContents value)
+           (function | \`DefIdContents value -> Some value | _ -> None)
+           parse_def_id_contents
            o
    in
    {value; id}
@@ -625,6 +635,7 @@ and parse_node_for__ty_kind (o: Yojson.Safe.t): node_for__ty_kind =
     ).join('\nand '));
     impl += `
 and to_json_node_for__ty_kind {value; id} = to_json_node_for_ty_kind_generated {value; id}
+and to_json_node_for__def_id_contents {value; id} = to_json_node_for_def_id_contents_generated {value; id}
 `;
 
 

--- a/frontend/exporter/src/id_table.rs
+++ b/frontend/exporter/src/id_table.rs
@@ -47,6 +47,7 @@ impl Session {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub enum Value {
     Ty(Arc<TyKind>),
+    DefId(Arc<DefIdContents>),
 }
 
 impl SupportedType<Value> for TyKind {
@@ -56,6 +57,19 @@ impl SupportedType<Value> for TyKind {
     fn from_types(t: &Value) -> Option<Arc<Self>> {
         match t {
             Value::Ty(value) => Some(value.clone()),
+            _ => None,
+        }
+    }
+}
+
+impl SupportedType<Value> for DefIdContents {
+    fn to_types(value: Arc<Self>) -> Value {
+        Value::DefId(value)
+    }
+    fn from_types(t: &Value) -> Option<Arc<Self>> {
+        match t {
+            Value::DefId(value) => Some(value.clone()),
+            _ => None,
         }
     }
 }
@@ -67,6 +81,13 @@ impl SupportedType<Value> for TyKind {
 pub struct Node<T: 'static + SupportedType<Value>> {
     id: Id,
     value: Arc<T>,
+}
+
+impl<T: SupportedType<Value>> std::ops::Deref for Node<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        self.value.as_ref()
+    }
 }
 
 /// Hax relies on hashes being deterministic for predicates
@@ -158,13 +179,14 @@ impl Session {
     }
 }
 
-impl<T: Sync + Send + Clone + 'static + SupportedType<Value>> Node<T> {
+impl<T: Sync + Send + 'static + SupportedType<Value>> Node<T> {
     pub fn new(value: T, session: &mut Session) -> Self {
         let id = session.fresh_id();
-        let kind = Arc::new(value);
-        session.table.0.insert(id.clone(), kind.clone());
-        Self { id, value: kind }
+        let value = Arc::new(value);
+        session.table.0.insert(id.clone(), value.clone());
+        Self { id, value }
     }
+
     pub fn inner(&self) -> &Arc<T> {
         &self.value
     }

--- a/frontend/exporter/src/rustc_utils.rs
+++ b/frontend/exporter/src/rustc_utils.rs
@@ -39,19 +39,16 @@ pub(crate) fn get_variant_information<'s, S: UnderOwnerState<'s>>(
         typ: constructs_type.clone(),
         variant: variant.sinto(s),
         kind,
-        type_namespace: DefId {
-            path: match constructs_type.path.as_slice() {
-                [init @ .., _] => init.to_vec(),
-                _ => {
-                    let span = s.base().tcx.def_span(variant);
-                    fatal!(
-                        s[span],
-                        "Type {:#?} appears to have no path",
-                        constructs_type
-                    )
-                }
-            },
-            ..constructs_type.clone()
+        type_namespace: match s.base().tcx.opt_parent((&constructs_type).into()) {
+            Some(parent) => parent.sinto(s),
+            None => {
+                let span = s.base().tcx.def_span(variant);
+                fatal!(
+                    s[span],
+                    "Type {:#?} appears to have no path",
+                    constructs_type
+                )
+            }
         },
     }
 }

--- a/frontend/exporter/src/rustc_utils.rs
+++ b/frontend/exporter/src/rustc_utils.rs
@@ -39,13 +39,13 @@ pub(crate) fn get_variant_information<'s, S: UnderOwnerState<'s>>(
         typ: constructs_type.clone(),
         variant: variant.sinto(s),
         kind,
-        type_namespace: match s.base().tcx.opt_parent(constructs_type.to_rust_def_id()) {
-            Some(parent) => parent.sinto(s),
+        type_namespace: match &constructs_type.parent {
+            Some(parent) => parent.clone(),
             None => {
                 let span = s.base().tcx.def_span(variant);
                 fatal!(
                     s[span],
-                    "Type {:#?} appears to have no path",
+                    "Type {:#?} appears to have no parent",
                     constructs_type
                 )
             }

--- a/frontend/exporter/src/rustc_utils.rs
+++ b/frontend/exporter/src/rustc_utils.rs
@@ -39,7 +39,7 @@ pub(crate) fn get_variant_information<'s, S: UnderOwnerState<'s>>(
         typ: constructs_type.clone(),
         variant: variant.sinto(s),
         kind,
-        type_namespace: match s.base().tcx.opt_parent((&constructs_type).into()) {
+        type_namespace: match s.base().tcx.opt_parent(constructs_type.to_rust_def_id()) {
             Some(parent) => parent.sinto(s),
             None => {
                 let span = s.base().tcx.def_span(variant);

--- a/frontend/exporter/src/types/def_id.rs
+++ b/frontend/exporter/src/types/def_id.rs
@@ -134,14 +134,21 @@ impl<'s, S: BaseState<'s>> SInto<S, DefId> for RDefId {
     }
 }
 
-#[cfg(feature = "rustc")]
-impl From<&DefId> for RDefId {
-    fn from<'tcx>(def_id: &DefId) -> Self {
-        let (krate, index) = def_id.index;
-        Self {
+impl DefId {
+    #[cfg(feature = "rustc")]
+    pub fn to_rust_def_id(&self) -> RDefId {
+        let (krate, index) = self.index;
+        RDefId {
             krate: rustc_hir::def_id::CrateNum::from_u32(krate),
             index: rustc_hir::def_id::DefIndex::from_u32(index),
         }
+    }
+}
+
+#[cfg(feature = "rustc")]
+impl From<&DefId> for RDefId {
+    fn from<'tcx>(def_id: &DefId) -> Self {
+        def_id.to_rust_def_id()
     }
 }
 


### PR DESCRIPTION
This adds `DefId`s to the interning table, and lets a `DefId` store a pointer to its parent.

This is incomplete: I did not propagate the changes to the ocaml side.