### PR TITLE
Frontend/exporter: Add a `kind` field to `DefIdContents`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -190,6 +190,7 @@
             pkgs.cargo-release
             pkgs.cargo-insta
             pkgs.openssl.dev
+            pkgs.libz.dev
             pkgs.pkg-config
             pkgs.rust-analyzer
             pkgs.toml2json

--- a/frontend/exporter/src/types/def_id.rs
+++ b/frontend/exporter/src/types/def_id.rs
@@ -54,6 +54,10 @@ pub struct DefIdContents {
     /// indexes unless you cannot do otherwise.
     pub index: (u32, u32),
     pub is_local: bool,
+
+    /// The kind of definition this `DefId` points to.
+    #[cfg(not(feature = "extract_names_mode"))]
+    pub kind: crate::DefKind,
 }
 
 #[cfg(feature = "rustc")]
@@ -140,6 +144,8 @@ pub(crate) fn translate_def_id<'tcx, S: BaseState<'tcx>>(s: &S, def_id: RDefId) 
             rustc_hir::def_id::DefIndex::as_u32(def_id.index),
         ),
         is_local: def_id.is_local(),
+        #[cfg(not(feature = "extract_names_mode"))]
+        kind: tcx.def_kind(def_id).sinto(s),
     };
     let contents =
         s.with_global_cache(|cache| id_table::Node::new(contents, &mut cache.id_table_session));

--- a/frontend/exporter/src/types/def_id.rs
+++ b/frontend/exporter/src/types/def_id.rs
@@ -144,7 +144,6 @@ pub struct DefIdContents {
     pub is_local: bool,
 
     /// The kind of definition this `DefId` points to.
-    #[cfg(not(feature = "extract_names_mode"))]
     pub kind: crate::DefKind,
 }
 
@@ -232,7 +231,6 @@ pub(crate) fn translate_def_id<'tcx, S: BaseState<'tcx>>(s: &S, def_id: RDefId) 
             rustc_hir::def_id::DefIndex::as_u32(def_id.index),
         ),
         is_local: def_id.is_local(),
-        #[cfg(not(feature = "extract_names_mode"))]
         kind: tcx.def_kind(def_id).sinto(s),
     };
     let contents =

--- a/frontend/exporter/src/types/def_id.rs
+++ b/frontend/exporter/src/types/def_id.rs
@@ -18,7 +18,7 @@ use crate::prelude::*;
 use crate::{AdtInto, JsonSchema};
 
 #[cfg(feature = "rustc")]
-use rustc_span::def_id::DefId as RDefId;
+use {rustc_hir as hir, rustc_span::def_id::DefId as RDefId};
 
 pub type Symbol = String;
 
@@ -27,6 +27,94 @@ impl<'t, S> SInto<S, Symbol> for rustc_span::symbol::Symbol {
     fn sinto(&self, _s: &S) -> Symbol {
         self.to_ident_string()
     }
+}
+
+/// Reflects [`hir::Safety`]
+#[cfg_attr(not(feature = "extract_names_mode"), derive(AdtInto, JsonSchema))]
+#[cfg_attr(not(feature = "extract_names_mode"), args(<S>, from: hir::Safety, state: S as _s))]
+#[derive_group(Serializers)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Safety {
+    Unsafe,
+    Safe,
+}
+
+pub type Mutability = bool;
+
+/// Reflects [`hir::def::CtorKind`]
+#[derive_group(Serializers)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(not(feature = "extract_names_mode"), derive(JsonSchema, AdtInto))]
+#[cfg_attr(not(feature = "extract_names_mode"), args(<S>, from: hir::def::CtorKind, state: S as _s))]
+pub enum CtorKind {
+    Fn,
+    Const,
+}
+
+/// Reflects [`hir::def::CtorOf`]
+#[derive_group(Serializers)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(not(feature = "extract_names_mode"), derive(JsonSchema, AdtInto))]
+#[cfg_attr(not(feature = "extract_names_mode"), args(<S>, from: hir::def::CtorOf, state: S as _s))]
+pub enum CtorOf {
+    Struct,
+    Variant,
+}
+
+/// Reflects [`rustc_span::hygiene::MacroKind`]
+#[derive_group(Serializers)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(not(feature = "extract_names_mode"), derive(JsonSchema, AdtInto))]
+#[cfg_attr(not(feature = "extract_names_mode"), args(<S>, from: rustc_span::hygiene::MacroKind, state: S as _s))]
+pub enum MacroKind {
+    Bang,
+    Attr,
+    Derive,
+}
+
+/// Reflects [`rustc_hir::def::DefKind`]
+#[derive_group(Serializers)]
+#[cfg_attr(not(feature = "extract_names_mode"), derive(JsonSchema, AdtInto))]
+#[cfg_attr(not(feature = "extract_names_mode"),args(<S>, from: rustc_hir::def::DefKind, state: S as tcx))]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum DefKind {
+    Mod,
+    Struct,
+    Union,
+    Enum,
+    Variant,
+    Trait,
+    TyAlias,
+    ForeignTy,
+    TraitAlias,
+    AssocTy,
+    TyParam,
+    Fn,
+    Const,
+    ConstParam,
+    Static {
+        safety: Safety,
+        mutability: Mutability,
+        nested: bool,
+    },
+    Ctor(CtorOf, CtorKind),
+    AssocFn,
+    AssocConst,
+    Macro(MacroKind),
+    ExternCrate,
+    Use,
+    ForeignMod,
+    AnonConst,
+    InlineConst,
+    OpaqueTy,
+    Field,
+    LifetimeParam,
+    GlobalAsm,
+    Impl {
+        of_trait: bool,
+    },
+    Closure,
+    SyntheticCoroutineBody,
 }
 
 /// Reflects [`rustc_hir::def_id::DefId`]

