### PR TITLE
Include defaulted items in `FullDefKind::TraitImpl`

### DIFF
--- a/frontend/exporter/src/state.rs
+++ b/frontend/exporter/src/state.rs
@@ -194,7 +194,7 @@ mod types {
     pub type MacroCalls = Rc<HashMap<Span, Span>>;
     pub type RcThir<'tcx> = Rc<rustc_middle::thir::Thir<'tcx>>;
     pub type RcMir<'tcx> = Rc<rustc_middle::mir::Body<'tcx>>;
-    pub type Binder<'tcx> = rustc_middle::ty::Binder<'tcx, ()>;
+    pub type UnitBinder<'tcx> = rustc_middle::ty::Binder<'tcx, ()>;
 }
 
 mk!(
@@ -203,7 +203,7 @@ mk!(
         thir: {'tcx} types::RcThir,
         mir: {'tcx} types::RcMir,
         owner_id: {} rustc_hir::def_id::DefId,
-        binder: {'tcx} types::Binder,
+        binder: {'tcx} types::UnitBinder,
     }
 );
 
@@ -212,7 +212,7 @@ pub use self::types::*;
 pub type StateWithBase<'tcx> = State<Base<'tcx>, (), (), (), ()>;
 pub type StateWithOwner<'tcx> = State<Base<'tcx>, (), (), rustc_hir::def_id::DefId, ()>;
 pub type StateWithBinder<'tcx> =
-    State<Base<'tcx>, (), (), rustc_hir::def_id::DefId, types::Binder<'tcx>>;
+    State<Base<'tcx>, (), (), rustc_hir::def_id::DefId, types::UnitBinder<'tcx>>;
 pub type StateWithThir<'tcx> =
     State<Base<'tcx>, types::RcThir<'tcx>, (), rustc_hir::def_id::DefId, ()>;
 pub type StateWithMir<'tcx> =

--- a/frontend/exporter/src/types/new/full_def.rs
+++ b/frontend/exporter/src/types/new/full_def.rs
@@ -143,6 +143,7 @@ pub enum FullDefKind<Body> {
         #[value(s.base().tcx.generics_of(s.owner_id()).sinto(s))]
         generics: TyGenerics,
         #[value(get_item_predicates(s, s.owner_id()))]
+        // FIXME: clarify implied vs required predicates
         predicates: GenericPredicates,
         #[value(s.base().tcx.associated_item(s.owner_id()).sinto(s))]
         associated_item: AssocItem,
@@ -372,7 +373,8 @@ pub enum FullDefKind<Body> {
 #[derive(Clone, Debug, JsonSchema)]
 pub struct ImplAssocItem<Body> {
     pub name: Symbol,
-    /// The definition of the item from the trait declaration.
+    /// The definition of the item from the trait declaration. This is `AssocTy`, `AssocFn` or
+    /// `AssocConst`.
     pub decl_def: Arc<FullDef<Body>>,
     /// The `ImplExpr`s required to satisfy the predicates on the associated type. E.g.:
     /// ```ignore
@@ -394,7 +396,8 @@ pub struct ImplAssocItem<Body> {
 pub enum ImplAssocItemValue<Body> {
     /// The item is provided by the trait impl.
     Provided {
-        /// The definition of the item in the trait impl.
+        /// The definition of the item in the trait impl. This is `AssocTy`, `AssocFn` or
+        /// `AssocConst`.
         def: Arc<FullDef<Body>>,
         /// Whether the trait had a default value for this item (which is therefore overriden).
         is_override: bool,


### PR DESCRIPTION
This reworks the representation of associated impl items. The problem this solves is:
```rust
trait Trait {
    type Type: Clone = i32;
}
impl Trait for () {}
```
Here the impl implicitly reuses the type provided by the trait. The version of the type that's virtually in the impl does not have a `DefId` however, which makes it hard to get information about it. This PR adds a representation for these defaulted items, and gathers the necessary information.

Now `FullDefKind::TraitImpl.items` always has the same number of entries (and in the same order) as `FullDefKind::Trait.items`.

There remains some work to do for methods because I don't yet handle that in charon. This is also unfortunately limited wrt GATs; we'd have to construct our own `ParamEnv`s to solve that properly so I'm leaving it as future work.