### PR TITLE
feat(frontend/consts): float lits: use strings not bits, more support

### DIFF
--- a/frontend/exporter/src/lib.rs
+++ b/frontend/exporter/src/lib.rs
@@ -23,6 +23,7 @@ cfg_feature_rustc! {
     extern crate rustc_ast;
     extern crate rustc_ast_pretty;
     extern crate rustc_attr;
+    extern crate rustc_apfloat;
     extern crate rustc_data_structures;
     extern crate rustc_driver;
     extern crate rustc_errors;


### PR DESCRIPTION
This commit:
 - changes the representation of floats for constant literals, instead of storing raw bits with a u128, we store a string representation of the float;
 - adds support for float in the function `scalar_int_to_constant_literal`

Note: this will require a change in Charon.