### PR TITLE
feat(engine): keep track of parent items in spans

### DIFF
--- a/engine/bin/lib.ml
+++ b/engine/bin/lib.ml
@@ -73,6 +73,8 @@ let import_thir_items (include_clauses : Types.inclusion_clause list)
         match Attrs.status i.attrs with Included _ -> true | _ -> false)
       items
   in
+  Hax_io.write
+    (ItemProcessed (List.filter_map ~f:(fun i -> Span.owner_hint i.span) items));
   let items = Deps.sort items in
   (* Extract error reports for the items we actually extract *)
   let reports =

--- a/engine/lib/import_thir.ml
+++ b/engine/lib/import_thir.ml
@@ -1441,7 +1441,9 @@ let cast_of_enum typ_name generics typ thir_span
   { v; span; ident; attrs = [] }
 
 let rec c_item ~ident ~drop_body (item : Thir.item) : item list =
-  try c_item_unwrapped ~ident ~drop_body item
+  try
+    Span.with_owner_hint item.owner_id (fun _ ->
+        c_item_unwrapped ~ident ~drop_body item)
   with Diagnostics.SpanFreeError.Exn payload ->
     let context, kind = Diagnostics.SpanFreeError.payload payload in
     let error = Diagnostics.pretty_print_context_kind context kind in

--- a/engine/lib/print_rust.ml
+++ b/engine/lib/print_rust.ml
@@ -140,6 +140,7 @@ module Raw = struct
                      ident";
                 };
             span = Span.to_thir span;
+            owner_id = Span.owner_hint span;
           };
         "print_rust_last_of_global_ident_error"
 

--- a/engine/lib/span.ml
+++ b/engine/lib/span.ml
@@ -93,26 +93,69 @@ module Imported = struct
     "<" ^ file ^ " " ^ display_loc s.lo ^ "→" ^ display_loc s.hi ^ ">"
 end
 
-type t = { id : int; data : Imported.span list }
+(* open struct *)
+(*   module DefId = struct *)
+(*       include Types *)
+(*       let def_id_of_yojson = Types.parse_def_id *)
+(*       let yojson_of_def_id = failwith "todo" *)
+(*     end *)
+(*   end *)
+
+type owner_id = OwnerId of int
 [@@deriving show, yojson, sexp, compare, eq, hash]
 
-let display { id = _; data } =
+let owner_id_list = ref []
+
+let fresh_owner_id (owner : Types.def_id) : owner_id =
+  let next_id = OwnerId (List.length !owner_id_list) in
+  owner_id_list := owner :: !owner_id_list;
+  next_id
+
+(** This state changes the behavior of `of_thir`: the hint placed into
+this state will be inserted automatically by `of_thir`. The field
+`owner_hint` shall be used solely for reporting to the user, not for
+any logic within the engine. *)
+let state_owner_hint : owner_id option ref = ref None
+
+let with_owner_hint (type t) (owner : Types.def_id) (f : unit -> t) : t =
+  let previous = !state_owner_hint in
+  state_owner_hint := Some (fresh_owner_id owner);
+  let result = f () in
+  state_owner_hint := previous;
+  result
+
+type t = { id : int; data : Imported.span list; owner_hint : owner_id option }
+[@@deriving show, yojson, sexp, compare, eq, hash]
+
+let display { id = _; data; _ } =
   match data with
   | [] -> "<dummy>"
   | [ span ] -> Imported.display_span span
   | spans -> List.map ~f:Imported.display_span spans |> String.concat ~sep:"∪"
 
 let of_thir span =
-  { data = [ Imported.span_of_thir span ]; id = FreshId.make () }
+  {
+    data = [ Imported.span_of_thir span ];
+    id = FreshId.make ();
+    owner_hint = !state_owner_hint;
+  }
 
 let to_thir { data; _ } = List.map ~f:Imported.span_to_thir data
 
 let union_list spans =
   let data = List.concat_map ~f:(fun { data; _ } -> data) spans in
-  { data; id = FreshId.make () }
+  let owner_hint = List.hd spans |> Option.bind ~f:(fun s -> s.owner_hint) in
+  { data; id = FreshId.make (); owner_hint }
 
 let union x y = union_list [ x; y ]
-let dummy () = { id = FreshId.make (); data = [] }
+
+let dummy () =
+  { id = FreshId.make (); data = []; owner_hint = !state_owner_hint }
+
 let id_of { id; _ } = id
 let refresh_id span = { span with id = FreshId.make () }
-let default = { id = 0; data = [] }
+let default = { id = 0; data = []; owner_hint = None }
+
+let owner_hint span =
+  span.owner_hint
+  |> Option.bind ~f:(fun (OwnerId id) -> List.nth !owner_id_list id)

--- a/engine/lib/span.ml
+++ b/engine/lib/span.ml
@@ -93,14 +93,6 @@ module Imported = struct
     "<" ^ file ^ " " ^ display_loc s.lo ^ "→" ^ display_loc s.hi ^ ">"
 end
 
