### PR TITLE
Add `ImplExpr` information to associated types in an impl block

### DIFF
--- a/frontend/exporter/src/traits.rs
+++ b/frontend/exporter/src/traits.rs
@@ -208,12 +208,13 @@ fn solve_item_traits_inner<'tcx, S: UnderOwnerState<'tcx>>(
     generics: ty::GenericArgsRef<'tcx>,
     predicates: impl Iterator<Item = ty::Clause<'tcx>>,
 ) -> Vec<ImplExpr> {
+    use crate::rustc_middle::ty::ToPolyTraitRef;
     let tcx = s.base().tcx;
     let param_env = s.param_env();
 
     predicates
         .filter_map(|clause| clause.as_trait_clause())
-        .map(|trait_pred| trait_pred.map_bound(|p| p.trait_ref))
+        .map(|clause| clause.to_poly_trait_ref())
         // Substitute the item generics
         .map(|trait_ref| ty::EarlyBinder::bind(trait_ref).instantiate(tcx, generics))
         // We unfortunately don't have a way to normalize without erasing regions.

--- a/frontend/exporter/src/types/new/full_def.rs
+++ b/frontend/exporter/src/types/new/full_def.rs
@@ -36,7 +36,7 @@ pub struct FullDef<Body = ()> {
 fn translate_full_def<'tcx, S, Body>(s: &S, def_id: RDefId) -> FullDef<Body>
 where
     S: BaseState<'tcx>,
-    Body: IsBody,
+    Body: IsBody + TypeMappable,
 {
     let tcx = s.base().tcx;
     let def_kind = tcx.def_kind(def_id);
@@ -88,7 +88,7 @@ where
 /// Imbues [`rustc_hir::def::DefKind`] with a lot of extra information.
 /// Important: the `owner_id()` must be the id of this definition.
 #[derive(AdtInto)]
-#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_hir::def::DefKind, state: S as s, where Body: IsBody)]
+#[args(<'tcx, S: UnderOwnerState<'tcx>>, from: rustc_hir::def::DefKind, state: S as s, where Body: IsBody + TypeMappable)]
 #[derive_group(Serializers)]
 #[derive(Clone, Debug, JsonSchema)]
 pub enum FullDefKind<Body> {
@@ -189,7 +189,7 @@ pub enum FullDefKind<Body> {
                 .collect::<Vec<_>>()
                 .sinto(s)
         )]
-        items: Vec<(AssocItem, Arc<FullDef>)>,
+        items: Vec<(AssocItem, Arc<FullDef<Body>>)>,
     },
     /// Trait alias: `trait IntIterator = Iterator<Item = i32>;`
     TraitAlias,
@@ -211,7 +211,7 @@ pub enum FullDefKind<Body> {
                 .collect::<Vec<_>>()
                 .sinto(s)
         )]
-        items: Vec<(AssocItem, Arc<FullDef>)>,
+        items: Vec<(AssocItem, Arc<FullDef<Body>>)>,
     },
 
     // Functions

