### PR TITLE
Update README.md: `unsafe` is OK to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,7 @@ that is where `setup.sh` will install hax.
 
 ## Supported Subset of the Rust Language
 
-Hax intends to support full Rust, with the two following exceptions, promoting a functional style:
- 1. no `unsafe` code (see https://github.com/hacspec/hax/issues/417);
- 2. mutable references (aka `&mut T`) on return types or when aliasing (see https://github.com/hacspec/hax/issues/420).
+Hax intends to support full Rust, with the one exception, promoting a functional style: mutable references (aka `&mut T`) on return types or when aliasing (see https://github.com/hacspec/hax/issues/420) are forbidden.
 
 Each unsupported Rust feature is documented as an issue labeled [`unsupported-rust`](https://github.com/hacspec/hax/issues?q=is%3Aissue+is%3Aopen+label%3Aunsupported-rust). When the issue is labeled [`wontfix-v1`](https://github.com/hacspec/hax/issues?q=is%3Aissue+is%3Aopen+label%3Aunsupported-rust+label%3Awontfix%2Cwontfix-v1), that means we don't plan on supporting that feature soon.
 


### PR DESCRIPTION
This PR changes slightly the README to reflect the state of https://github.com/hacspec/hax/issues/417: unsafe blocks are handled for some time already.

I noticed that while writting release notes.