-(* open struct *)
-(*   module DefId = struct *)
-(*       include Types *)
-(*       let def_id_of_yojson = Types.parse_def_id *)
-(*       let yojson_of_def_id = failwith "todo" *)
-(*     end *)
-(*   end *)
-
 type owner_id = OwnerId of int
 [@@deriving show, yojson, sexp, compare, eq, hash]
 

--- a/engine/lib/span.mli
+++ b/engine/lib/span.mli
@@ -2,32 +2,35 @@ type t [@@deriving show, yojson, sexp, compare, eq, hash]
 
 val display : t -> string
 
-(** Imports a THIR span as a hax span *)
 val of_thir : Types.span -> t
-(** Exports a hax span to THIR spans (a hax span might be a collection of spans) *)
+(** Imports a THIR span as a hax span *)
+
 val to_thir : t -> Types.span list
+(** Exports a hax span to THIR spans (a hax span might be a collection of spans) *)
 
 val union_list : t list -> t
 val union : t -> t -> t
 
-(** Generates a dummy span: this should be avoided at all cost. *)
 val dummy : unit -> t
-(** Lookup the internal unique identifier of a span. *)
-val id_of : t -> int
-(** Replaces the internal identifier by a fresh one. This can be useful for debugging. *)
-val refresh_id : t -> t
+(** Generates a dummy span: this should be avoided at all cost. *)
 
+val id_of : t -> int
+(** Lookup the internal unique identifier of a span. *)
+
+val refresh_id : t -> t
+(** Replaces the internal identifier by a fresh one. This can be useful for debugging. *)
+
+val default : t
 (** A default span can be useful when a span is required in some
 computation that never reports error and when we know the span will go
 away. Using this should be avoided. *)
-val default : t
 
