### PR TITLE
feat(frontend/cli): improve options

### DIFF
--- a/cli/subcommands/src/cargo_hax.rs
+++ b/cli/subcommands/src/cargo_hax.rs
@@ -569,7 +569,23 @@ fn run_command(options: &Options, haxmeta_files: Vec<EmitHaxMetaMessage>) -> boo
 
 fn main() {
     let args: Vec<String> = get_args("hax");
-    let mut options = Options::parse_from(args.iter());
+    let mut options = match &args[..] {
+        [_, kw] if kw == "__json" => serde_json::from_str(
+            &std::env::var(ENV_VAR_OPTIONS_FRONTEND).unwrap_or_else(|_| {
+                panic!(
+                    "Cannot find environnement variable {}",
+                    ENV_VAR_OPTIONS_FRONTEND
+                )
+            }),
+        )
+        .unwrap_or_else(|_| {
+            panic!(
+                "Invalid value for the environnement variable {}",
+                ENV_VAR_OPTIONS_FRONTEND
+            )
+        }),
+        _ => Options::parse_from(args.iter()),
+    };
     options.normalize_paths();
 
     let (haxmeta_files, exit_code) = compute_haxmeta_files(&options);

--- a/frontend/exporter/options/src/lib.rs
+++ b/frontend/exporter/options/src/lib.rs
@@ -8,11 +8,30 @@ pub enum Glob {
     Many, // **
 }
 
+impl ToString for Glob {
+    fn to_string(&self) -> String {
+        match self {
+            Self::One => "*",
+            Self::Many => "**",
+        }
+        .to_string()
+    }
+}
+
 #[derive_group(Serializers)]
 #[derive(Debug, Clone, JsonSchema)]
 pub enum NamespaceChunk {
     Glob(Glob),
     Exact(String),
+}
+
+impl ToString for NamespaceChunk {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Glob(glob) => glob.to_string(),
+            Self::Exact(string) => string.to_string(),
+        }
+    }
 }
 
 impl std::convert::From<&str> for NamespaceChunk {
@@ -29,6 +48,17 @@ impl std::convert::From<&str> for NamespaceChunk {
 #[derive(Debug, Clone, JsonSchema)]
 pub struct Namespace {
     pub chunks: Vec<NamespaceChunk>,
+}
+
+impl ToString for Namespace {
+    fn to_string(&self) -> String {
+        self.chunks
+            .iter()
+            .map(NamespaceChunk::to_string)
+            .collect::<Vec<_>>()
+            .join("::")
+            .to_string()
+    }
 }
 
 impl std::convert::From<String> for Namespace {

--- a/hax-types/src/cli_options/extension.rs
+++ b/hax-types/src/cli_options/extension.rs
@@ -32,7 +32,7 @@ pub struct EmptyArgsExtension {}
 #[derive(JsonSchema, Subcommand, Debug, Clone)]
 pub enum EmptySubcommandExtension {}
 
-pub trait Extension {
+pub trait Extension: 'static {
     type Options: ArgsExtensionPoint;
     type Command: SubcommandExtensionPoint;
     type BackendOptions: ArgsExtensionPoint;

--- a/hax-types/src/cli_options/mod.rs
+++ b/hax-types/src/cli_options/mod.rs
@@ -215,9 +215,22 @@ enum InclusionKind {
 
 #[derive_group(Serializers)]
 #[derive(JsonSchema, Debug, Clone)]
-struct InclusionClause {
-    kind: InclusionKind,
-    namespace: Namespace,
+pub struct InclusionClause {
+    pub kind: InclusionKind,
+    pub namespace: Namespace,
+}
+
+impl ToString for InclusionClause {
+    fn to_string(&self) -> String {
+        let kind = match self.kind {
+            InclusionKind::Included(DepsKind::Transitive) => "+",
+            InclusionKind::Included(DepsKind::Shallow) => "+~",
+            InclusionKind::Included(DepsKind::None) => "+!",
+            InclusionKind::SignatureOnly => "+:",
+            InclusionKind::Excluded => "-",
+        };
+        format!("{kind}{}", self.namespace.to_string())
+    }
 }
 
 fn parse_inclusion_clause(

--- a/hax-types/src/cli_options/mod.rs
+++ b/hax-types/src/cli_options/mod.rs
@@ -127,7 +127,7 @@ pub struct ProVerifOptions {
         value_delimiter = ' ',
         allow_hyphen_values(true)
     )]
-    assume_items: Vec<InclusionClause>,
+    pub assume_items: Vec<InclusionClause>,
 }
 
 #[derive_group(Serializers)]
@@ -135,13 +135,13 @@ pub struct ProVerifOptions {
 pub struct FStarOptions<E: Extension> {
     /// Set the Z3 per-query resource limit
     #[arg(long, default_value = "15")]
-    z3rlimit: u32,
+    pub z3rlimit: u32,
     /// Number of unrolling of recursive functions to try
     #[arg(long, default_value = "0")]
-    fuel: u32,
+    pub fuel: u32,
     /// Number of unrolling of inductive datatypes to try
     #[arg(long, default_value = "1")]
-    ifuel: u32,
+    pub ifuel: u32,
     /// Modules for which Hax should extract interfaces (`*.fsti`
     /// files) in supplement to implementations (`*.fst` files). By
     /// default we extract no interface, only implementations. If a
@@ -160,10 +160,10 @@ pub struct FStarOptions<E: Extension> {
         value_delimiter = ' ',
         allow_hyphen_values(true)
     )]
-    interfaces: Vec<InclusionClause>,
+    pub interfaces: Vec<InclusionClause>,
 
     #[arg(long, default_value = "100", env = "HAX_FSTAR_LINE_WIDTH")]
-    line_width: u16,
+    pub line_width: u16,
 
     #[group(flatten)]
     pub cli_extension: E::FStarOptions,
@@ -198,7 +198,7 @@ impl fmt::Display for Backend<()> {
 
 #[derive_group(Serializers)]
 #[derive(JsonSchema, Debug, Clone)]
-enum DepsKind {
+pub enum DepsKind {
     Transitive,
     Shallow,
     None,
@@ -206,7 +206,7 @@ enum DepsKind {
 
 #[derive_group(Serializers)]
 #[derive(JsonSchema, Debug, Clone)]
-enum InclusionKind {
+pub enum InclusionKind {
     /// `+query` include the items selected by `query`
     Included(DepsKind),
     SignatureOnly,
@@ -233,7 +233,7 @@ impl ToString for InclusionClause {
     }
 }
 
-fn parse_inclusion_clause(
+pub fn parse_inclusion_clause(
     s: &str,
 ) -> Result<InclusionClause, Box<dyn std::error::Error + Send + Sync + 'static>> {
     let s = s.trim();
@@ -303,7 +303,7 @@ pub struct TranslationOptions {
         value_delimiter = ' ',
     )]
     #[arg(short, allow_hyphen_values(true))]
-    include_namespaces: Vec<InclusionClause>,
+    pub include_namespaces: Vec<InclusionClause>,
 }
 
 #[derive_group(Serializers)]

--- a/hax-types/src/cli_options/mod.rs
+++ b/hax-types/src/cli_options/mod.rs
@@ -220,14 +220,20 @@ pub struct InclusionClause {
     pub namespace: Namespace,
 }
 
+const PREFIX_INCLUDED_TRANSITIVE: &str = "+";
+const PREFIX_INCLUDED_SHALLOW: &str = "+~";
+const PREFIX_INCLUDED_NONE: &str = "+!";
+const PREFIX_SIGNATURE_ONLY: &str = "+:";
+const PREFIX_EXCLUDED: &str = "-";
+
 impl ToString for InclusionClause {
     fn to_string(&self) -> String {
         let kind = match self.kind {
-            InclusionKind::Included(DepsKind::Transitive) => "+",
-            InclusionKind::Included(DepsKind::Shallow) => "+~",
-            InclusionKind::Included(DepsKind::None) => "+!",
-            InclusionKind::SignatureOnly => "+:",
-            InclusionKind::Excluded => "-",
+            InclusionKind::Included(DepsKind::Transitive) => PREFIX_INCLUDED_TRANSITIVE,
+            InclusionKind::Included(DepsKind::Shallow) => PREFIX_INCLUDED_SHALLOW,
+            InclusionKind::Included(DepsKind::None) => PREFIX_INCLUDED_NONE,
+            InclusionKind::SignatureOnly => PREFIX_SIGNATURE_ONLY,
+            InclusionKind::Excluded => PREFIX_EXCLUDED,
         };
         format!("{kind}{}", self.namespace.to_string())
     }
@@ -248,11 +254,11 @@ pub fn parse_inclusion_clause(
         )
     };
     let kind = match &prefix[..] {
-        "+" => InclusionKind::Included(DepsKind::Transitive),
-        "+~" => InclusionKind::Included(DepsKind::Shallow),
-        "+!" => InclusionKind::Included(DepsKind::None),
-        "+:" => InclusionKind::SignatureOnly,
-        "-" => InclusionKind::Excluded,
+        PREFIX_INCLUDED_TRANSITIVE => InclusionKind::Included(DepsKind::Transitive),
+        PREFIX_INCLUDED_SHALLOW => InclusionKind::Included(DepsKind::Shallow),
+        PREFIX_INCLUDED_NONE => InclusionKind::Included(DepsKind::None),
+        PREFIX_SIGNATURE_ONLY => InclusionKind::SignatureOnly,
+        PREFIX_EXCLUDED => InclusionKind::Excluded,
         prefix => Err(format!(
             "Expected `+`, `+~`, `+!`, `+:` or `-`, got an `{prefix}`"
         ))?,


### PR DESCRIPTION
This is useful for the workbench.
This PR:
 - adds a hidden option `cargo hax __json` that just consumes stdin and parse that as CLI options
 - implements `ToString` for a few types
 - make more fields public for types in cli_options 