--- a/frontend/exporter/src/types/hir.rs
+++ b/frontend/exporter/src/types/hir.rs
@@ -62,7 +62,7 @@ impl<S> SInto<S, Mutability> for hir::Mutability {
 
 /// Reflects [`hir::def::CtorKind`]
 #[derive_group(Serializers)]
-#[derive(AdtInto, Clone, Debug, JsonSchema)]
+#[derive(AdtInto, JsonSchema, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[args(<S>, from: hir::def::CtorKind, state: S as _s)]
 pub enum CtorKind {
     Fn,
@@ -71,7 +71,7 @@ pub enum CtorKind {
 
 /// Reflects [`hir::def::CtorOf`]
 #[derive_group(Serializers)]
-#[derive(AdtInto, Clone, Debug, JsonSchema)]
+#[derive(AdtInto, JsonSchema, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[args(<S>, from: hir::def::CtorOf, state: S as _s)]
 pub enum CtorOf {
     Struct,
@@ -1177,7 +1177,51 @@ pub enum AttrKind {
     DocComment(CommentKind, Symbol),
 }
 
-sinto_todo!(rustc_hir::def, DefKind);
+/// Reflects [`rustc_hir::def::DefKind`]
+#[derive(AdtInto)]
+#[args(<S>, from: rustc_hir::def::DefKind, state: S as tcx)]
+#[derive_group(Serializers)]
+#[derive(Debug, JsonSchema, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum DefKind {
+    Mod,
+    Struct,
+    Union,
+    Enum,
+    Variant,
+    Trait,
+    TyAlias,
+    ForeignTy,
+    TraitAlias,
+    AssocTy,
+    TyParam,
+    Fn,
+    Const,
+    ConstParam,
+    Static {
+        safety: Safety,
+        mutability: Mutability,
+        nested: bool,
+    },
+    Ctor(CtorOf, CtorKind),
+    AssocFn,
+    AssocConst,
+    Macro(MacroKind),
+    ExternCrate,
+    Use,
+    ForeignMod,
+    AnonConst,
+    InlineConst,
+    OpaqueTy,
+    Field,
+    LifetimeParam,
+    GlobalAsm,
+    Impl {
+        of_trait: bool,
+    },
+    Closure,
+    SyntheticCoroutineBody,
+}
+
 sinto_todo!(rustc_hir, GenericArgs<'a> as HirGenericArgs);
 sinto_todo!(rustc_hir, InlineAsm<'a>);
 sinto_todo!(rustc_hir, MissingLifetimeKind);

--- a/frontend/exporter/src/types/hir.rs
+++ b/frontend/exporter/src/types/hir.rs
@@ -48,8 +48,6 @@ pub enum Movability {
     Movable,
 }
 
-pub type Mutability = bool;
-
 #[cfg(feature = "rustc")]
 impl<S> SInto<S, Mutability> for hir::Mutability {
     fn sinto(&self, _s: &S) -> Mutability {
@@ -60,24 +58,6 @@ impl<S> SInto<S, Mutability> for hir::Mutability {
     }
 }
 
-/// Reflects [`hir::def::CtorKind`]
-#[derive_group(Serializers)]
-#[derive(AdtInto, JsonSchema, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[args(<S>, from: hir::def::CtorKind, state: S as _s)]
-pub enum CtorKind {
-    Fn,
-    Const,
-}
-
-/// Reflects [`hir::def::CtorOf`]
-#[derive_group(Serializers)]
-#[derive(AdtInto, JsonSchema, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[args(<S>, from: hir::def::CtorOf, state: S as _s)]
-pub enum CtorOf {
-    Struct,
-    Variant,
-}
-
 /// Reflects [`hir::RangeEnd`]
 #[derive(AdtInto)]
 #[args(<S>, from: hir::RangeEnd, state: S as _s)]
@@ -86,16 +66,6 @@ pub enum CtorOf {
 pub enum RangeEnd {
     Included,
     Excluded,
-}
-
-/// Reflects [`hir::Safety`]
-#[derive(AdtInto)]
-#[args(<S>, from: hir::Safety, state: S as _s)]
-#[derive_group(Serializers)]
-#[derive(Clone, Debug, JsonSchema, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub enum Safety {
-    Unsafe,
-    Safe,
 }
 
 /// Reflects [`hir::ImplicitSelfKind`]
@@ -1175,51 +1145,6 @@ pub struct NormalAttr {
 pub enum AttrKind {
     Normal(NormalAttr),
     DocComment(CommentKind, Symbol),
-}
-
-/// Reflects [`rustc_hir::def::DefKind`]
-#[derive(AdtInto)]
-#[args(<S>, from: rustc_hir::def::DefKind, state: S as tcx)]
-#[derive_group(Serializers)]
-#[derive(Debug, JsonSchema, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum DefKind {
-    Mod,
-    Struct,
-    Union,
-    Enum,
-    Variant,
-    Trait,
-    TyAlias,
-    ForeignTy,
-    TraitAlias,
-    AssocTy,
-    TyParam,
-    Fn,
-    Const,
-    ConstParam,
-    Static {
-        safety: Safety,
-        mutability: Mutability,
-        nested: bool,
-    },
-    Ctor(CtorOf, CtorKind),
-    AssocFn,
-    AssocConst,
-    Macro(MacroKind),
-    ExternCrate,
-    Use,
-    ForeignMod,
-    AnonConst,
-    InlineConst,
-    OpaqueTy,
-    Field,
-    LifetimeParam,
-    GlobalAsm,
-    Impl {
-        of_trait: bool,
-    },
-    Closure,
-    SyntheticCoroutineBody,
 }
 
 sinto_todo!(rustc_hir, GenericArgs<'a> as HirGenericArgs);

--- a/frontend/exporter/src/types/span.rs
+++ b/frontend/exporter/src/types/span.rs
@@ -38,7 +38,7 @@ pub enum AstPass {
 
 /// Reflects [`rustc_span::hygiene::MacroKind`]
 #[derive_group(Serializers)]
-#[derive(AdtInto, Clone, Debug, JsonSchema)]
+#[derive(AdtInto, JsonSchema, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[args(<S>, from: rustc_span::hygiene::MacroKind, state: S as _s)]
 pub enum MacroKind {
     Bang,

--- a/frontend/exporter/src/types/span.rs
+++ b/frontend/exporter/src/types/span.rs
@@ -36,16 +36,6 @@ pub enum AstPass {
     ProcMacroHarness,
 }
 
-/// Reflects [`rustc_span::hygiene::MacroKind`]
-#[derive_group(Serializers)]
-#[derive(AdtInto, JsonSchema, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[args(<S>, from: rustc_span::hygiene::MacroKind, state: S as _s)]
-pub enum MacroKind {
-    Bang,
-    Attr,
-    Derive,
-}
-
 /// Reflects [`rustc_span::hygiene::ExpnKind`]
 #[derive(AdtInto)]
 #[args(<'tcx, S: BaseState<'tcx>>, from: rustc_span::hygiene::ExpnKind, state: S as gstate)]


### PR DESCRIPTION
This PR fixes [#1162](https://github.com/hacspec/hax/issues/1162): it is adding a `DefKind` on `DefIdContents`.