### PR TITLE
hax-types: version for serde-brief

### DIFF
--- a/hax-types/Cargo.toml
+++ b/hax-types/Cargo.toml
@@ -22,7 +22,7 @@ serde_json.workspace = true
 annotate-snippets.workspace = true
 hax-adt-into.workspace = true
 tracing.workspace = true
-serde-brief ={ version = "*", features = ["std", "alloc"]}
+serde-brief ={ version = "0.1", features = ["std", "alloc"]}
 zstd = "0.13.1"
 miette = "7.2.0"
 


### PR DESCRIPTION
You can not publish a crate with a wildecard as version number.

I published all the crates. You need to move all the tags to this commit when merged.

I published with
```
cargo release -p hax-frontend-exporter-options -p hax-adt-into -p hax-frontend-exporter -p hax-types -p hax-subcommands -p cargo-hax -p hax-export-json-schemas -p hax-pretty-print-diagnostics -p hax-lib-macros-types -p hax-lib-macros -p hax-lib -p hax-driver --no-tag --execute
```
