### PR TITLE
fix(exporter/constants): support usize casted to raw pointers constants

### DIFF
--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -837,7 +837,7 @@ end) : EXPR = struct
       | Borrow arg ->
           Borrow { arg = constant_expr_to_expr arg; borrow_kind = Thir.Shared }
       | ConstRef { id } -> ConstRef { id }
-      | MutPtr _ | TraitConst _ | FnPtr _ ->
+      | Cast _ | RawBorrow _ | TraitConst _ | FnPtr _ ->
           assertion_failure [ span ]
             "constant_lit_to_lit: TraitConst | FnPtr | MutPtr"
       | Todo _ -> assertion_failure [ span ] "ConstantExpr::Todo"


### PR DESCRIPTION
Fixes #1026, and renames a variant of `ConstantExpr`.
Will reflect the change in Charon.