### PR TITLE
fix(CI) Update F* version to fix mlkem CI job 

### DIFF
--- a/.github/workflows/mlkem.yml
+++ b/.github/workflows/mlkem.yml
@@ -33,7 +33,7 @@ jobs:
           nix profile install ./hax
 
       - name: ⤵ Install FStar
-        run: nix profile install github:FStarLang/FStar/v2024.01.13
+        run: nix profile install github:FStarLang/FStar/v2024.09.05
 
       - name: ⤵ Clone HACL-star repository
         uses: actions/checkout@v4

--- a/.github/workflows/mlkem.yml
+++ b/.github/workflows/mlkem.yml
@@ -33,7 +33,7 @@ jobs:
           nix profile install ./hax
 
       - name: ⤵ Install FStar
-        run: nix profile install github:FStarLang/FStar/v2024.09.05
+        run: nix profile install github:FStarLang/FStar/v2024.12.03
 
       - name: ⤵ Clone HACL-star repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR updates the F* version used by the ML-KEM CI job. The job was failing recently (see for example https://github.com/hacspec/hax/actions/runs/12482298578/job/34836176279, because of a syntax error). Using a more recent F* fixes this (https://github.com/hacspec/hax/actions/runs/12483217088/job/34838637301)