--- a/frontend/exporter/src/types/new/full_def.rs
+++ b/frontend/exporter/src/types/new/full_def.rs
@@ -222,6 +222,8 @@ pub enum FullDefKind<Body> {
         predicates: GenericPredicates,
         #[value(s.base().tcx.codegen_fn_attrs(s.owner_id()).inline.sinto(s))]
         inline: InlineAttr,
+        #[value(s.base().tcx.constness(s.owner_id()) == rustc_hir::Constness::Const)]
+        is_const: bool,
         #[value(s.base().tcx.fn_sig(s.owner_id()).instantiate_identity().sinto(s))]
         sig: PolyFnSig,
         #[value(s.owner_id().as_local().map(|ldid| Body::body(ldid, s)))]
@@ -240,6 +242,8 @@ pub enum FullDefKind<Body> {
         predicates: GenericPredicates,
         #[value(s.base().tcx.codegen_fn_attrs(s.owner_id()).inline.sinto(s))]
         inline: InlineAttr,
+        #[value(s.base().tcx.constness(s.owner_id()) == rustc_hir::Constness::Const)]
+        is_const: bool,
         #[value(s.base().tcx.fn_sig(s.owner_id()).instantiate_identity().sinto(s))]
         sig: PolyFnSig,
         #[value(s.owner_id().as_local().map(|ldid| Body::body(ldid, s)))]
@@ -255,6 +259,8 @@ pub enum FullDefKind<Body> {
         /// constant.
         #[value(s.base().tcx.parent(s.owner_id()).sinto(s))]
         parent: DefId,
+        #[value(s.base().tcx.constness(s.owner_id()) == rustc_hir::Constness::Const)]
+        is_const: bool,
         #[value({
             let fun_type = s.base().tcx.type_of(s.owner_id()).instantiate_identity();
             match fun_type.kind() {

--- a/frontend/exporter/src/types/ty.rs
+++ b/frontend/exporter/src/types/ty.rs
@@ -1357,23 +1357,34 @@ fn get_container_for_assoc_item<'tcx, S: BaseState<'tcx>>(
     s: &S,
     item: &ty::AssocItem,
 ) -> AssocItemContainer {
-    let container_id = item.container_id(s.base().tcx);
+    let tcx = s.base().tcx;
+    let container_id = item.container_id(tcx);
     match item.container {
         ty::AssocItemContainer::TraitContainer => AssocItemContainer::TraitContainer {
             trait_id: container_id.sinto(s),
         },
         ty::AssocItemContainer::ImplContainer => {
             if let Some(implemented_trait_item) = item.trait_item_def_id {
+                // The trait ref that is being implemented by this `impl` block.
+                let implemented_trait_ref = tcx
+                    .impl_trait_ref(container_id)
+                    .unwrap()
+                    .instantiate_identity();
+
+                // Resolve required impl exprs for this item.
+                let item_args = ty::GenericArgs::identity_for_item(tcx, item.def_id);
+                // Subtlety: we have to add the GAT arguments (if any) to the trait ref arguments.
+                let args = item_args.rebase_onto(tcx, container_id, implemented_trait_ref.args);
+                let state_with_id = with_owner_id(s.base(), (), (), item.def_id);
+                let required_impl_exprs =
+                    solve_item_implied_traits(&state_with_id, implemented_trait_item, args);
+
                 AssocItemContainer::TraitImplContainer {
                     impl_id: container_id.sinto(s),
-                    implemented_trait: s
-                        .base()
-                        .tcx
-                        .trait_of_item(implemented_trait_item)
-                        .unwrap()
-                        .sinto(s),
+                    implemented_trait: implemented_trait_ref.def_id.sinto(s),
                     implemented_trait_item: implemented_trait_item.sinto(s),
-                    overrides_default: s.base().tcx.defaultness(implemented_trait_item).has_value(),
+                    overrides_default: tcx.defaultness(implemented_trait_item).has_value(),
+                    required_impl_exprs,
                 }
             } else {
                 AssocItemContainer::InherentImplContainer {
@@ -1431,6 +1442,17 @@ pub enum AssocItemContainer {
         /// Whether the corresponding trait item had a default (and therefore this one overrides
         /// it).
         overrides_default: bool,
+        /// The `ImplExpr`s required to satisfy the predicates on the associated type. E.g.:
+        /// ```ignore
+        /// trait Foo {
+        ///     type Type<T>: Clone,
+        /// }
+        /// impl Foo for () {
+        ///     type Type<T>: Arc<T>; // would supply an `ImplExpr` for `Arc<T>: Clone`.
+        /// }
+        /// ```
+        /// Empty if this item is an associated const or fn.
+        required_impl_exprs: Vec<ImplExpr>,
     },
     InherentImplContainer {
         impl_id: DefId,


### PR DESCRIPTION
Along with constness information, this is one of the last remaining queries we were doing in charon. 