### PR TITLE
Engine: source maps: fix bugs, add features, enable for Coq

### DIFF
--- a/cli/subcommands/src/cargo_hax.rs
+++ b/cli/subcommands/src/cargo_hax.rs
@@ -341,7 +341,7 @@ fn run_engine(
                                     if path.is_absolute() {
                                         path
                                     } else {
-                                        manifest_dir.join(path).to_path_buf()
+                                        working_dir.join(path).to_path_buf()
                                     }
                                 })
                                 .map(|path| fs::read_to_string(path).ok())

--- a/engine/backends/coq/coq/coq_backend.ml
+++ b/engine/backends/coq/coq/coq_backend.ml
@@ -770,7 +770,7 @@ let translate m _ ~bundles:_ (items : AST.item list) : Types.file list =
          let sourcemap, contents =
            let annotated = my_printer#entrypoint_modul items in
            let open Generic_printer.AnnotatedString in
-           let header = pure hardcoded_coq_headers in
+           let header = pure (hardcoded_coq_headers ^ "\n") in
            let annotated = concat header annotated in
            (to_sourcemap annotated, to_string annotated)
          in

--- a/engine/backends/coq/coq/coq_backend.ml
+++ b/engine/backends/coq/coq/coq_backend.ml
@@ -767,13 +767,16 @@ let translate m _ ~bundles:_ (items : AST.item list) : Types.file list =
                 ~f:(map_first_letter String.uppercase)
                 (fst ns :: snd ns))
          in
-         let contents, _annotations = my_printer#entrypoint_modul items in
-         Types.
-           {
-             path = mod_name ^ ".v";
-             contents = hardcoded_coq_headers ^ "\n" ^ contents;
-             sourcemap = None;
-           })
+         let sourcemap, contents =
+           let annotated = my_printer#entrypoint_modul items in
+           let open Generic_printer.AnnotatedString in
+           let header = pure hardcoded_coq_headers in
+           let annotated = concat header annotated in
+           (to_sourcemap annotated, to_string annotated)
+         in
+         let sourcemap = Some sourcemap in
+         let path = mod_name ^ ".v" in
+         Types.{ path; contents; sourcemap })
 
 open Phase_utils
 

--- a/engine/utils/sourcemaps/location.ml
+++ b/engine/utils/sourcemaps/location.ml
@@ -1,6 +1,6 @@
 open Prelude
 
-type t = { line : int; col : int } [@@deriving eq]
+type t = { line : int; col : int } [@@deriving eq, yojson]
 
 let show { line; col } =
   "(" ^ Int.to_string line ^ ":" ^ Int.to_string col ^ ")"

--- a/engine/utils/sourcemaps/mappings/dual.ml
+++ b/engine/utils/sourcemaps/mappings/dual.ml
@@ -1,4 +1,4 @@
-type 'a t = { gen : 'a; src : 'a } [@@deriving show, eq]
+type 'a t = { gen : 'a; src : 'a } [@@deriving show, eq, yojson]
 
 let transpose ~(default : 'a t) ({ gen; src } : 'a option t) : 'a t option =
   match (gen, src) with

--- a/engine/utils/sourcemaps/mappings/instruction.ml
+++ b/engine/utils/sourcemaps/mappings/instruction.ml
@@ -8,9 +8,7 @@ type t =
 [@@deriving show { with_path = false }, eq]
 
 let encode_one : t -> string * [ `Sep | `NeedsSep ] = function
-  | ShiftGenLinesResetGenCols { lines } ->
-      Stdlib.prerr_endline ("lines:::" ^ Int.to_string lines);
-      (String.make lines ';', `Sep)
+  | ShiftGenLinesResetGenCols { lines } -> (String.make lines ';', `Sep)
   | ShiftGenCols n -> (Vql.encode_base64 [ n ], `NeedsSep)
   | Full { shift_gen_col; shift_src; meta = { file_offset; name } } ->
       ( Vql.encode_base64

--- a/engine/utils/sourcemaps/mappings/mappings.ml
+++ b/engine/utils/sourcemaps/mappings/mappings.ml
@@ -2,10 +2,11 @@ open Prelude
 include Types
 
 type range = { start : Location.t; end_ : Location.t option }
-[@@deriving show, eq]
+[@@deriving show, eq, yojson]
 
 module Chunk = struct
-  type t = { gen : range; src : range; meta : meta } [@@deriving show, eq]
+  type t = { gen : range; src : range; meta : meta }
+  [@@deriving show, eq, yojson]
 
   let compare (x : t) (y : t) = Location.compare x.gen.start y.gen.start
 

--- a/engine/utils/sourcemaps/mappings/mappings.mli
+++ b/engine/utils/sourcemaps/mappings/mappings.mli
@@ -1,8 +1,12 @@
-type meta = { file_offset : int; name : int option } [@@deriving show, eq]
+type meta = { file_offset : int; name : int option }
+[@@deriving show, eq, yojson]
+
 type range = { start : Location.t; end_ : Location.t option }
+[@@deriving show, eq, yojson]
 
 module Chunk : sig
-  type t = { gen : range; src : range; meta : meta } [@@deriving show, eq]
+  type t = { gen : range; src : range; meta : meta }
+  [@@deriving show, eq, yojson]
 
   val compare : t -> t -> int
 end

--- a/engine/utils/sourcemaps/mappings/types.ml
+++ b/engine/utils/sourcemaps/mappings/types.ml
@@ -1,4 +1,6 @@
 open Prelude
 
-type meta = { file_offset : int; name : int option } [@@deriving show, eq]
-type point = Location.t Dual.t * meta option [@@deriving show, eq]
+type meta = { file_offset : int; name : int option }
+[@@deriving show, eq, yojson]
+
+type point = Location.t Dual.t * meta option [@@deriving show, eq, yojson]

--- a/engine/utils/sourcemaps/source_maps.ml
+++ b/engine/utils/sourcemaps/source_maps.ml
@@ -45,7 +45,6 @@ let mk ?(file = "") ?(sourceRoot = "") ?(sourcesContent = fun _ -> None)
     Chunk.{ gen; src; meta }
   in
   let mappings = List.map mappings ~f |> List.sort ~compare:Chunk.compare in
-  Stdlib.prerr_endline @@ [%show: Chunk.t list] mappings;
   let mappings = Mappings.encode mappings in
   let sourcesContent = List.map ~f:sourcesContent sources in
   { mappings; sourceRoot; sourcesContent; sources; names; version = 3; file }


### PR DESCRIPTION
This PR:
 - makes cargo hax save source maps as files if the engine produce any
 - fix a bug in the source map encoding
 - output source maps for the Coq backend

To test the source maps for Coq:
 - `cargo hax into coq` on a crate
 - https://evanw.github.io/source-map-visualization/, upload one `.v` file and it's corresponding `.v.map` file (no need for the rust source files, they are embedded in sourcemaps)