+val with_owner_hint : Types.def_id -> (unit -> 't) -> 't
 (** Inserts a hint about the fact that, in function `f`, we're
 translating spans that are "owned" by an item `owner`. This should be
 used only in `import_thir`, also, the hint shall be used only to
 enhance user reporting, not for any logic within the engine. *)
-val with_owner_hint : Types.def_id -> (unit -> 't) -> 't
 
+val owner_hint : t -> Types.def_id option
 (** Looks up the owner hint for a span. This should be used for user
 reports only. *)
-val owner_hint: t -> Types.def_id option

--- a/engine/lib/span.mli
+++ b/engine/lib/span.mli
@@ -1,12 +1,33 @@
-(* type loc [@@deriving show, yojson, sexp, compare, eq, hash] *)
 type t [@@deriving show, yojson, sexp, compare, eq, hash]
 
 val display : t -> string
+
+(** Imports a THIR span as a hax span *)
 val of_thir : Types.span -> t
+(** Exports a hax span to THIR spans (a hax span might be a collection of spans) *)
 val to_thir : t -> Types.span list
+
 val union_list : t list -> t
 val union : t -> t -> t
+
+(** Generates a dummy span: this should be avoided at all cost. *)
 val dummy : unit -> t
+(** Lookup the internal unique identifier of a span. *)
 val id_of : t -> int
+(** Replaces the internal identifier by a fresh one. This can be useful for debugging. *)
 val refresh_id : t -> t
+
+(** A default span can be useful when a span is required in some
+computation that never reports error and when we know the span will go
+away. Using this should be avoided. *)
 val default : t
+
+(** Inserts a hint about the fact that, in function `f`, we're
+translating spans that are "owned" by an item `owner`. This should be
+used only in `import_thir`, also, the hint shall be used only to
+enhance user reporting, not for any logic within the engine. *)
+val with_owner_hint : Types.def_id -> (unit -> 't) -> 't
+
+(** Looks up the owner hint for a span. This should be used for user
+reports only. *)
+val owner_hint: t -> Types.def_id option

--- a/engine/names/extract/build.rs
+++ b/engine/names/extract/build.rs
@@ -18,7 +18,7 @@ mod id_table {
     #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
     pub struct Node<T> {
         value: Arc<T>,
-        cache_id: u32,
+        id: u32,
     }
 
     impl<T> std::ops::Deref for Node<T> {

--- a/engine/utils/ocaml_of_json_schema/ocaml_of_json_schema.js
+++ b/engine/utils/ocaml_of_json_schema/ocaml_of_json_schema.js
@@ -582,11 +582,11 @@ let parse_table_id_node (type t) (name: string) (encode: t -> map_types) (decode
     let label = "parse_table_id_node:" ^ name ^ ": " in
     match o with
     | \`Assoc alist -> begin
-          let id = match List.assoc_opt "cache_id" alist with
+          let id = match List.assoc_opt "id" alist with
             | Some (\`Int id) -> Base.Int.to_int64 id
             | Some (\`Intlit lit) -> (try Base.Int64.of_string lit with | _ -> failwith (label ^ "Base.Int64.of_string failed for " ^ lit))
             | Some bad_json -> failwith (label ^ "id was expected to be an int, got: " ^ Yojson.Safe.pretty_to_string bad_json ^ "\n\n\nfull json: " ^ Yojson.Safe.pretty_to_string o)
-            | None -> failwith (label ^ " could not find the key 'cache_id' in the following json: " ^ Yojson.Safe.pretty_to_string o)
+            | None -> failwith (label ^ " could not find the key 'id' in the following json: " ^ Yojson.Safe.pretty_to_string o)
           in
           let decode v = decode v |> Base.Option.value_exn ~message:(label ^ "could not decode value (wrong type)") in
           match List.assoc_opt "value" alist with

--- a/frontend/exporter/src/id_table.rs
+++ b/frontend/exporter/src/id_table.rs
@@ -272,7 +272,7 @@ mod serde_repr {
 
     #[derive(Serialize, Deserialize, JsonSchema, Debug)]
     pub(super) struct NodeRepr<T> {
-        cache_id: Id,
+        id: Id,
         value: Option<Arc<T>>,
     }
 
@@ -290,8 +290,8 @@ mod serde_repr {
             } else {
                 Some(self.value.clone())
             };
-            let cache_id = self.id;
-            NodeRepr { value, cache_id }
+            let id = self.id;
+            NodeRepr { value, id }
         }
     }
 
@@ -301,7 +301,7 @@ mod serde_repr {
         fn try_from(cached: NodeRepr<T>) -> Result<Self, Self::Error> {
             use serde::de::Error;
             let table = DESERIALIZATION_STATE.lock().unwrap();
-            let id = cached.cache_id;
+            let id = cached.id;
             let kind = if let Some(kind) = cached.value {
                 kind
             } else {

--- a/hax-types/src/cli_options/mod.rs
+++ b/hax-types/src/cli_options/mod.rs
@@ -308,8 +308,14 @@ pub struct BackendOptions<E: Extension> {
     #[arg(short, long, action = clap::ArgAction::Count)]
     pub verbose: u8,
 
-    /// Enables profiling for the engine
-    #[arg(short, long)]
+    /// Prints statistics about how many items have been translated
+    /// successfully by the engine.
+    #[arg(long)]
+    pub stats: bool,
+
+    /// Enables profiling for the engine: for each phase of the
+    /// engine, time and memory usage are recorded and reported.
+    #[arg(long)]
     pub profile: bool,
 
     /// Enable engine debugging: dumps the AST at each phase.

--- a/hax-types/src/diagnostics/message.rs
+++ b/hax-types/src/diagnostics/message.rs
@@ -24,6 +24,9 @@ pub enum HaxMessage {
         backend: Backend<()>,
     } = 4,
     ProfilingData(crate::engine_api::ProfilingData) = 5,
+    Stats {
+        errors_per_item: Vec<(hax_frontend_exporter::DefId, usize)>,
+    } = 6,
 }
 
 impl HaxMessage {

--- a/hax-types/src/diagnostics/mod.rs
+++ b/hax-types/src/diagnostics/mod.rs
@@ -10,6 +10,7 @@ pub struct Diagnostics {
     pub kind: Kind,
     pub span: Vec<hax_frontend_exporter::Span>,
     pub context: String,
+    pub owner_id: Option<hax_frontend_exporter::DefId>,
 }
 
 impl std::fmt::Display for Diagnostics {

--- a/hax-types/src/engine_api.rs
+++ b/hax-types/src/engine_api.rs
@@ -79,6 +79,7 @@ pub struct ProfilingData {
 
 pub mod protocol {
     use super::*;
+
     #[derive_group(Serializers)]
     #[derive(JsonSchema, Debug, Clone)]
     pub enum FromEngine {
@@ -88,6 +89,8 @@ pub mod protocol {
         PrettyPrintRust(String),
         DebugString(String),
         ProfilingData(ProfilingData),
+        /// Declares a list of items that will be processed by the engine
+        ItemProcessed(Vec<hax_frontend_exporter::DefId>),
         Exit,
         Ping,
     }

--- a/test-harness/src/snapshots/toolchain__include-flag into-coq.snap
+++ b/test-harness/src/snapshots/toolchain__include-flag into-coq.snap
@@ -56,7 +56,7 @@ Class t_Trait `{v_Self : Type} : Type :=
 Arguments t_Trait:clear implicits.
 Arguments t_Trait (_).
 
-Instance t_Trait_187936720 : t_Trait ((t_Foo)) :=
+Instance t_Trait_254780795 : t_Trait ((t_Foo)) :=
   {
   }.
 


### PR DESCRIPTION
This PR:
 - makes spans carry a hint about their parent item;
 - makes errors carry a hint about which item the error comes from;
 - adds a `--stats` flag to the verb `into`, printing information about how many items the engine was able to process and a total number of items.

This will be quite useful for mass testing the engine: we'll be able to have statistics about how many items in a crate we can translate.