### PR TITLE
Engine: get rid of most of exception throwing function calls, improve parsers and error reports

### DIFF
--- a/cli/driver/src/exporter.rs
+++ b/cli/driver/src/exporter.rs
@@ -286,6 +286,7 @@ impl Callbacks for ExtractionCallbacks {
                             .flatten()
                             .collect(),
                         def_ids,
+                        hax_version: hax_types::HAX_VERSION.into(),
                     };
                     haxmeta.write(&mut file, cache_map);
                 }

--- a/cli/subcommands/build.rs
+++ b/cli/subcommands/build.rs
@@ -14,7 +14,7 @@ fn rustc_version_env_var() {
 }
 
 fn json_schema_static_asset() {
-    let schema = schemars::schema_for!((
+    let mut schema = schemars::schema_for!((
         hax_frontend_exporter::Item<hax_frontend_exporter::ThirBody>,
         hax_types::cli_options::Options,
         hax_types::diagnostics::Diagnostics,
@@ -25,6 +25,7 @@ fn json_schema_static_asset() {
         hax_types::engine_api::protocol::ToEngine,
         hax_lib_macros_types::AttrPayload,
     ));
+    schema.schema.metadata.get_or_insert_default().id = Some(hax_types::HAX_VERSION.into());
     serde_json::to_writer(
         std::fs::File::create(format!("{}/schema.json", std::env::var("OUT_DIR").unwrap()))
             .unwrap(),

--- a/cli/subcommands/src/cargo_hax.rs
+++ b/cli/subcommands/src/cargo_hax.rs
@@ -240,6 +240,7 @@ fn run_engine(
     message_format: MessageFormat,
 ) -> bool {
     let engine_options = EngineOptions {
+        hax_version: haxmeta.hax_version,
         backend: backend.clone(),
         input: haxmeta.items,
         impl_infos: haxmeta.impl_infos,
@@ -532,6 +533,7 @@ fn compute_haxmeta_files(options: &Options) -> (Vec<EmitHaxMetaMessage>, i32) {
     } else {
         0
     };
+
     (haxmeta_files, exit_code)
 }
 

--- a/engine/backends/fstar/fstar_backend.ml
+++ b/engine/backends/fstar/fstar_backend.ml
@@ -111,6 +111,24 @@ module Make
 struct
   open Ctx
 
+  module StringToFStar = struct
+    let catch_parsing_error (type a b) kind span (f : a -> b) x =
+      try f x
+      with e ->
+        let kind =
+          Types.FStarParseError
+            {
+              fstar_snippet = "";
+              details =
+                "While parsing a " ^ kind ^ ", error: "
+                ^ Base.Error.to_string_hum (Base.Error.of_exn e);
+            }
+        in
+        Error.raise { span; kind }
+
+    let term span = catch_parsing_error "term" span F.term_of_string
+  end
+
   let doc_to_string : PPrint.document -> string =
     FStar_Pprint.pretty_string 1.0 (Z.of_int ctx.line_width)
 
@@ -667,7 +685,7 @@ struct
              kind = UnsupportedMacro { id = [%show: global_ident] macro };
              span = e.span;
            }
-    | Quote quote -> pquote e.span quote |> F.term_of_string
+    | Quote quote -> pquote e.span quote |> StringToFStar.term e.span
     | _ -> .
 
   (** Prints a `quote` to a string *)

--- a/engine/bin/lib.ml
+++ b/engine/bin/lib.ml
@@ -186,6 +186,21 @@ let parse_options () =
   let table, json =
     Hax_io.read_json () |> Option.value_exn |> parse_id_table_node
   in
+  let version =
+    try Yojson.Safe.Util.(member "hax_version" json |> to_string)
+    with _ -> "unknown"
+  in
+  if String.equal version Types.hax_version |> not then (
+    prerr_endline
+      [%string
+        {|
+The versions of `hax-engine` and of `cargo-hax` are different:
+  - `hax-engine` version: %{Types.hax_version}
+  - `cargo-hax`  version: %{version}
+
+Please reinstall hax.
+|}];
+    Stdlib.exit 1);
   table
   |> List.iter ~f:(fun (id, json) ->
          Hashtbl.add_exn Types.cache_map ~key:id ~data:(`JSON json));

--- a/engine/bin/lib.ml
+++ b/engine/bin/lib.ml
@@ -189,7 +189,7 @@ let parse_options () =
   table
   |> List.iter ~f:(fun (id, json) ->
          Hashtbl.add_exn Types.cache_map ~key:id ~data:(`JSON json));
-  let options = Types.parse_engine_options json in
+  let options = [%of_yojson: Types.engine_options] json in
   Profiling.enabled := options.backend.profile;
   options
 

--- a/engine/lib/ast_builder.ml
+++ b/engine/lib/ast_builder.ml
@@ -210,7 +210,8 @@ module Make (F : Features.T) = struct
   end
 
   module type S = module type of Make0 (struct
-    let span = failwith "dummy"
+    (* This [failwith] is OK: this module is never actually used for computation. It is useful only for typing. *)
+    let span = failwith "type only module: this will never be computed"
   end)
 
   module Make (Span : sig

--- a/engine/lib/ast_utils.ml
+++ b/engine/lib/ast_utils.ml
@@ -954,6 +954,7 @@ module Make (F : Features.T) = struct
     (** Prints an expression pretty-printed as Rust, with its full
     AST encoded as JSON, available as a file, so that one can
     `jless` or `jq` into it. *)
+
     val item' : ?label:string -> AST.item -> string
     val item : ?label:string -> AST.item -> unit
   end = struct
@@ -968,15 +969,16 @@ module Make (F : Features.T) = struct
       |> Stdio.prerr_endline
 
     let item' ?(label = "") (e : AST.item) : string =
-        let path = tempfile_path ~suffix:".json" in
-        Core.Out_channel.write_all path
-          ~data:([%yojson_of: AST.item] e |> Yojson.Safe.pretty_to_string);
-        let e = LiftToFullAst.item e in
-        "```rust " ^ label ^ "\n" ^ Print_rust.pitem_str e
-        ^ "\n```\x1b[34m JSON-encoded AST available at \x1b[1m" ^ path
-        ^ "\x1b[0m (hint: use `jless " ^ path ^ "`)"
+      let path = tempfile_path ~suffix:".json" in
+      Core.Out_channel.write_all path
+        ~data:([%yojson_of: AST.item] e |> Yojson.Safe.pretty_to_string);
+      let e = LiftToFullAst.item e in
+      "```rust " ^ label ^ "\n" ^ Print_rust.pitem_str e
+      ^ "\n```\x1b[34m JSON-encoded AST available at \x1b[1m" ^ path
+      ^ "\x1b[0m (hint: use `jless " ^ path ^ "`)"
 
-    let item ?(label = "") (e : AST.item) = item' ~label e |> Stdio.prerr_endline
+    let item ?(label = "") (e : AST.item) =
+      item' ~label e |> Stdio.prerr_endline
   end
 
   let unbox_expr' (next : expr -> expr) (e : expr) : expr =

--- a/engine/lib/attr_payloads.ml
+++ b/engine/lib/attr_payloads.ml
@@ -6,7 +6,7 @@ let payloads : attrs -> (Types.ha_payload * span) list =
   let parse =
     (* we have to parse ["JSON"]: first a string, then a ha_payload *)
     function
-    | `String s -> Yojson.Safe.from_string s |> Types.parse_ha_payload
+    | `String s -> Yojson.Safe.from_string s |> [%of_yojson: Types.ha_payload]
     | x ->
         Stdlib.failwith
         @@ "Attr_payloads: payloads: expected a string while parsing JSON, got "
@@ -23,7 +23,7 @@ let payloads : attrs -> (Types.ha_payload * span) list =
 (** Create a attribute out of a [payload] *)
 let to_attr (payload : Types.ha_payload) (span : span) : attr =
   let json =
-    `String (Yojson.Safe.to_string (Types.to_json_ha_payload payload))
+    `String (Yojson.Safe.to_string ([%yojson_of: Types.ha_payload] payload))
   in
   let kind : attr_kind =
     Tool { path = "_hax::json"; tokens = Yojson.Safe.to_string json }

--- a/engine/lib/hax_io.ml
+++ b/engine/lib/hax_io.ml
@@ -36,10 +36,10 @@ include (
     end)
 
 let read () : Types.to_engine =
-  read_json () |> Option.value_exn |> Types.parse_to_engine
+  read_json () |> Option.value_exn |> [%of_yojson: Types.to_engine]
 
 let write (msg : Types.from_engine) : unit =
-  Types.to_json_from_engine msg |> write_json
+  [%yojson_of: Types.from_engine] msg |> write_json
 
 let close () : unit =
   write Exit;

--- a/engine/lib/phases/phase_hoist_disjunctive_patterns.ml
+++ b/engine/lib/phases/phase_hoist_disjunctive_patterns.ml
@@ -72,6 +72,7 @@ module Make (F : Features.T) =
                   List.map (treat_args [ [] ] fields_as_pat)
                     ~f:(fun fields_as_pat ->
                       let fields =
+                        (* exn justification: `rev_map fields` and `fields` have the same length *)
                         List.map2_exn fields_as_pat fields
                           ~f:(fun pat { field; _ } -> { field; pat })
                       in

--- a/engine/lib/phases/phase_transform_hax_lib_inline.ml
+++ b/engine/lib/phases/phase_transform_hax_lib_inline.ml
@@ -106,11 +106,21 @@ module%inlined_contents Make (F : Features.T) = struct
                     let id =
                       extract_pattern e
                       |> Option.bind ~f:first_global_ident
-                      |> Option.value_exn
+                      |> Option.value_or_thunk ~default:(fun _ ->
+                             Error.assertion_failure span
+                               "Could not extract pattern (case constructor): \
+                                this may be a bug in the quote macros in \
+                                hax-lib.")
                     in
                     `Expr { e with e = GlobalVar id }
                 | Some "_pat" ->
-                    let pat = extract_pattern e |> Option.value_exn in
+                    let pat =
+                      extract_pattern e
+                      |> Option.value_or_thunk ~default:(fun _ ->
+                             Error.assertion_failure span
+                               "Could not extract pattern (case pat): this may \
+                                be a bug in the quote macros in hax-lib.")
+                    in
                     `Pat pat
                 | Some "_ty" ->
                     let typ =

--- a/engine/names/extract/build.rs
+++ b/engine/names/extract/build.rs
@@ -140,7 +140,7 @@ fn reader_to_str(s: String) -> String {
     result += "\n";
     result += "module Values = struct\n";
     for (json, name) in &def_ids {
-        result += &format!("{TAB}let parsed_{name} = Types.parse_def_id (Yojson.Safe.from_string {}{ESCAPE_KEY}|{}|{ESCAPE_KEY}{})\n", "{", json, "}");
+        result += &format!("{TAB}let parsed_{name} = Types.def_id_of_yojson (Yojson.Safe.from_string {}{ESCAPE_KEY}|{}|{ESCAPE_KEY}{})\n", "{", json, "}");
     }
     result += "end\n\n";
 
@@ -155,7 +155,7 @@ fn reader_to_str(s: String) -> String {
 
     result += &format!("let impl_infos_json_list = match Yojson.Safe.from_string {}{ESCAPE_KEY}|{}|{ESCAPE_KEY}{} with | `List l -> l | _ -> failwith \"Expected a list of `def_id * impl_infos`\"\n\n", "{", serde_json::to_string(&impl_infos).unwrap(), "}");
     result +=
-        &format!("let impl_infos = Base.List.map ~f:(function | `List [did; ii] -> (Types.parse_def_id did, Types.parse_impl_infos ii) | _ -> failwith \"Expected tuple\") impl_infos_json_list");
+        &format!("let impl_infos = Base.List.map ~f:(function | `List [did; ii] -> (Types.def_id_of_yojson did, Types.impl_infos_of_yojson ii) | _ -> failwith \"Expected tuple\") impl_infos_json_list");
 
     result
 }

--- a/flake.nix
+++ b/flake.nix
@@ -190,6 +190,7 @@
             pkgs.cargo-release
             pkgs.cargo-insta
             pkgs.openssl.dev
+            pkgs.libz.dev
             pkgs.pkg-config
             pkgs.rust-analyzer
             pkgs.toml2json

--- a/hax-types/src/diagnostics/mod.rs
+++ b/hax-types/src/diagnostics/mod.rs
@@ -68,6 +68,8 @@ impl std::fmt::Display for Diagnostics {
 
             Kind::NonTrivialAndMutFnInput => write!(f, "The support in hax of function with one or more inputs of type `&mut _` is limited. Onlu trivial patterns are allowed there: `fn f(x: &mut (T, U)) ...` is allowed while `f((x, y): &mut (T, U))` is rejected."),
 
+            Kind::FStarParseError { fstar_snippet, details: _ } => write!(f, "The following code snippet could not be parsed as valid F*:\n```\n{fstar_snippet}\n```"),
+
             _ => write!(f, "{:?}", self.kind),
         }
     }
@@ -135,7 +137,13 @@ pub enum Kind {
     /// An hax attribute (from `hax-lib-macros`) was rejected
     AttributeRejected {
         reason: String,
-    },
+    } = 12,
+
+    /// A snippet of F* code could not be parsed
+    FStarParseError {
+        fstar_snippet: String,
+        details: String,
+    } = 13,
 }
 
 impl Kind {

--- a/hax-types/src/engine_api.rs
+++ b/hax-types/src/engine_api.rs
@@ -6,6 +6,7 @@ type ThirBody = hax_frontend_exporter::ThirBody;
 #[derive_group(Serializers)]
 #[derive(JsonSchema, Debug, Clone)]
 pub struct EngineOptions {
+    pub hax_version: String,
     pub backend: BackendOptions<()>,
     pub input: Vec<hax_frontend_exporter::Item<ThirBody>>,
     pub impl_infos: Vec<(


### PR DESCRIPTION
This PR:
 - adds a version to `haxmeta` files
 - adds a version to the engine
 - makes the frontend check haxmeta versions
 - makes the engine check the frontend version
 - improve parsing error reporting
 - makes generated parsers conform to yojson style
 - report parsing errors in the F* backend
 - removes most of `*_exn` calls
 - removes most of failwith calls

Fixes https://github.com/hacspec/hax/issues/1150, fixes https://github.com/hacspec/hax/issues/1188, fixes #1187

Context: this PR goes toward better user experience for releasing hax v0.1, it gets rid of most of remaining unhandled explicit failures